### PR TITLE
Fix `Tooltip` Visibility on Main Dashboard

### DIFF
--- a/src/Angor/Client/Shared/NavMenu.razor.css
+++ b/src/Angor/Client/Shared/NavMenu.razor.css
@@ -71,6 +71,7 @@
     transition: all 0.4s ease;
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
     overflow: hidden;
+    z-index: 9999;
 }
 
 .sidebar.collapsed {


### PR DESCRIPTION
Fixes the issue where the tooltip was appearing below the screen. The z-index for the tooltip has been adjusted to ensure it overlays correctly and is visible to everyone



**Before**

<img width="662" alt="Screenshot 2025-04-11 at 10 28 02 PM" src="https://github.com/user-attachments/assets/4af0eb82-a580-487e-b275-66cdd7ffc114" />


**After**

<img width="692" alt="Screenshot 2025-04-11 at 10 25 34 PM" src="https://github.com/user-attachments/assets/0c4b3b57-0568-4591-a801-4d1f79d56683" />
