### PR TITLE
Feat: Save investments list to Nostr called incorrectly

### DIFF
--- a/src/Angor/Client/Pages/Invest.razor
+++ b/src/Angor/Client/Pages/Invest.razor
@@ -937,13 +937,18 @@ else
 
     private async Task Send()
     {
-        if (!passwordComponent.HasPassword())
+    if (!passwordComponent.HasPassword())
+    {
+        investSpinner = false;
+        showCreateModal = false;
+
+        passwordComponent.ShowPassword(async () =>
         {
-            investSpinner = false;
-            showCreateModal = false;
-            notificationComponent.ShowErrorMessage("Wallet password expired");
-            return;
-        }
+            await Send();
+        });
+
+        return;
+    }
 
         investSpinner = true;
         StateHasChanged();
@@ -965,59 +970,68 @@ else
 
             var investorProject = (InvestorProject)project;
 
-            // remove signatures when requesting founder to sign
-            investorProject.SignaturesInfo = new()
-                {
-                    ProjectIdentifier = investorProject!.ProjectInfo.ProjectIdentifier,
-                };
+        investorProject.SignaturesInfo = new()
+        {
+            ProjectIdentifier = investorProject.ProjectInfo.ProjectIdentifier
+        };
 
-            var strippedInvestmentTransaction = network.CreateTransaction(investorProject.SignedTransactionHex);
-            strippedInvestmentTransaction.Inputs.ForEach(f => f.WitScript = Blockcore.Consensus.TransactionInfo.WitScript.Empty);
+        var strippedTx = network
+            .CreateTransaction(investorProject.SignedTransactionHex);
+        strippedTx.Inputs
+            .ForEach(i => i.WitScript = 
+                Blockcore.Consensus.TransactionInfo.WitScript.Empty);
 
-            var accountInfo = storage.GetAccountInfo(network.Name);
+        var accountInfo = storage.GetAccountInfo(network.Name);
+        var words       = await passwordComponent.GetWalletAsync();
+        var privKey     = _derivationOperations
+                            .DeriveProjectNostrPrivateKey(
+                                words, 
+                                project.ProjectInfo.FounderKey);
+        var privKeyHex  = Encoders.Hex.EncodeData(privKey.ToBytes());
+        var releaseAddr = accountInfo.GetNextReceiveAddress();
 
-            var words = await passwordComponent.GetWalletAsync();
+        var signReq = new SignRecoveryRequest
+        {
+            ProjectIdentifier           = investorProject.ProjectInfo.ProjectIdentifier,
+            InvestmentTransactionHex    = strippedTx
+                                              .ToHex(network.Consensus.ConsensusFactory),
+            UnfundedReleaseAddress      = releaseAddr,
+            AdditionalNpub              = Investment.AdditionalNpub
+        };
 
