### PR TITLE
Add cleanup on rescan

### DIFF
--- a/src/Angor/Client/Pages/Founder.razor
+++ b/src/Angor/Client/Pages/Founder.razor
@@ -34,12 +34,15 @@
 
                 </div>
             </div>
-            <button class="btn btn-border" @onclick="NavigateToCreateProject">
+            <button class="btn btn-border" @onclick="NavigateToCreateProject" disabled="@scanningForProjects">
                 <i>
                     <Icon IconName="add"></Icon>
                 </i>
-                <span class="nav-link-text ms-1">Create Project</span>
+                    <span class="nav-link-text ms-1">
+                    @(scanningForProjects ? "Scanning..." : "Create Project")
+                </span>
             </button>
+
         </div>
         <p class="mb-0 font-weight-normal text-sm mt-4">
             To create a new project or view your existing projects, an on-chain transaction and a Nostr DID are required.
@@ -104,110 +107,107 @@
         }
     }
 
-private async Task LookupProjectKeysOnIndexerAsync()
-{
-    scanningForProjects = true; 
-
-    var keys = _walletStorage.GetFounderKeys();
-    var founderProjectsToLookup = new Dictionary<string, ProjectIndexerData>();
-
-    // Gather projects to lookup, excluding already loaded projects
-    foreach (var key in keys.Keys)
+    private async Task LookupProjectKeysOnIndexerAsync()
     {
-        if (founderProjects.Any(_ => _.ProjectInfo.ProjectIdentifier == key.ProjectIdentifier))
-            continue;
+        scanningForProjects = true; 
 
-        var indexerProject = await _IndexerService.GetProjectByIdAsync(key.ProjectIdentifier);
+        var keys = _walletStorage.GetFounderKeys();
+        var founderProjectsToLookup = new Dictionary<string, ProjectIndexerData>();
 
-        if (indexerProject != null)
+        foreach (var key in keys.Keys)
         {
-            founderProjectsToLookup.Add(key.NostrPubKey, indexerProject);
-        }
-    }
+            if (founderProjects.Any(_ => _.ProjectInfo.ProjectIdentifier == key.ProjectIdentifier))
+                continue;
 
-    if (!founderProjectsToLookup.Any())
-    {
-        scanningForProjects = false;
-        return;
-    }
+            var indexerProject = await _IndexerService.GetProjectByIdAsync(key.ProjectIdentifier);
 
-    // Request projects from relay
-    RelayService.RequestProjectCreateEventsByPubKey(
-        e =>
-        {
-            switch (e)
+            if (indexerProject != null)
             {
-                case { Kind: NostrKind.Metadata }:
-                    var nostrMetadata = serializer.Deserialize<ProjectMetadata>(e.Content);
-                    var existingProject = founderProjects.FirstOrDefault(_ => _.ProjectInfo.NostrPubKey == e.Pubkey);
-
-                    if (existingProject != null)
-                    {
-                        // Update metadata if it's not already set
-                        if (existingProject.Metadata is null)
-                            existingProject.Metadata = nostrMetadata;
-                    }
-                    else
-                    {
-                        // If project doesn't exist, create a new entry
-                        founderProjects.Add(new FounderProject
-                        {
-                            Metadata = nostrMetadata,
-                            ProjectInfo = new ProjectInfo { NostrPubKey = e.Pubkey }
-                        });
-                    }
-                    break;
-
-                case { Kind: NostrKind.ApplicationSpecificData }:
-                    var projectInfo = serializer.Deserialize<ProjectInfo>(e.Content);
-                    var project = founderProjects.FirstOrDefault(_ => _.ProjectInfo.NostrPubKey == e.Pubkey);
-
-                    if (project != null)
-                    {
-                        // Update existing project's information
-                        project.ProjectInfo = projectInfo;
-                    }
-                    else
-                    {
-                        // Add new project with project info
-                        var projectIndex = founderProjectsToLookup.Keys.ToList().IndexOf(e.Pubkey) + 1;
-                        var trxId = founderProjectsToLookup[e.Pubkey].TrxId;
-
-                        founderProjects.Add(new FounderProject
-                        {
-                            ProjectInfo = projectInfo,
-                            ProjectIndex = projectIndex,
-                            CreationTransactionId = trxId
-                        });
-                    }
-                    break;
+                founderProjectsToLookup.Add(key.NostrPubKey, indexerProject);
             }
-        },
-        () =>
+        }
+
+        if (!founderProjectsToLookup.Any())
         {
             scanningForProjects = false;
+            return;
+        }
 
-            // Merge or update projects in storage
-            foreach (var project in founderProjects)
+        RelayService.RequestProjectCreateEventsByPubKey(
+            e =>
             {
-                var existing = storage.GetFounderProjects().FirstOrDefault(p => p.ProjectInfo.ProjectIdentifier == project.ProjectInfo.ProjectIdentifier);
-                if (existing == null)
+                switch (e)
                 {
-                    storage.AddFounderProject(new[] { project });
+                    case { Kind: NostrKind.Metadata }:
+                        var nostrMetadata = serializer.Deserialize<ProjectMetadata>(e.Content);
+                        var existingProject = founderProjects.FirstOrDefault(_ => _.ProjectInfo.NostrPubKey == e.Pubkey);
+
+                        if (existingProject != null)
+                        {
+                            if (existingProject.Metadata is null)
+                                existingProject.Metadata = nostrMetadata;
+                        }
+                        else
+                        {
+                            founderProjects.Add(new FounderProject
+                            {
+                                Metadata = nostrMetadata,
+                                ProjectInfo = new ProjectInfo { NostrPubKey = e.Pubkey }
+                            });
+                        }
+                        break;
+
+                    case { Kind: NostrKind.ApplicationSpecificData }:
+                        var projectInfo = serializer.Deserialize<ProjectInfo>(e.Content);
+                        var project = founderProjects.FirstOrDefault(_ => _.ProjectInfo.NostrPubKey == e.Pubkey);
+
+                        if (project != null)
+                        {
+                            project.ProjectInfo = projectInfo;
+                        }
+                        else
+                        {
+                            var projectIndex = founderProjectsToLookup.Keys.ToList().IndexOf(e.Pubkey) + 1;
+                            var trxId = founderProjectsToLookup[e.Pubkey].TrxId;
+
+                            founderProjects.Add(new FounderProject
+                            {
+                                ProjectInfo = projectInfo,
+                                ProjectIndex = projectIndex,
+                                CreationTransactionId = trxId
+                            });
+                        }
+                        break;
                 }
-                else
+            },
+            () =>
+            {
+                scanningForProjects = false;
+
+                // Merge or update projects in storage
+                foreach (var project in founderProjects)
                 {
-                    storage.UpdateFounderProject(project);
+                    var existing = storage.GetFounderProjects().FirstOrDefault(p => p.ProjectInfo.ProjectIdentifier == project.ProjectInfo.ProjectIdentifier);
+                    if (existing == null)
+                    {
+                        storage.AddFounderProject(new[] { project });
+                    }
+                    else
+                    {
+                        storage.UpdateFounderProject(project);
+                    }
                 }
-            }
 
-            StateHasChanged();
-        },
-        founderProjectsToLookup.Keys.ToArray());
-}
+                StateHasChanged();
+            },
+            founderProjectsToLookup.Keys.ToArray());
+    }
 
