### PR TITLE
Add password strength requirements to wallet creation

### DIFF
--- a/src/Angor/Client/Pages/Wallet.razor
+++ b/src/Angor/Client/Pages/Wallet.razor
@@ -225,6 +225,17 @@
                                                         }
                                                     </button>
                                                 </div>
+                                                <div class="@(IsPasswordValid() ? "text-success" : "text-danger") mt-2 small">
+                                                    @GetPasswordStrengthFeedback()
+                                                </div>
+                                                <div class="text-muted mt-2 small">
+                                                    <p>For a strong password:</p>
+                                                    <ul>
+                                                        <li>Use at least 8 characters</li>
+                                                        <li>Include uppercase and lowercase letters</li>
+                                                        <li>Include at least one number or special character</li>
+                                                    </ul>
+                                                </div>
                                             </div>
                                             break;
                                     }
@@ -284,6 +295,17 @@
                                                         }
 
                                                     </button>
+                                                </div>
+                                                <div class="@(IsPasswordValid() ? "text-success" : "text-danger") mt-2 small">
+                                                    @GetPasswordStrengthFeedback()
+                                                </div>
+                                                <div class="text-muted mt-2 small">
+                                                    <p>For a strong password:</p>
+                                                    <ul>
+                                                        <li>Use at least 8 characters</li>
+                                                        <li>Include uppercase and lowercase letters</li>
+                                                        <li>Include at least one number or special character</li>
+                                                    </ul>
                                                 </div>
                                             </div>
                                             break;
@@ -1155,7 +1177,8 @@ else
         {
             1 => !string.IsNullOrWhiteSpace(newWalletWords) && (isNewWallet ? backupConfirmation : true),
             2 => isNewWallet ? verificationPassed : true,
-            3 => true,
+            3 => isNewWallet ? true : IsPasswordValid(),
+            4 => IsPasswordValid(),
             _ => false
         };
     }
@@ -1165,10 +1188,47 @@ else
         if (string.IsNullOrWhiteSpace(newWalletPassword))
             return false;
 
+        if (newWalletPassword.Length < 8)
+            return false;
+            
+        // Password strength requirements
+        bool hasUppercase = newWalletPassword.Any(char.IsUpper);
+        bool hasLowercase = newWalletPassword.Any(char.IsLower);
+        bool hasDigit = newWalletPassword.Any(char.IsDigit);
+        bool hasSpecialChar = newWalletPassword.Any(c => !char.IsLetterOrDigit(c));
+        
+        if (!(hasUppercase && hasLowercase && (hasDigit || hasSpecialChar)))
+            return false;
+
         if (isNewWallet && !backupConfirmation)
             return false;
 
         return true;
+    }
+    
+    private string GetPasswordStrengthFeedback()
+    {
+        if (string.IsNullOrWhiteSpace(newWalletPassword))
+            return "Password is required";
+            
+        if (newWalletPassword.Length < 8)
+            return "Password must be at least 8 characters long";
+            
+        bool hasUppercase = newWalletPassword.Any(char.IsUpper);
+        bool hasLowercase = newWalletPassword.Any(char.IsLower);
+        bool hasDigit = newWalletPassword.Any(char.IsDigit);
+        bool hasSpecialChar = newWalletPassword.Any(c => !char.IsLetterOrDigit(c));
+        
+        List<string> missing = new List<string>();
+        
+        if (!hasUppercase) missing.Add("uppercase letter");
+        if (!hasLowercase) missing.Add("lowercase letter");
+        if (!hasDigit && !hasSpecialChar) missing.Add("number or special character");
+        
+        if (missing.Count > 0)
+            return $"Password must include: {string.Join(", ", missing)}";
+            
+        return "Password strength: Good";
     }
 
     protected override async Task OnInitializedAsync()
@@ -1920,6 +1980,22 @@ else
         verificationPassed = true;
         showVerificationError = false;
         NextStep();
+    }
+
+    private bool IsPasswordValid()
+    {
+        if (string.IsNullOrWhiteSpace(newWalletPassword))
+            return false;
+            
+        if (newWalletPassword.Length < 8)
+            return false;
+            
+        bool hasUppercase = newWalletPassword.Any(char.IsUpper);
+        bool hasLowercase = newWalletPassword.Any(char.IsLower);
+        bool hasDigit = newWalletPassword.Any(char.IsDigit);
+        bool hasSpecialChar = newWalletPassword.Any(c => !char.IsLetterOrDigit(c));
+        
+        return hasUppercase && hasLowercase && (hasDigit || hasSpecialChar);
     }
 
     protected override void OnInitialized()

