### PR TITLE
Disable the minify steps in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,16 +194,6 @@ jobs:
     - name: Add .nojekyll file
       run: touch dist/wwwroot/.nojekyll
 
-    - name: Minify and replace JS files
-      run: |
-        npm install uglify-js -g
-        find dist/wwwroot/assets/js -type f -name '*.js' -exec uglifyjs {} -o {} --compress --mangle \;
-
-    - name: Minify and replace CSS files
-      run: |
-        npm install csso-cli -g
-        find dist/wwwroot/assets/css -type f -name '*.css' -exec csso {} -o {} \;
-
     - name: Deploy to Github Pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,16 +54,6 @@ jobs:
     - name: Add .nojekyll file
       run: touch dist/wwwroot/.nojekyll
 
-    - name: Minify and replace JS files
-      run: |
-        npm install uglify-js -g
-        find dist/wwwroot/assets/js -type f -name '*.js' -exec uglifyjs {} -o {} --compress --mangle \;
-
-    - name: Minify and replace CSS files
-      run: |
-        npm install csso-cli -g
-        find dist/wwwroot/assets/css -type f -name '*.css' -exec csso {} -o {} \;
-
     - name: Deploy to Github Pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:


### PR DESCRIPTION
- Creates issues with security validation, because builds generates hashes for files and uses that to ensure correct files are loaded.