### PR TITLE
Automatically Perform Rescan After Wallet Restore with UI Feedback & …

### DIFF
--- a/src/Angor/Client/Pages/Founder.razor
+++ b/src/Angor/Client/Pages/Founder.razor
@@ -5,6 +5,8 @@
 @using Angor.Shared.Services
 @using Nostr.Client.Messages
 @using Angor.Client.Shared
+@using System.Threading
+@using System.Threading.Tasks
 
 @inject NavigationManager NavigationManager
 @inject NavMenuState NavMenuState
@@ -106,7 +108,7 @@
     bool scanningForProjects;
 
     private NotificationComponent notificationComponent;
-
+    private CancellationTokenSource _scanCts;
 
     protected override async Task OnInitializedAsync()
     {
@@ -118,100 +120,148 @@
         if (hasWallet)
         {
             founderProjects = storage.GetFounderProjects().Where(_ => !string.IsNullOrEmpty(_.CreationTransactionId)).ToList();
+            
+            // Check if we need to perform an automatic rescan
+            if (_walletStorage.NeedsRescan())
+            {
+                notificationComponent?.ShowInfo("Performing automatic rescan after wallet restore...");
+                await LookupProjectKeysOnIndexerAsync(isAutoRescan: true);
+                _walletStorage.SetNeedsRescan(false);
+            }
         }
     }
 