-    private void NavigateToCreateProject()
+    private async Task NavigateToCreateProject()
     {
+        // perform a rescan before creating a project (to update the keys)
+        await LookupProjectKeysOnIndexerAsync();
+        
         NavigationManager.NavigateTo("/create");
     }
 

--- a/src/Angor/Client/Pages/Founder.razor
+++ b/src/Angor/Client/Pages/Founder.razor
@@ -107,6 +107,9 @@
     private async Task LookupProjectKeysOnIndexerAsync()
     {
         scanningForProjects = true;
+        // Clear the existing projects before rescan
+        founderProjects.Clear();
+        storage.ClearFounderProjects();
 
         var keys = _walletStorage.GetFounderKeys();
 

--- a/src/Angor/Client/Pages/Founder.razor
+++ b/src/Angor/Client/Pages/Founder.razor
@@ -104,68 +104,107 @@
         }
     }
 
-    private async Task LookupProjectKeysOnIndexerAsync()
+private async Task LookupProjectKeysOnIndexerAsync()
+{
+    scanningForProjects = true; 
+
+    var keys = _walletStorage.GetFounderKeys();
+    var founderProjectsToLookup = new Dictionary<string, ProjectIndexerData>();
+
+    // Gather projects to lookup, excluding already loaded projects
+    foreach (var key in keys.Keys)
     {
-        scanningForProjects = true;
-        // Clear the existing projects before rescan
-        founderProjects.Clear();
-        storage.ClearFounderProjects();
+        if (founderProjects.Any(_ => _.ProjectInfo.ProjectIdentifier == key.ProjectIdentifier))
+            continue;
 
-        var keys = _walletStorage.GetFounderKeys();
+        var indexerProject = await _IndexerService.GetProjectByIdAsync(key.ProjectIdentifier);
 
-        var founderProjectsToLookup = new Dictionary<string, ProjectIndexerData>();
-
-        foreach (var key in keys.Keys)
+        if (indexerProject != null)
         {
-            if (founderProjects.Exists(_ => _.ProjectInfo.ProjectIdentifier == key.ProjectIdentifier))
-                continue;
-
-            var indexerProject = await _IndexerService.GetProjectByIdAsync(key.ProjectIdentifier);
-
-            if (indexerProject == null)
-                break;
-
             founderProjectsToLookup.Add(key.NostrPubKey, indexerProject);
         }
+    }
 
-        if (founderProjectsToLookup.Any())
+    if (!founderProjectsToLookup.Any())
+    {
+        scanningForProjects = false;
+        return;
+    }
+
+    // Request projects from relay
+    RelayService.RequestProjectCreateEventsByPubKey(
+        e =>
         {
-            RelayService.RequestProjectCreateEventsByPubKey(e =>
-                {
-                    switch (e)
-                    {
-                        case { Kind: NostrKind.Metadata }:
-                            var nostrMetadata = serializer.Deserialize<ProjectMetadata>(e.Content);
-                            var founderProject = founderProjects.FirstOrDefault(_ => _.ProjectInfo.NostrPubKey == e.Pubkey);
-                            if (founderProject != null && founderProject.Metadata is null)
-                                founderProject.Metadata = nostrMetadata;
-                            break;
+            switch (e)
+            {
+                case { Kind: NostrKind.Metadata }:
+                    var nostrMetadata = serializer.Deserialize<ProjectMetadata>(e.Content);
+                    var existingProject = founderProjects.FirstOrDefault(_ => _.ProjectInfo.NostrPubKey == e.Pubkey);
 
-                        case { Kind: NostrKind.ApplicationSpecificData }:
-                            var projectInfo = serializer.Deserialize<ProjectInfo>(e.Content);
-                            if (founderProjects.All(_ => _.ProjectInfo.NostrPubKey != e.Pubkey))  // Getting events from multiple relays
-                                founderProjects.Add(new FounderProject
-                                {
-                                    ProjectInfo = projectInfo,
-                                    ProjectIndex = founderProjectsToLookup.Keys.ToList().IndexOf(e.Pubkey) + 1,
-                                    CreationTransactionId = founderProjectsToLookup[e.Pubkey].TrxId
-                                });
-                            break;
+                    if (existingProject != null)
+                    {
+                        // Update metadata if it's not already set
+                        if (existingProject.Metadata is null)
+                            existingProject.Metadata = nostrMetadata;
                     }
-                },
-                () =>
-                {
-                    scanningForProjects = false;
-                    storage.AddFounderProject(founderProjects.ToArray());
-                    StateHasChanged();
-                },
-                founderProjectsToLookup.Keys.ToArray());
-        }
-        else
+                    else
+                    {
+                        // If project doesn't exist, create a new entry
+                        founderProjects.Add(new FounderProject
+                        {
+                            Metadata = nostrMetadata,
+                            ProjectInfo = new ProjectInfo { NostrPubKey = e.Pubkey }
+                        });
+                    }
+                    break;
+
+                case { Kind: NostrKind.ApplicationSpecificData }:
+                    var projectInfo = serializer.Deserialize<ProjectInfo>(e.Content);
+                    var project = founderProjects.FirstOrDefault(_ => _.ProjectInfo.NostrPubKey == e.Pubkey);
+
+                    if (project != null)
+                    {
+                        // Update existing project's information
+                        project.ProjectInfo = projectInfo;
+                    }
+                    else
+                    {
+                        // Add new project with project info
+                        var projectIndex = founderProjectsToLookup.Keys.ToList().IndexOf(e.Pubkey) + 1;
+                        var trxId = founderProjectsToLookup[e.Pubkey].TrxId;
+
+                        founderProjects.Add(new FounderProject
+                        {
+                            ProjectInfo = projectInfo,
+                            ProjectIndex = projectIndex,
+                            CreationTransactionId = trxId
+                        });
+                    }
+                    break;
+            }
+        },
+        () =>
         {
             scanningForProjects = false;
-        }
-    }
+
+            // Merge or update projects in storage
+            foreach (var project in founderProjects)
+            {
+                var existing = storage.GetFounderProjects().FirstOrDefault(p => p.ProjectInfo.ProjectIdentifier == project.ProjectInfo.ProjectIdentifier);
+                if (existing == null)
+                {
+                    storage.AddFounderProject(new[] { project });
+                }
+                else
+                {
+                    storage.UpdateFounderProject(project);
+                }
+            }
+
+            StateHasChanged();
+        },
+        founderProjectsToLookup.Keys.ToArray());
+}
 
     private void NavigateToCreateProject()
     {

--- a/src/Angor/Client/Pages/Founder.razor
+++ b/src/Angor/Client/Pages/Founder.razor
@@ -38,7 +38,7 @@
                 <i>
                     <Icon IconName="add"></Icon>
                 </i>
-                    <span class="nav-link-text ms-1">
+                <span class="nav-link-text ms-1">
                     @(scanningForProjects ? "Scanning..." : "Create Project")
                 </span>
             </button>
@@ -56,7 +56,7 @@
         <div class="card card-body angor-alert-info pt-2 pb-2">
             <div class="d-flex align-items-center align-items-center">
                 <span class="me-3 user-select-none">
-                    <Icon IconName="info" Width="40" Height="40" Color="var(--angor-primary)" />
+                    <Icon IconName="info" Width="40" Height="40" Color="var(--angor-primary)"/>
                 </span>
                 <span class="text-white">No projects found.</span>
             </div>
@@ -109,7 +109,7 @@
 
     private async Task LookupProjectKeysOnIndexerAsync()
     {
-        scanningForProjects = true; 
+        scanningForProjects = true;
 
         var keys = _walletStorage.GetFounderKeys();
         var founderProjectsToLookup = new Dictionary<string, ProjectIndexerData>();
@@ -155,6 +155,7 @@
                                 ProjectInfo = new ProjectInfo { NostrPubKey = e.Pubkey }
                             });
                         }
