### PR TITLE
Fix: Disable animation & auto-hide in sidebar menu #199

### DIFF
--- a/src/Angor/Avalonia/AngorApp/Sections/Shell/Sidebar.axaml
+++ b/src/Angor/Avalonia/AngorApp/Sections/Shell/Sidebar.axaml
@@ -32,15 +32,8 @@
             <Setter Property="Height" Value="{StaticResource IconSize}" />
         </Style>
         <Style Selector="controls|Pane">
-            <Setter Property="Width" Value="{StaticResource CollapsedWidth}" />
+            <Setter Property="Width" Value="{StaticResource ExpandedWidth}" /> <!-- Always Expanded -->
             <Setter Property="Padding" Value="10" />
-            <Setter Property="Transitions">
-                <Setter.Value>
-                    <Transitions>
-                        <DoubleTransition Property="Width" Duration="{StaticResource ExpandToggleDuration}" />
-                    </Transitions>
-                </Setter.Value>
-            </Setter>
         </Style>
         <Style Selector="controls|Pane TextBlock">
             <Setter Property="Opacity" Value="0" />
@@ -51,12 +44,7 @@
                 </Transitions>
             </Setter>
         </Style>
-        <Style Selector="controls|Pane:pointerover">
-            <Setter Property="Width" Value="{StaticResource ExpandedWidth}" />
-        </Style>
-        <Style Selector="controls|Pane:pointerover TextBlock">
-            <Setter Property="Opacity" Value="1" />
-        </Style>
+        <!-- Removed auto-expand on hover -->
     </UserControl.Styles>
 
     <controls:Pane>


### PR DESCRIPTION
## Fix: Sidebar Always Expanded in AngorApp #199 

###  Changes Made:
1. **Removed Auto-Hide Behavior**  
   - Deleted the `pointerover` styles that caused the sidebar to expand/collapse on hover.

2. **Removed Expand/Collapse Animation**  
   - Updated the `controls|Pane` style to always keep the sidebar at `ExpandedWidth`.
   - Removed `DoubleTransition` animation for width changes.

###  Issue Fixed:
- The sidebar now **remains expanded** and **does not collapse on hover**.

resolves #199 
@sondreb @dangershony 
