### PR TITLE
error: Add handling for empty case errors in the AddExplorer method inside Settings.

### DIFF
--- a/src/Angor/Client/Pages/Settings.razor
+++ b/src/Angor/Client/Pages/Settings.razor
@@ -707,44 +707,47 @@
 
     private async Task AddExplorer()
     {
-        if (!string.IsNullOrWhiteSpace(newExplorerLink))
+        if (string.IsNullOrWhiteSpace(newExplorerLink))
         {
-            if (!Uri.TryCreate(newExplorerLink, UriKind.Absolute, out Uri? uri))
-            {
-                notificationComponent.ShowErrorMessage($"Invalid URL: {newExplorerLink}");
-                return;
-            }
-
-            if (uri.Scheme is not ("http" or "https"))
-            {
-                notificationComponent.ShowErrorMessage($"Invalid URL schema. Must be HTTP or HTTPS.");
-                return;
-            }
-             newExplorerLink = $"{uri.Scheme}://{uri.Authority}{uri.AbsolutePath}";
-
-            if (settingsInfo.Explorers.Any(a => a.Url == newExplorerLink))
-            {
-                notificationComponent.ShowErrorMessage($"URL already exists: {newExplorerLink}");
-                return;
-            }
-
-            // Add explorer to settings
-            var newExplorer = new SettingsUrl
-                {
-                    Url = newExplorerLink,
-                    LastCheck = DateTime.UtcNow,
-                    Status = UrlStatus.Online,
-                    IsPrimary = !settingsInfo.Explorers.Any(e => e.IsPrimary) // Set as primary if no primary exists
-                };
-
-            settingsInfo.Explorers.Add(newExplorer);
-
-            _clientStorage.SetSettingsInfo(settingsInfo);
-            notificationComponent.ShowNotificationMessage("Explorer added successfully.");
-            newExplorerLink = string.Empty;
-
-            await Refresh(false);
+            notificationComponent.ShowErrorMessage("Explorer URL cannot be empty.");
+            return;
         }
+
+        if (!Uri.TryCreate(newExplorerLink, UriKind.Absolute, out Uri? uri))
+        {
+            notificationComponent.ShowErrorMessage($"Invalid URL: {newExplorerLink}");
+            return;
+        }
+
+        if (uri.Scheme is not ("http" or "https"))
+        {
+            notificationComponent.ShowErrorMessage($"Invalid URL schema. Must be HTTP or HTTPS.");
+            return;
+        }
+        newExplorerLink = $"{uri.Scheme}://{uri.Authority}{uri.AbsolutePath}";
+
+        if (settingsInfo.Explorers.Any(a => a.Url == newExplorerLink))
+        {
+            notificationComponent.ShowErrorMessage($"URL already exists: {newExplorerLink}");
+            return;
+        }
+
+        // Add explorer to settings
+        var newExplorer = new SettingsUrl
+            {
+                Url = newExplorerLink,
+                LastCheck = DateTime.UtcNow,
+                Status = UrlStatus.Online,
+                IsPrimary = !settingsInfo.Explorers.Any(e => e.IsPrimary) // Set as primary if no primary exists
+            };   
+
+        settingsInfo.Explorers.Add(newExplorer);
+
+        _clientStorage.SetSettingsInfo(settingsInfo);
+        notificationComponent.ShowNotificationMessage("Explorer added successfully.");
+        newExplorerLink = string.Empty;
+
+        await Refresh(false);
     }
 
     private async Task AddChatApp()


### PR DESCRIPTION
Currently, while adding a url in the explorer section in settings, we are not getting any warning indicating that the input filed is empty.

This pull request enhances the `AddExplorer` method in the `Settings.razor` file by improving input validation and error handling.

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/5edf433b-2bf7-4dd7-b2c8-218599731510) | ![After](https://github.com/user-attachments/assets/440feaf3-0ea0-4fd9-a523-24fdbfb7d817) |





