### PR TITLE
Add Striphtmltags service

### DIFF
--- a/src/Angor/Client/Angor.Client.csproj
+++ b/src/Angor/Client/Angor.Client.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="Blazored.SessionStorage" Version="2.4.0" />
     <PackageReference Include="Blockcore.Core" Version="1.1.41" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageReference Include="NBitcoin" Version="7.0.25" />
     <PackageReference Include="Nostr.Client" Version="2.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/src/Angor/Client/Angor.Client.csproj
+++ b/src/Angor/Client/Angor.Client.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="Blazored.SessionStorage" Version="2.4.0" />
     <PackageReference Include="Blockcore.Core" Version="1.1.41" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageReference Include="NBitcoin" Version="7.0.25" />
     <PackageReference Include="Nostr.Client" Version="2.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/src/Angor/Client/Components/FounderProjectItem.razor
+++ b/src/Angor/Client/Components/FounderProjectItem.razor
@@ -37,7 +37,7 @@
                     </h5>
                 </div>
             </div>
-            <p class="mb-0 line-clamp-3">@(ConvertToMarkupString(HtmlStripperService.StripHtmlTags(FounderProject.Metadata.About)))</p>
+            <p class="mb-0 line-clamp-3">@(ConvertToMarkupString(FounderProject.Metadata.About))</p>
 
 
 

--- a/src/Angor/Client/Components/FounderProjectItem.razor
+++ b/src/Angor/Client/Components/FounderProjectItem.razor
@@ -2,77 +2,78 @@
 @using Angor.Client.Models
 @using Angor.Client.Storage
 @using System.Text.RegularExpressions
+ 
 
 @inject IRelayService RelayService;
 @inject IClientStorage Storage;
+@inject IHtmlStripperService HtmlStripperService;
 
 
 
+<div class="col d-flex align-items-stretch">
+    <div class="card mt-4 w-100 project-card">
+        <a class="d-block">
 
-    <div class="col d-flex align-items-stretch">
-        <div class="card mt-4 w-100 project-card">
-            <a class="d-block">
-
-                <div class="banner-container">
-                    <img class="banner-image" src="@(FounderProject?.Metadata?.Banner ?? "/assets/img/no-image.jpg")" alt="@(@FounderProject?.Metadata?.Banner != null ? "" : "no-image")" onerror="this.onerror=null; this.src='/assets/img/no-image.jpg';" />
-                    <div class="profile-container">
-                        <img class="profile-image" src="@(FounderProject?.Metadata?.Picture ?? "/assets/img/no-image.jpg")" alt="@(FounderProject?.Metadata?.Banner != null ? "" : "no-image")" onerror="this.onerror=null; this.src='/assets/img/no-image.jpg';" />
-                    </div>
+            <div class="banner-container">
+                <img class="banner-image" src="@(FounderProject?.Metadata?.Banner ?? "/assets/img/no-image.jpg")" alt="@(@FounderProject?.Metadata?.Banner != null ? "" : "no-image")" onerror="this.onerror=null; this.src='/assets/img/no-image.jpg';" />
+                <div class="profile-container">
+                    <img class="profile-image" src="@(FounderProject?.Metadata?.Picture ?? "/assets/img/no-image.jpg")" alt="@(FounderProject?.Metadata?.Banner != null ? "" : "no-image")" onerror="this.onerror=null; this.src='/assets/img/no-image.jpg';" />
                 </div>
-
-            </a>
-
-            <div class="card-body pb-0">
-
-
-
-                <div class="d-flex align-items-center mb-4">
-                    <span class="user-select-none">
-                        <Icon IconName="view" Height="24" Width="24"></Icon>
-                    </span>
-                    <div class="h-100 ms-3">
-                        <h5 class="mb-0 font-weight-bolder">
-                            <a href="/view/@FounderProject.ProjectInfo.ProjectIdentifier"> @FounderProject.Metadata.Name</a>
-                        </h5>
-                    </div>
-                </div>
-                <p class="mb-0 line-clamp-3">@(ConvertToMarkupString(StripHtmlTags(FounderProject.Metadata.About)))</p>
-
-
-
             </div>