-            var investorNostrPrivateKey = _derivationOperations.DeriveProjectNostrPrivateKey(words, project.ProjectInfo.FounderKey);
-            var nostrPrivateKeyHex = Encoders.Hex.EncodeData(investorNostrPrivateKey.ToBytes());
-
-            var releaseAddress = accountInfo.GetNextReceiveAddress();
-
-            SignRecoveryRequest signRecoveryRequest = new()
-                {
-                    ProjectIdentifier = investorProject.ProjectInfo.ProjectIdentifier,
-                    InvestmentTransactionHex = strippedInvestmentTransaction.ToHex(network.Consensus.ConsensusFactory),
-                    UnfundedReleaseAddress = releaseAddress,
-                    AdditionalNpub = Investment.AdditionalNpub
-                };
-
-            var sigJson = serializer.Serialize(signRecoveryRequest);
-
-            var encryptedContent = await encryption.EncryptNostrContentAsync(
-                nostrPrivateKeyHex, investorProject.ProjectInfo.NostrPubKey,
-                sigJson);
-
-            var investmentSigsRequest = _SignService.RequestInvestmentSigs(encryptedContent, nostrPrivateKeyHex, investorProject.ProjectInfo.NostrPubKey);
-
-            investorProject.SignaturesInfo!.TimeOfSignatureRequest = investmentSigsRequest.eventTime;
-            investorProject.SignaturesInfo!.SignatureRequestEventId = investmentSigsRequest.eventId;
-            investorProject.InvestorNPub = NostrPrivateKey.FromHex(nostrPrivateKeyHex).DerivePublicKey().Hex;
-            investorProject.UnfundedReleaseAddress = releaseAddress;
-            investorProject.AdditionalNpub = Investment.AdditionalNpub;
-
-            storage.AddInvestmentProject(investorProject);
-
-            foreach (var input in strippedInvestmentTransaction.Inputs)
-                accountInfo.UtxoReservedForInvestment.Add(input.PrevOut.ToString());
-
-            storage.SetAccountInfo(network.Name, accountInfo);
-
-            _SignService.LookupSignatureForInvestmentRequest(
-                investorProject.InvestorNPub,
+        var signJson = serializer.Serialize(signReq);
+        var encryptedContent = await encryption
+            .EncryptNostrContentAsync(
+                privKeyHex, 
                 investorProject.ProjectInfo.NostrPubKey,
-                investorProject.SignaturesInfo.TimeOfSignatureRequest.Value,
-                investorProject.SignaturesInfo.SignatureRequestEventId,
-                signatures => HandleSignatureReceivedAsync(nostrPrivateKeyHex, signatures));
+                signJson);
+
+        var sigRequest = _SignService
+            .RequestInvestmentSigs(
+                encryptedContent,
+                privKeyHex,
+                investorProject.ProjectInfo.NostrPubKey);
+
+        investorProject.SignaturesInfo!.TimeOfSignatureRequest = sigRequest.eventTime;
+        investorProject.SignaturesInfo!.SignatureRequestEventId = sigRequest.eventId;
+        investorProject.InvestorNPub      = NostrPrivateKey
+                                                .FromHex(privKeyHex)
+                                                .DerivePublicKey()
+                                                .Hex;
+        investorProject.UnfundedReleaseAddress = releaseAddr;
+        investorProject.AdditionalNpub          = Investment.AdditionalNpub;
+
+        storage.AddInvestmentProject(investorProject);
+        foreach (var inp in strippedTx.Inputs)
+            accountInfo.UtxoReservedForInvestment.Add(inp.PrevOut.ToString());
+        storage.SetAccountInfo(network.Name, accountInfo);
+
+        _SignService.LookupSignatureForInvestmentRequest(
+            investorProject.InvestorNPub,
+            investorProject.ProjectInfo.NostrPubKey,
+            investorProject.SignaturesInfo.TimeOfSignatureRequest.Value,
+            investorProject.SignaturesInfo.SignatureRequestEventId,
+            signatures => HandleSignatureReceivedAsync(privKeyHex, signatures));
 
             notificationComponent.ShowNotificationMessage("Signature request sent", 5);
         }
@@ -1088,13 +1102,13 @@ else
         StateHasChanged();
         await Task.Delay(10);
 
-        try
-        {
-            Debug.Assert(project != null, nameof(project) + " != null");
-            var investorProject = project as InvestorProject;
-            Debug.Assert(investorProject is not null, "The project must be an investor project", nameof(project) + " != null");
-            Debug.Assert(investorProject.SignaturesInfo != null, nameof(investorProject.SignaturesInfo) + " != null");
-            Debug.Assert(investorProject.SignedTransactionHex != null, nameof(investorProject.SignedTransactionHex) + " != null");
+    try
+    {
+        Debug.Assert(project != null, nameof(project) + " != null");
+        var investorProject = project as InvestorProject 
+                              ?? throw new InvalidOperationException("Not an investor project");
+        Debug.Assert(investorProject.SignaturesInfo != null, nameof(investorProject.SignaturesInfo) + " != null");
+        Debug.Assert(investorProject.SignedTransactionHex != null, nameof(investorProject.SignedTransactionHex) + " != null");
 
             signedTransaction ??= new TransactionInfo();
 
@@ -1116,12 +1130,36 @@ else
                 return;
             }
 
-            // link the trx to the signatures
-            investorProject.CompleteProjectInvestment(signedTransaction.Transaction);
+        investorProject.CompleteProjectInvestment(signedTransaction.Transaction);
+        storage.UpdateInvestmentProject(investorProject);
+    }
+    catch (Exception e)
+    {
+        notificationComponent.ShowErrorMessage(e.Message, e);
+        return;
+    }
+    finally
+    {
+        publishSpinner = false;
+    }
 