+
                         break;
 
                     case { Kind: NostrKind.ApplicationSpecificData }:
@@ -177,6 +178,7 @@
                                 CreationTransactionId = trxId
                             });
                         }
+
                         break;
                 }
             },
@@ -207,7 +209,7 @@
     {
         // perform a rescan before creating a project (to update the keys)
         await LookupProjectKeysOnIndexerAsync();
-        
+
         NavigationManager.NavigateTo("/create");
     }
 

--- a/src/Angor/Client/Storage/ClientStorage.cs
+++ b/src/Angor/Client/Storage/ClientStorage.cs
@@ -96,10 +96,6 @@ public class ClientStorage : IClientStorage, INetworkStorage
         _storage.SetItem("founder-projects", ret.OrderBy(_ => _.ProjectIndex));
     }
     
-    public void ClearFounderProjects()
-    {
-        _storage.SetItem("founder-projects", new List<FounderProject>());
-    }
     
     public List<FounderProject> GetFounderProjects()
     {

--- a/src/Angor/Client/Storage/ClientStorage.cs
+++ b/src/Angor/Client/Storage/ClientStorage.cs
@@ -96,6 +96,11 @@ public class ClientStorage : IClientStorage, INetworkStorage
         _storage.SetItem("founder-projects", ret.OrderBy(_ => _.ProjectIndex));
     }
     