-            <div class="card-footer pt-0">
-                <hr class="horizontal light mt-3">
 
-                <a role="button" class="d-flex align-items-center btn btn-border w-100-m" href=@($"/view/{FounderProject.ProjectInfo.ProjectIdentifier}")>
+        </a>
+
+        <div class="card-body pb-0">
+
+
+
+            <div class="d-flex align-items-center mb-4">
+                <span class="user-select-none">
+                    <Icon IconName="view" Height="24" Width="24"></Icon>
+                </span>
+                <div class="h-100 ms-3">
+                    <h5 class="mb-0 font-weight-bolder">
+                        <a href="/view/@FounderProject.ProjectInfo.ProjectIdentifier"> @FounderProject.Metadata.Name</a>
+                    </h5>
+                </div>
+            </div>
+            <p class="mb-0 line-clamp-3">@(ConvertToMarkupString(HtmlStripperService.StripHtmlTags(FounderProject.Metadata.About)))</p>
+
+
+
+        </div>
+        <div class="card-footer pt-0">
+            <hr class="horizontal light mt-3">
+
+            <a role="button" class="d-flex align-items-center btn btn-border w-100-m" href=@($"/view/{FounderProject.ProjectInfo.ProjectIdentifier}")>
+                <span class="user-select-none">
+                    <Icon IconName="view-project" Height="24" Width="24"></Icon>
+                </span>
+                <div class="h-100 ms-3">
+                    <span class="mb-0 font-weight-bolder text-primary">
+                        View Project
+                    </span>
+                </div>
+            </a>
+            @if (InvestmentRequests)
+            {
+                <hr class="horizontal light mt-3">
+                <a role="button" class="d-flex align-items-center btn btn-border w-100-m" href=@($"/signatures/{FounderProject.ProjectInfo.ProjectIdentifier}")>
                     <span class="user-select-none">
-                        <Icon IconName="view-project" Height="24" Width="24"></Icon>
+                        <Icon IconName="check-circle" Height="24" Width="24"></Icon>
                     </span>
                     <div class="h-100 ms-3">
-                        <span class="mb-0 font-weight-bolder text-primary">
-                            View Project
+                        <span class="mb-0 font-weight-bolder">
+                            Approve signatures
                         </span>
                     </div>
                 </a>
-                @if (InvestmentRequests)
-                {
-                    <hr class="horizontal light mt-3">
-                <a role="button" class="d-flex align-items-center btn btn-border w-100-m" href=@($"/signatures/{FounderProject.ProjectInfo.ProjectIdentifier}")>
-                        <span class="user-select-none">
-                            <Icon IconName="check-circle" Height="24" Width="24"></Icon>
-                        </span>
-                        <div class="h-100 ms-3">
-                            <span class="mb-0 font-weight-bolder">
-                                Approve signatures
-                            </span>
-                        </div>
-                    </a>
-                }
+            }
 
-            </div>
         </div>
     </div>
- 
+</div>
+
 
 @code {
 
@@ -94,51 +95,11 @@
             });
     }
 