-    private async Task LookupProjectKeysOnIndexerAsync()
+    private async Task LookupProjectKeysOnIndexerAsync(bool isAutoRescan = false)
     {
-        scanningForProjects = true;
-
-        var keys = _walletStorage.GetFounderKeys();
-        var founderProjectsToLookup = new Dictionary<string, ProjectIndexerData>();
-
-        foreach (var key in keys.Keys)
+        if (scanningForProjects)
         {
-            if (founderProjects.Any(_ => _.ProjectInfo.ProjectIdentifier == key.ProjectIdentifier))
-                continue;
-
-            var indexerProject = await _IndexerService.GetProjectByIdAsync(key.ProjectIdentifier);
-
-            if (indexerProject != null) //TODO we need to talk about supporting projects that are created with gaps
-                founderProjectsToLookup.Add(key.NostrPubKey, indexerProject);
-        }
-
-        if (!founderProjectsToLookup.Any())
-        {
-            scanningForProjects = false;
+            notificationComponent?.ShowWarning("A scan is already in progress");
             return;
         }
 
-        RelayService.RequestProjectCreateEventsByPubKey(
-            e =>
+        scanningForProjects = true;
+        StateHasChanged();
+
+        try 
+        {
+            // Create new CancellationTokenSource with 5-minute timeout
+            _scanCts?.Dispose();
+            _scanCts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+
+            var keys = _walletStorage.GetFounderKeys();
+            var founderProjectsToLookup = new Dictionary<string, ProjectIndexerData>();
+
+            foreach (var key in keys.Keys)
             {
-                switch (e)
-                {
-                    case { Kind: NostrKind.Metadata }:
-                        var nostrMetadata = serializer.Deserialize<ProjectMetadata>(e.Content);
-                        var existingProject = founderProjects.FirstOrDefault(_ => _.ProjectInfo.NostrPubKey == e.Pubkey);
+                // Check for cancellation
+                _scanCts.Token.ThrowIfCancellationRequested();
+                
+                if (founderProjects.Any(_ => _.ProjectInfo.ProjectIdentifier == key.ProjectIdentifier))
+                    continue;
 
-                        if (existingProject != null)
-                        {
-                            existingProject.Metadata ??= nostrMetadata;
-                        }
-                        else
-                        {
-                            var founderProject = CreateFounderProject(founderProjectsToLookup, e);
-                            founderProject.Metadata = nostrMetadata;
-                            founderProjects.Add(founderProject);
-                        }
+                var indexerProject = await _IndexerService.GetProjectByIdAsync(key.ProjectIdentifier);
 
-                        break;
+                if (indexerProject != null)
+                    founderProjectsToLookup.Add(key.NostrPubKey, indexerProject);
+            }
 
-                    case { Kind: NostrKind.ApplicationSpecificData }:
-
-                        if (e.Id != founderProjectsToLookup[e.Pubkey].NostrEventId)
-                            return;
-
-                        var projectInfo = serializer.Deserialize<ProjectInfo>(e.Content);
-                        var project = founderProjects.FirstOrDefault(_ => _.ProjectInfo.NostrPubKey == e.Pubkey);
-
-                        if (project != null)
-                        {
-                            if (!string.IsNullOrEmpty(project.ProjectInfo.ProjectIdentifier))
-                                return;
-
-                            project.ProjectInfo = projectInfo;
-                        }
-                        else
-                        {
-                            project ??= CreateFounderProject(founderProjectsToLookup, e, projectInfo);
-                            founderProjects.Add(project);
-                        }
-
-                        break;
-                }
-            },
-            () =>
+            if (!founderProjectsToLookup.Any())
             {
                 scanningForProjects = false;
-
-                // Merge or update projects in storage
-                foreach (var project in founderProjects)
+                if (isAutoRescan)
                 {
-                    var existing = storage.GetFounderProjects().FirstOrDefault(p => p.ProjectInfo.ProjectIdentifier == project.ProjectInfo.ProjectIdentifier);
-                    if (existing == null)
-                    {
-                        storage.AddFounderProject(new[] { project });
-                    }
-                    else
-                    {
-                        storage.UpdateFounderProject(project);
-                    }
+                    notificationComponent?.ShowSuccess("Automatic rescan complete - No new projects found");
                 }
+                return;
+            }
 
-                StateHasChanged();
-            },
-            founderProjectsToLookup.Keys.ToArray());
+            RelayService.RequestProjectCreateEventsByPubKey(
+                e =>
+                {
+                    // Check for cancellation in the event handler
+                    if (_scanCts.Token.IsCancellationRequested) return;
+                    
+                    switch (e)
+                    {
+                        case { Kind: NostrKind.Metadata }:
+                            var nostrMetadata = serializer.Deserialize<ProjectMetadata>(e.Content);
+                            var existingProject = founderProjects.FirstOrDefault(_ => _.ProjectInfo.NostrPubKey == e.Pubkey);
+
+                            if (existingProject != null)
+                            {
+                                existingProject.Metadata ??= nostrMetadata;
+                            }
+                            else
+                            {
+                                var founderProject = CreateFounderProject(founderProjectsToLookup, e);
+                                founderProject.Metadata = nostrMetadata;
+                                founderProjects.Add(founderProject);
+                            }
+
+                            break;
+
+                        case { Kind: NostrKind.ApplicationSpecificData }:
+                            if (e.Id != founderProjectsToLookup[e.Pubkey].NostrEventId)
+                                return;
+
+                            var projectInfo = serializer.Deserialize<ProjectInfo>(e.Content);
+                            var project = founderProjects.FirstOrDefault(_ => _.ProjectInfo.NostrPubKey == e.Pubkey);
+
+                            if (project != null)
+                            {
+                                if (!string.IsNullOrEmpty(project.ProjectInfo.ProjectIdentifier))
+                                    return;
+
+                                project.ProjectInfo = projectInfo;
+                            }
+                            else
+                            {
+                                project ??= CreateFounderProject(founderProjectsToLookup, e, projectInfo);
+                                founderProjects.Add(project);
+                            }
+
+                            break;
+                    }
+                },
+                () =>
+                {
+                    scanningForProjects = false;
+
+                    // Merge or update projects in storage
+                    foreach (var project in founderProjects)
+                    {
+                        var existing = storage.GetFounderProjects().FirstOrDefault(p => p.ProjectInfo.ProjectIdentifier == project.ProjectInfo.ProjectIdentifier);
+                        if (existing == null)
+                        {
+                            storage.AddFounderProject(new[] { project });
+                        }
+                        else
+                        {
+                            storage.UpdateFounderProject(project);
+                        }
+                    }
+
+                    if (isAutoRescan)
+                    {
+                        notificationComponent?.ShowSuccess($"Automatic rescan complete - Found {founderProjectsToLookup.Count} project(s)");
+                    }
+
+                    StateHasChanged();
+                },
+                founderProjectsToLookup.Keys.ToArray());
+        }
+        catch (OperationCanceledException)
+        {
+            scanningForProjects = false;
+            notificationComponent?.ShowWarning("Scan operation timed out. Please try again.");
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            scanningForProjects = false;
+            notificationComponent?.ShowError($"Error during {(isAutoRescan ? "automatic " : "")}rescan: {ex.Message}");
+            StateHasChanged();
+        }
     }
 
     private FounderProject CreateFounderProject(Dictionary<string, ProjectIndexerData> founderProjectsToLookup,
@@ -247,5 +297,8 @@
         return "Create a new project.";
     }
 