--- a/src/Angor/Client/Pages/Wallet.razor
+++ b/src/Angor/Client/Pages/Wallet.razor
@@ -228,14 +228,17 @@
                                                 <div class="@(IsPasswordValid() ? "text-success" : "text-danger") mt-2 small">
                                                     @GetPasswordStrengthFeedback()
                                                 </div>
-                                                <div class="text-muted mt-2 small">
-                                                    <p>For a strong password:</p>
-                                                    <ul>
-                                                        <li>Use at least 8 characters</li>
-                                                        <li>Include uppercase and lowercase letters</li>
-                                                        <li>Include at least one number or special character</li>
-                                                    </ul>
-                                                </div>
+                                                @if (network.NetworkType == NetworkType.Mainnet)
+                                                {
+                                                    <div class="text-muted mt-2 small">
+                                                        <p>For a strong password:</p>
+                                                        <ul>
+                                                            <li>Use at least 8 characters</li>
+                                                            <li>Include uppercase and lowercase letters</li>
+                                                            <li>Include at least one number or special character</li>
+                                                        </ul>
+                                                    </div>
+                                                }
                                             </div>
                                             break;
                                     }
@@ -299,14 +302,17 @@
                                                 <div class="@(IsPasswordValid() ? "text-success" : "text-danger") mt-2 small">
                                                     @GetPasswordStrengthFeedback()
                                                 </div>
-                                                <div class="text-muted mt-2 small">
-                                                    <p>For a strong password:</p>
-                                                    <ul>
-                                                        <li>Use at least 8 characters</li>
-                                                        <li>Include uppercase and lowercase letters</li>
-                                                        <li>Include at least one number or special character</li>
-                                                    </ul>
-                                                </div>
+                                                @if (network.NetworkType == NetworkType.Mainnet)
+                                                {
+                                                    <div class="text-muted mt-2 small">
+                                                        <p>For a strong password:</p>
+                                                        <ul>
+                                                            <li>Use at least 8 characters</li>
+                                                            <li>Include uppercase and lowercase letters</li>
+                                                            <li>Include at least one number or special character</li>
+                                                        </ul>
+                                                    </div>
+                                                }
                                             </div>
                                             break;
                                     }
@@ -1188,17 +1194,23 @@ else
         if (string.IsNullOrWhiteSpace(newWalletPassword))
             return false;
 
-        if (newWalletPassword.Length < 8)
-            return false;
+        // Different validation based on network type
+        if (network.NetworkType == NetworkType.Mainnet)
+        {
+            // Strict validation for MainNet
+            if (newWalletPassword.Length < 8)
+                return false;
+                
+            // Password strength requirements
+            bool hasUppercase = newWalletPassword.Any(char.IsUpper);
+            bool hasLowercase = newWalletPassword.Any(char.IsLower);
+            bool hasDigit = newWalletPassword.Any(char.IsDigit);
+            bool hasSpecialChar = newWalletPassword.Any(c => !char.IsLetterOrDigit(c));
             
-        // Password strength requirements
-        bool hasUppercase = newWalletPassword.Any(char.IsUpper);
-        bool hasLowercase = newWalletPassword.Any(char.IsLower);
-        bool hasDigit = newWalletPassword.Any(char.IsDigit);
-        bool hasSpecialChar = newWalletPassword.Any(c => !char.IsLetterOrDigit(c));
-        
-        if (!(hasUppercase && hasLowercase && (hasDigit || hasSpecialChar)))
-            return false;
+            if (!(hasUppercase && hasLowercase && (hasDigit || hasSpecialChar)))
+                return false;
+        }
+        // For TestNet, any non-empty password is acceptable
 
         if (isNewWallet && !backupConfirmation)
             return false;
@@ -1211,24 +1223,34 @@ else
         if (string.IsNullOrWhiteSpace(newWalletPassword))
             return "Password is required";
             