-    public string StripHtmlTags(string input)
-    {
-        if (string.IsNullOrWhiteSpace(input))
-        {
-            return string.Empty;
-        }
-
-        input = Regex.Replace(input, @"<script.*?>.*?</script>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
-
-        input = Regex.Replace(input, @"<style.*?>.*?</style>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
-        input = Regex.Replace(input, @"<([a-zA-Z][^\s>]*)(\s+[^>]*)?>", match =>
-    {
-    string tag = match.Groups[1].Value;
-    string attributes = match.Groups[2].Value;
-
-    attributes = Regex.Replace(attributes, @"\s+(style|class)\s*=\s*""[^""]*""", string.Empty, RegexOptions.IgnoreCase);
-
-    return $"<{tag}{attributes}>";
-    }, RegexOptions.IgnoreCase);
-
-        string allowedTagsPattern = @"<(?!\/?(br|p|a|ul|ol|li|strong|em|b|i|u|hr|blockquote|img|div|span|table|thead|tbody|tr|td|th)\b)[^>]+>";
-        input = Regex.Replace(input, allowedTagsPattern, string.Empty, RegexOptions.IgnoreCase);
-
-        string[] blockTags = { "h1", "h2", "h3", "h4", "h5", "h6", "p", "div", "section", "article", "footer", "header", "main" };
-
-        foreach (var tag in blockTags)
-        {
-            input = Regex.Replace(input, $@"<\/?{tag}[^>]*>", "<br />", RegexOptions.IgnoreCase);
-        }
-
-        input = Regex.Replace(input, @"<((?!br\s*/?)[^>]+)>", string.Empty);
-
-        input = Regex.Replace(input, @"(\r?\n){2,}", "\n");
-        input = Regex.Replace(input, @"(<br />\s*){2,}", "<br />");
-        input = Regex.Replace(input, @"^\s*<br />\s*|\s*<br />\s*$", string.Empty);
-        input = Regex.Replace(input, @"\s*(<br />)\s*", "$1");
-
-        return input;
-    }
+ 
 
     public MarkupString ConvertToMarkupString(string input)
     {
-        string sanitizedInput = StripHtmlTags(input);
+        string sanitizedInput = HtmlStripperService.StripHtmlTags(input);
         return new MarkupString(sanitizedInput);
     }
 }

--- a/src/Angor/Client/Pages/Browse.razor
+++ b/src/Angor/Client/Pages/Browse.razor
@@ -1,7 +1,6 @@
 ﻿@page "/browse"
 @using Angor.Shared.Models
 @using Angor.Shared.Services
-@using HtmlAgilityPack
 @using Nostr.Client.Messages
 @using Angor.Client.Models
 @using Angor.Client.Storage
@@ -199,7 +198,7 @@ else
                                                         </div>
                                                     </div>
 
-                                                    <p class="card-text line-clamp-3" role="button" @onclick="() => ViewProjectDetails(indexerData.ProjectIdentifier)">@ConvertToMarkupString(HtmlStripperService.StripHtmlTags(project.Metadata.About))</p>
+                                                    <p class="card-text line-clamp-3" role="button" @onclick="() => ViewProjectDetails(indexerData.ProjectIdentifier)">@ConvertToMarkupString(project.Metadata.About)</p>
                                                 }
                                             }
                                             else

--- a/src/Angor/Client/Pages/Browse.razor
+++ b/src/Angor/Client/Pages/Browse.razor
@@ -1,6 +1,7 @@
 ﻿@page "/browse"
 @using Angor.Shared.Models
 @using Angor.Shared.Services
+@using HtmlAgilityPack
 @using Nostr.Client.Messages
 @using Angor.Client.Models
 @using Angor.Client.Storage
@@ -12,6 +13,7 @@
 @inject INetworkService _NetworkService
 @inject ISerializer serializer
 @inject ILogger<Browse> Logger;
+@inject IHtmlStripperService HtmlStripperService;
 
 <NotificationComponent @ref="notificationComponent" />
 
@@ -197,7 +199,7 @@ else
                                                         </div>
                                                     </div>
 
-                                                    <p class="card-text line-clamp-3" role="button" @onclick="() => ViewProjectDetails(indexerData.ProjectIdentifier)">@ConvertToMarkupString(StripHtmlTags(project.Metadata.About))</p>
+                                                    <p class="card-text line-clamp-3" role="button" @onclick="() => ViewProjectDetails(indexerData.ProjectIdentifier)">@ConvertToMarkupString(HtmlStripperService.StripHtmlTags(project.Metadata.About))</p>
                                                 }
                                             }
                                             else
@@ -511,53 +513,11 @@ else
     {
         searchQuery = e.Value.ToString();
     }