-
+    public void Dispose()
+    {
+        _scanCts?.Dispose();
+    }
 }

--- a/src/Angor/Client/Storage/IWalletStorage.cs
+++ b/src/Angor/Client/Storage/IWalletStorage.cs
@@ -12,4 +12,6 @@ public interface IWalletStorage
     
     void SetFounderKeys(FounderKeyCollection founderPubKeys);
     FounderKeyCollection GetFounderKeys();
+    bool NeedsRescan();
+    void SetNeedsRescan(bool value);
 }

--- a/src/Angor/Client/Storage/WalletStorage.cs
+++ b/src/Angor/Client/Storage/WalletStorage.cs
@@ -8,15 +8,45 @@ public class WalletStorage : IWalletStorage
     private readonly ISyncLocalStorageService _storage;
 
     private const string WalletKey = "wallet";
+    private const string NeedsRescanKeyPrefix = "needs_rescan_";
 
     public WalletStorage(ISyncLocalStorageService storage)
     {
         _storage = storage;
     }
 
+    private string GetRescanKey(Wallet wallet)
+    {
+        // Use a combination of wallet-specific properties to create a unique key
+        // This ensures each wallet has its own rescan flag
+        return $"{NeedsRescanKeyPrefix}{wallet.GetHashCode()}";
+    }
+
     public bool HasWallet()
     {
         return _storage.ContainKey(WalletKey);
+    }
+
+    public bool NeedsRescan()
+    {
+        var wallet = GetWallet();
+        var rescanKey = GetRescanKey(wallet);
+        return _storage.ContainKey(rescanKey) && _storage.GetItem<bool>(rescanKey);
+    }
+
+    public void SetNeedsRescan(bool value)
+    {
+        var wallet = GetWallet();
+        var rescanKey = GetRescanKey(wallet);
+        
+        if (value)
+        {
+            _storage.SetItem(rescanKey, true);
+        }
+        else
+        {
+            _storage.RemoveItem(rescanKey);
+        }
     }
 
     public void SaveWalletWords(Wallet wallet)
@@ -27,10 +57,22 @@ public class WalletStorage : IWalletStorage
         }
 
         _storage.SetItem(WalletKey, wallet);
+        
+        // Set rescan flag for the new wallet
+        var rescanKey = GetRescanKey(wallet);
+        _storage.SetItem(rescanKey, true);
     }
 
     public void DeleteWallet()
     {
+        // Clean up rescan flag for the current wallet before deleting it
+        if (HasWallet())
+        {
+            var wallet = GetWallet();
+            var rescanKey = GetRescanKey(wallet);
+            _storage.RemoveItem(rescanKey);
+        }
+        
         _storage.RemoveItem(WalletKey);
     }
 
@@ -50,7 +92,6 @@ public class WalletStorage : IWalletStorage
     {
         var wallet = GetWallet();
         wallet.FounderKeys = founderPubKeys;
-
         _storage.SetItem(WalletKey, wallet);
     }
 


### PR DESCRIPTION
Pull Request Description
This PR resolves Issue https://github.com/block-core/angor/issues/211 by ensuring that after a wallet is restored, the first time the user opens the "Founder" page, an automatic rescan is triggered.

Key Changes:
Added a rescan flag (needs_rescan) in WalletStorage to track when a rescan is needed.
Modified SaveWalletWords() to set the rescan flag when a wallet is restored or created.
Updated OnInitializedAsync() in Founder.razor to:
Check if a rescan is needed on page load.
Perform the rescan automatically if required.
Clear the rescan flag after completion.