-        if (newWalletPassword.Length < 8)
-            return "Password must be at least 8 characters long";
+        // Different feedback based on network type
+        if (network.NetworkType == NetworkType.Mainnet)
+        {
+            // Detailed feedback for MainNet
+            if (newWalletPassword.Length < 8)
+                return "Password must be at least 8 characters long";
+                
+            bool hasUppercase = newWalletPassword.Any(char.IsUpper);
+            bool hasLowercase = newWalletPassword.Any(char.IsLower);
+            bool hasDigit = newWalletPassword.Any(char.IsDigit);
+            bool hasSpecialChar = newWalletPassword.Any(c => !char.IsLetterOrDigit(c));
             
-        bool hasUppercase = newWalletPassword.Any(char.IsUpper);
-        bool hasLowercase = newWalletPassword.Any(char.IsLower);
-        bool hasDigit = newWalletPassword.Any(char.IsDigit);
-        bool hasSpecialChar = newWalletPassword.Any(c => !char.IsLetterOrDigit(c));
-        
-        List<string> missing = new List<string>();
-        
-        if (!hasUppercase) missing.Add("uppercase letter");
-        if (!hasLowercase) missing.Add("lowercase letter");
-        if (!hasDigit && !hasSpecialChar) missing.Add("number or special character");
-        
-        if (missing.Count > 0)
-            return $"Password must include: {string.Join(", ", missing)}";
+            List<string> missing = new List<string>();
             
-        return "Password strength: Good";
+            if (!hasUppercase) missing.Add("uppercase letter");
+            if (!hasLowercase) missing.Add("lowercase letter");
+            if (!hasDigit && !hasSpecialChar) missing.Add("number or special character");
+            
+            if (missing.Count > 0)
+                return $"Password must include: {string.Join(", ", missing)}";
+                
+            return "Password strength: Good";
+        }
+        else
+        {
+            // Simple feedback for TestNet
+            return "Password accepted (TestNet mode)";
+        }
     }
 
     protected override async Task OnInitializedAsync()
@@ -1987,15 +2009,25 @@ else
         if (string.IsNullOrWhiteSpace(newWalletPassword))
             return false;
             
-        if (newWalletPassword.Length < 8)
-            return false;
+        // Different validation based on network type
+        if (network.NetworkType == NetworkType.Mainnet)
+        {
+            // Strict validation for MainNet
+            if (newWalletPassword.Length < 8)
+                return false;
+                
+            bool hasUppercase = newWalletPassword.Any(char.IsUpper);
+            bool hasLowercase = newWalletPassword.Any(char.IsLower);
+            bool hasDigit = newWalletPassword.Any(char.IsDigit);
+            bool hasSpecialChar = newWalletPassword.Any(c => !char.IsLetterOrDigit(c));
             
-        bool hasUppercase = newWalletPassword.Any(char.IsUpper);
-        bool hasLowercase = newWalletPassword.Any(char.IsLower);
-        bool hasDigit = newWalletPassword.Any(char.IsDigit);
-        bool hasSpecialChar = newWalletPassword.Any(c => !char.IsLetterOrDigit(c));
-        
-        return hasUppercase && hasLowercase && (hasDigit || hasSpecialChar);
+            return hasUppercase && hasLowercase && (hasDigit || hasSpecialChar);
+        }
+        else
+        {
+            // Simple validation for TestNet - just require any non-empty password
+            return !string.IsNullOrWhiteSpace(newWalletPassword);
+        }
     }
 
     protected override void OnInitialized()


### PR DESCRIPTION
## Overview
This PR adds password strength validation during wallet creation to improve security and prevent users from creating wallets with weak passwords.

## Changes
- Added password validation that requires:
   - Minimum 8 characters
   - At least one uppercase letter
   - At least one lowercase letter
   - At least one number or special character
- Added real-time password strength feedback in the UI
- Added password requirements list in the wallet creation wizard
- Implemented consistent validation across both new wallet creation and wallet recovery flows

## Testing
- Verified password requirements are enforced when creating a new wallet
- Verified password requirements are enforced when recovering a wallet
- Confirmed the "Next" and "Create Wallet" buttons remain disabled until a valid password is provided
- Tested with various password combinations to ensure correct validation behavior

## Screenshots/ Recording

https://github.com/user-attachments/assets/60ffb0b1-a256-4e3b-a8a5-2a998adf0ee7