-
-    public string StripHtmlTags(string input)
-    {
-        if (string.IsNullOrWhiteSpace(input))
-        {
-            return string.Empty;
-        }
-
-        input = Regex.Replace(input, @"<script.*?>.*?</script>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
-
-        input = Regex.Replace(input, @"<style.*?>.*?</style>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
-        input = Regex.Replace(input, @"<([a-zA-Z][^\s>]*)(\s+[^>]*)?>", match =>
-        {
-            string tag = match.Groups[1].Value;
-            string attributes = match.Groups[2].Value;
-
-            attributes = Regex.Replace(attributes, @"\s+(style|class)\s*=\s*""[^""]*""", string.Empty, RegexOptions.IgnoreCase);
-
-            return $"<{tag}{attributes}>";
-        }, RegexOptions.IgnoreCase);
-
-        string allowedTagsPattern = @"<(?!\/?(br|p|a|ul|ol|li|strong|em|b|i|u|hr|blockquote|img|div|span|table|thead|tbody|tr|td|th)\b)[^>]+>";
-        input = Regex.Replace(input, allowedTagsPattern, string.Empty, RegexOptions.IgnoreCase);
-
-        string[] blockTags = { "h1", "h2", "h3", "h4", "h5", "h6", "p", "div", "section", "article", "footer", "header", "main" };
-
-        foreach (var tag in blockTags)
-        {
-            input = Regex.Replace(input, $@"<\/?{tag}[^>]*>", "<br />", RegexOptions.IgnoreCase);
-        }
-
-        input = Regex.Replace(input, @"<((?!br\s*/?)[^>]+)>", string.Empty);
-
-        input = Regex.Replace(input, @"(\r?\n){2,}", "\n");
-        input = Regex.Replace(input, @"(<br />\s*){2,}", "<br />");
-        input = Regex.Replace(input, @"^\s*<br />\s*|\s*<br />\s*$", string.Empty);
-        input = Regex.Replace(input, @"\s*(<br />)\s*", "$1");
-
-
-        return input;
-    }
+ 
 
     public MarkupString ConvertToMarkupString(string input)
     {
-        string sanitizedInput = StripHtmlTags(input);
+        string sanitizedInput = HtmlStripperService.StripHtmlTags(input);
         return new MarkupString(sanitizedInput);
     }
 }

--- a/src/Angor/Client/Pages/Create.razor
+++ b/src/Angor/Client/Pages/Create.razor
@@ -19,6 +19,7 @@
 @inject IWalletOperations _WalletOperations
 @inject IRelayService _RelayService
 @inject ILogger<Create> _Logger;
+@inject IHtmlStripperService HtmlStripperService;
 
 @inject IFounderTransactionActions _founderTransactionActions
 <NotificationComponent @ref="notificationComponent" />
@@ -200,7 +201,7 @@
                             }
                             else
                             {
-                                <p class="mb-0 line-clamp-3">@project.Metadata.About</p>
+                                <p class="mb-0 line-clamp-3">@ConvertToMarkupString(project.Metadata.About)</p>
                             }
 
                         </div>
@@ -885,4 +886,11 @@
     {
         project.ProjectInfo.Stages.Remove(stage);
     }
+
+    public MarkupString ConvertToMarkupString(string input)
+    {
+        string sanitizedInput = HtmlStripperService.StripHtmlTags(input);
+        return new MarkupString(sanitizedInput);
+    }
+
 }

--- a/src/Angor/Client/Pages/View.razor
+++ b/src/Angor/Client/Pages/View.razor
@@ -20,6 +20,7 @@
 @inject ISerializer serializer
 @inject IJSRuntime Js;
 @inject ILogger<Browse> Logger;
+@inject IHtmlStripperService HtmlStripperService;
 
 @inject Angor.Shared.Utilities.NostrConversionHelper NostrHelper
 