-            storage.UpdateInvestmentProject(investorProject);
 
-            await SaveInvestmentsListToNostrAsync();
+    if (!passwordComponent.HasPassword())
+    {
+        passwordComponent.ShowPassword(async () =>
+        {
+            await PerformPostPublishTasksAsync();
+        });
+    }
+    else
+    {
+        await PerformPostPublishTasksAsync();
+    }
+}
+
+private async Task PerformPostPublishTasksAsync()
+{
+    await SaveInvestmentsListToNostrAsync();
 
             var accountInfo = storage.GetAccountInfo(network.Name);
             var unspentInfo = SessionStorage.GetUnconfirmedInboundFunds();
@@ -1136,19 +1174,10 @@ else
             unspentInfo.AddRange(spendUtxos);
             SessionStorage.SetUnconfirmedInboundFunds(unspentInfo);
 
-            notificationComponent.ShowNotificationMessage("Invested in project", 5);
-
-            NavigationManager.NavigateTo($"/view/{project.ProjectInfo.ProjectIdentifier}");
-        }
-        catch (Exception e)
-        {
-            notificationComponent.ShowErrorMessage(e.Message, e);
-        }
-        finally
-        {
-            publishSpinner = false;
-        }
-    }
+   
+    notificationComponent.ShowNotificationMessage("Invested in project", 5);
+    NavigationManager.NavigateTo($"/view/{project.ProjectInfo.ProjectIdentifier}");
+}
 
     private async Task SaveInvestmentsListToNostrAsync()
     {


### PR DESCRIPTION
This PR fixes the issue #249 

## Steps to reproduce the problem 
- Hop onto the `Angor` Website
- Ensure that you have a wallet created with some test coins imported in it for a transaction
- `Navbar -> Browse -> View Any Project -> Scroll Down -> Click on Invest Now`.
- Select the amount and click on `Continue to Confirmation & enter your wallet password`
- Wait for a period of 1 min or lesser(if you have reduced the time for a quick testing, this is what i did) before confirming the investment to reproduce the error. 
- Now on clicking on `Confirm Investment` we find the wallet is locked and then it will disrupt the rest of the flow only showing a warning. 

<img width="748" alt="Screenshot 2025-04-19 at 5 03 09 AM" src="https://github.com/user-attachments/assets/b4314982-2db5-4b04-bea8-999ed7bbb3b0" />

## Solution 
This PR makes both our “Send recovery‑agreement” and “Publish investment” flows resilient to wallet timeouts by:
- Wrapping each flow in a HasPassword checking that, if expired, pops up the unlock dialog and then retries the operation once we re‑enter the wallet password.
- Pulling all of the post‑publish work (Nostr save, UTXO cleanup, success toast & navigation) into its own helper so it always runs last, only after a successful on‑chain publish and any necessary re‑unlock.

## Demonstration

The demonstration is through two videos skipping the wait time in between them. 


https://github.com/user-attachments/assets/23fb6466-c480-4fa6-8432-d8b405eb5bf2

This is the 1st portion of the video where i go through the steps mentioned above and wait for 1 min or so before confirming the transaction. 


https://github.com/user-attachments/assets/8b47bc14-aebf-4101-b5fe-ef9546587af9

The second video shows how the above error is getting handled. After 1 min the wallet password has expired thereby locking the wallet. However instead of just throwing an error it redirects and prompts to enter the password again and thereby confirming the transaction rather than breaking the workflow as intended by the issue #249 



