### PR TITLE
Fix a nostr subscription registration bug

### DIFF
--- a/src/Angor/Shared/Services/INostrCommunicationFactory.cs
+++ b/src/Angor/Shared/Services/INostrCommunicationFactory.cs
@@ -8,7 +8,7 @@ public interface INostrCommunicationFactory
     void CloseClientConnection();
     int GetNumberOfRelaysConnected();
     bool EoseEventReceivedOnAllRelays(string subscription);
-    void MonitoringEoseReceivedOnSubscription(string subscription);
+    bool MonitoringEoseReceivedOnSubscription(string subscription);
     void ClearEoseReceivedOnSubscriptionMonitoring(string subscription);
     bool OkEventReceivedOnAllRelays(string eventId);
     void MonitoringOkReceivedOnSubscription(string eventId);

--- a/src/Angor/Shared/Services/NostrCommunicationFactory.cs
+++ b/src/Angor/Shared/Services/NostrCommunicationFactory.cs
@@ -114,13 +114,15 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
         return response;
     }
     
-    public void MonitoringEoseReceivedOnSubscription(string subscription)
+    public bool MonitoringEoseReceivedOnSubscription(string subscription)
     {
         _logger.LogInformation($"Started monitoring subscription {subscription}");
         var addedToSubscriptionClients = _eoseCalledOnSubscriptionClients.TryAdd(subscription, new List<string>());
 
         if(!addedToSubscriptionClients)
             _logger.LogWarning($"Subscription {subscription} is already being monitored");
+
+        return addedToSubscriptionClients;
     }
     
     public void ClearEoseReceivedOnSubscriptionMonitoring(string subscription)

--- a/src/Angor/Shared/Services/NostrCommunicationFactory.cs
+++ b/src/Angor/Shared/Services/NostrCommunicationFactory.cs
@@ -117,7 +117,7 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
     public void MonitoringEoseReceivedOnSubscription(string subscription)
     {
         _logger.LogInformation($"Started monitoring subscription {subscription}");
-        _eoseCalledOnSubscriptionClients.Add(subscription, new List<string>());
+        _eoseCalledOnSubscriptionClients.TryAdd(subscription, new List<string>());
     }
     
     public void ClearEoseReceivedOnSubscriptionMonitoring(string subscription)

--- a/src/Angor/Shared/Services/NostrCommunicationFactory.cs
+++ b/src/Angor/Shared/Services/NostrCommunicationFactory.cs
@@ -117,7 +117,10 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
     public void MonitoringEoseReceivedOnSubscription(string subscription)
     {
         _logger.LogInformation($"Started monitoring subscription {subscription}");
-        _eoseCalledOnSubscriptionClients.TryAdd(subscription, new List<string>());
+        var addedToSubscriptionClients = _eoseCalledOnSubscriptionClients.TryAdd(subscription, new List<string>());
+
+        if(!addedToSubscriptionClients)
+            _logger.LogWarning($"Subscription {subscription} is already being monitored");
     }
     
     public void ClearEoseReceivedOnSubscriptionMonitoring(string subscription)

--- a/src/Angor/Shared/Services/NostrCommunicationFactory.cs
+++ b/src/Angor/Shared/Services/NostrCommunicationFactory.cs
@@ -117,12 +117,7 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
     public bool MonitoringEoseReceivedOnSubscription(string subscription)
     {
         _logger.LogInformation($"Started monitoring subscription {subscription}");
-        var addedToSubscriptionClients = _eoseCalledOnSubscriptionClients.TryAdd(subscription, new List<string>());
-
-        if(!addedToSubscriptionClients)
-            _logger.LogWarning($"Subscription {subscription} is already being monitored");
-
-        return addedToSubscriptionClients;
+        return _eoseCalledOnSubscriptionClients.TryAdd(subscription, new List<string>());
     }
     
     public void ClearEoseReceivedOnSubscriptionMonitoring(string subscription)

--- a/src/Angor/Shared/Services/RelaySubscriptionsHandling.cs
+++ b/src/Angor/Shared/Services/RelaySubscriptionsHandling.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Blockcore.EventBus;
 using Microsoft.Extensions.Logging;
 using Nostr.Client.Requests;
 using Nostr.Client.Responses;
@@ -65,9 +66,12 @@ public class RelaySubscriptionsHandling : IDisposable, IRelaySubscriptionsHandli
 
     public bool TryAddEoseAction(string subscriptionName, Action action)
     {
-        _communicationFactory.MonitoringEoseReceivedOnSubscription(subscriptionName);
-        
-        return userEoseActions.TryAdd(subscriptionName,action);
+        var add = _communicationFactory.MonitoringEoseReceivedOnSubscription(subscriptionName);
+
+        if (!add)
+            _logger.LogWarning($"Subscription {subscriptionName} is already being monitored");
+
+        return userEoseActions.TryAdd(subscriptionName,action); 
     }
 
     public void HandleEoseMessages(NostrEoseResponse _)


### PR DESCRIPTION
Check the dictionary _eoseCalledOnSubscriptionClients before adding a subscription class

I am not sure this is the correct fix because it might mean that we are not disposing of a subscription correctly
note this error returns until I refresh the page