@@ -697,38 +698,10 @@
             notificationComponent.ShowNotificationMessage("Public key is not available.", 3);
         }
     }
-
-    public string StripHtmlTags(string input)
-    {
-        if (string.IsNullOrWhiteSpace(input))
-        {
-            return string.Empty;
-        }
-
-        input = Regex.Replace(input, @"<script.*?>.*?</script>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
-        input = Regex.Replace(input, @"<style.*?>.*?</style>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
-        input = Regex.Replace(input, @"<([a-zA-Z][^\s>]*)(\s+[^>]*)?>", match =>
-     {
-     string tag = match.Groups[1].Value;
-     string attributes = match.Groups[2].Value;
-
-     attributes = Regex.Replace(attributes, @"\s+(style|class)\s*=\s*""[^""]*""", string.Empty, RegexOptions.IgnoreCase);
-
-     return $"<{tag}{attributes}>";
-     }, RegexOptions.IgnoreCase);
-
-        string allowedTagsPattern = @"<(?!\/?(br|p|a|ul|ol|li|strong|em|b|i|u|hr|blockquote|img|div|span|table|thead|tbody|tr|td|th)\b)[^>]+>";
-        input = Regex.Replace(input, allowedTagsPattern, string.Empty, RegexOptions.IgnoreCase);
-
-
-        return input;
-    }
-
+ 
     public MarkupString ConvertToMarkupString(string input)
     {
-        string sanitizedInput = StripHtmlTags(input);
+        string sanitizedInput = HtmlStripperService.StripHtmlTags(input);
         return new MarkupString(sanitizedInput);
     }
 }

--- a/src/Angor/Client/Program.cs
+++ b/src/Angor/Client/Program.cs
@@ -56,6 +56,8 @@ builder.Services.AddTransient<ITaprootScriptBuilder, TaprootScriptBuilder>();
 builder.Services.AddSingleton<INostrCommunicationFactory, NostrCommunicationFactory>();
 builder.Services.AddScoped<IRelaySubscriptionsHandling, RelaySubscriptionsHandling>();
 builder.Services.AddSingleton<IPasswordCacheService, PasswordCacheService>();
+builder.Services.AddTransient<IHtmlStripperService, HtmlStripperService>();
+
 builder.Services.AddScoped<NostrConversionHelper>();
 
 builder.Services.AddScoped<IconService>();

--- a/src/Angor/Client/Services/HtmlStripperService.cs
+++ b/src/Angor/Client/Services/HtmlStripperService.cs
@@ -1,4 +1,4 @@
-﻿using HtmlAgilityPack;
+﻿using System.Text.RegularExpressions;
 
 namespace Angor.Client.Services
 {
@@ -7,19 +7,44 @@ namespace Angor.Client.Services
         public string StripHtmlTags(string input)
         {
             if (string.IsNullOrWhiteSpace(input))
+            {
                 return string.Empty;
+            }
 
-            var doc = new HtmlDocument();
-            doc.LoadHtml(input);
+            input = Regex.Replace(input, @"<script.*?>.*?</script>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-            doc.DocumentNode.SelectNodes("//script|//style")?.ToList().ForEach(node => node.Remove());
+            input = Regex.Replace(input, @"<style.*?>.*?</style>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-            var output = string.Join("\n", doc.DocumentNode.SelectNodes("//text()[normalize-space()]")
-                ?.Select(node => HtmlEntity.DeEntitize(node.InnerText.Trim()))
-                .Where(text => !string.IsNullOrEmpty(text)) ?? Enumerable.Empty<string>());
+            input = Regex.Replace(input, @"<([a-zA-Z][^\s>]*)(\s+[^>]*)?>", match =>
+            {
+                string tag = match.Groups[1].Value;
+                string attributes = match.Groups[2].Value;
 
-            return output.Trim();
+                attributes = Regex.Replace(attributes, @"\s+(style|class)\s*=\s*""[^""]*""", string.Empty, RegexOptions.IgnoreCase);
+
+                return $"<{tag}{attributes}>";
+            }, RegexOptions.IgnoreCase);
+
+            string allowedTagsPattern = @"<(?!\/?(br|p|a|ul|ol|li|strong|em|b|i|u|hr|blockquote|img|div|span|table|thead|tbody|tr|td|th)\b)[^>]+>";
+            input = Regex.Replace(input, allowedTagsPattern, string.Empty, RegexOptions.IgnoreCase);
+
+            string[] blockTags = { "h1", "h2", "h3", "h4", "h5", "h6", "p", "div", "section", "article", "footer", "header", "main" };
+
+            foreach (var tag in blockTags)
+            {
+                input = Regex.Replace(input, $@"<\/?{tag}[^>]*>", "<br />", RegexOptions.IgnoreCase);
+            }
+
+            input = Regex.Replace(input, @"<((?!br\s*/?)[^>]+)>", string.Empty);
+
+            input = Regex.Replace(input, @"(\r?\n){2,}", "\n");
+            input = Regex.Replace(input, @"(<br />\s*){2,}", "<br />");
+            input = Regex.Replace(input, @"^\s*<br />\s*|\s*<br />\s*$", string.Empty);
+            input = Regex.Replace(input, @"\s*(<br />)\s*", "$1");
+
+            return input;
         }
+
     }
 
 }

--- a/src/Angor/Client/Services/HtmlStripperService.cs
+++ b/src/Angor/Client/Services/HtmlStripperService.cs
@@ -1,0 +1,25 @@
+﻿using HtmlAgilityPack;
+
+namespace Angor.Client.Services
+{
+    public class HtmlStripperService : IHtmlStripperService
+    {
+        public string StripHtmlTags(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                return string.Empty;
+
+            var doc = new HtmlDocument();
+            doc.LoadHtml(input);
+
+            doc.DocumentNode.SelectNodes("//script|//style")?.ToList().ForEach(node => node.Remove());
+
+            var output = string.Join("\n", doc.DocumentNode.SelectNodes("//text()[normalize-space()]")
+                ?.Select(node => HtmlEntity.DeEntitize(node.InnerText.Trim()))
+                .Where(text => !string.IsNullOrEmpty(text)) ?? Enumerable.Empty<string>());
+
+            return output.Trim();
+        }
+    }
+
+}

--- a/src/Angor/Client/Services/IHtmlStripperService.cs
+++ b/src/Angor/Client/Services/IHtmlStripperService.cs
@@ -1,0 +1,8 @@
+﻿namespace Angor.Client.Services
+{
+    public interface IHtmlStripperService
+    {
+        string StripHtmlTags(string input);
+
+    }
+}


### PR DESCRIPTION
### HtmlStripperService

The `HtmlStripperService` processes and cleans HTML content by removing unnecessary or harmful tags and attributes while preserving a list of allowed tags for basic formatting. This helps ensure content safety and consistent appearance in web applications.

#### Key Features

- Removes `<script>` and `<style>` tags to prevent malicious or unwanted scripts and styles.
- Retains only allowed tags (e.g., `<p>`, `<br>`, `<a>`) and strips unsupported tags.
- Removes inline attributes like `style` and `class` to maintain design consistency.
- Replaces block-level tags (e.g., `<div>`, `<section>`) with `<br>` for simplified layout.
- Cleans redundant `<br>` tags and trims unnecessary whitespace.

#### Example Usage

```csharp
@inject IHtmlStripperService HtmlStripperService;

string rawHtml = "<div><script>alert('malicious');</script><p>Welcome!</p><style>.hidden { display: none; }</style></div>";
string sanitizedHtml = HtmlStripperService.StripHtmlTags(rawHtml);
Console.WriteLine(sanitizedHtml); // Outputs: "<br /><br />Welcome!"
```

#### Dependency Injection Setup

In `Program.cs`, register the service with:
```csharp
builder.Services.AddTransient<IHtmlStripperService, HtmlStripperService>();
```