+    public void ClearFounderProjects()
+    {
+        _storage.SetItem("founder-projects", new List<FounderProject>());
+    }
+    
     public List<FounderProject> GetFounderProjects()
     {
         var ret = _storage.GetItem<List<FounderProject>>("founder-projects");

--- a/src/Angor/Client/Storage/IClientStorage.cs
+++ b/src/Angor/Client/Storage/IClientStorage.cs
@@ -17,6 +17,7 @@ namespace Angor.Client.Storage
         
         
         void AddFounderProject(params FounderProject[] projects);
+        void ClearFounderProjects();
         List<FounderProject> GetFounderProjects();
         FounderProject? GetFounderProjects(string projectIdentifier);
         void UpdateFounderProject(FounderProject project);

--- a/src/Angor/Client/Storage/IClientStorage.cs
+++ b/src/Angor/Client/Storage/IClientStorage.cs
@@ -17,7 +17,6 @@ namespace Angor.Client.Storage
         
         
         void AddFounderProject(params FounderProject[] projects);
-        void ClearFounderProjects();
         List<FounderProject> GetFounderProjects();
         FounderProject? GetFounderProjects(string projectIdentifier);
         void UpdateFounderProject(FounderProject project);


### PR DESCRIPTION
@dangershony @DavidGershony 
After removing the change from [this commit](https://github.com/block-core/angor/pull/136/commits/660765ee662d1f3f91093c34f61a8fc5076e237a), 
I noticed an issue during rescanning: if another project is found, duplicate projects can appear. 

If there's a more effective solution that avoids deleting i'll implement that

p.s, Maybe we can do a softer filter in LookupProjectKeysOnIndexerAsync?

![image](https://github.com/user-attachments/assets/5d7ca8a1-5ce4-4a3b-a410-c736aeed2e3f)
