### PR TITLE
fix: show error popup on empty input for `Indexer`, `Nostr Relays`, and `Chat Apps`

### DIFF
--- a/src/Angor/Client/Pages/Settings.razor
+++ b/src/Angor/Client/Pages/Settings.razor
@@ -615,94 +615,98 @@
 
     private async Task AddIndexer()
     {
-        if (!string.IsNullOrWhiteSpace(newIndexerLink))
+        if (string.IsNullOrWhiteSpace(newIndexerLink))
         {
-            if (!Uri.TryCreate(newIndexerLink, UriKind.Absolute, out Uri? uri))
-            {
-                notificationComponent.ShowErrorMessage($"Invalid URL: {newIndexerLink}");
-                return;
-            }
-
-            if (uri.Scheme is not ("http" or "https"))
-            {
-                notificationComponent.ShowErrorMessage($"Invalid URL schema. Must be HTTP or HTTPS.");
-                return;
-            }
-
-            newIndexerLink = $"{uri.Scheme}://{uri.Authority}".TrimEnd('/');
-
-            Logger.LogInformation($"Normalized URL: {newIndexerLink}");
-
-            if (settingsInfo.Indexers.Any(a => a.Url == newIndexerLink))
-            {
-                notificationComponent.ShowErrorMessage($"URL already exists: {newIndexerLink}");
-                return;
-            }
-
-            // Check indexer status and fetch genesis block hash
-            var (isOnline, genesisHash) = await _indexerService.CheckIndexerNetwork(newIndexerLink);
-            if (!isOnline)
-            {
-                notificationComponent.ShowErrorMessage("The indexer is offline or unreachable.");
-                return;
-            }
-
-            var expectedHash = _networkConfiguration.GetGenesisBlockHash();
-            if (!_indexerService.ValidateGenesisBlockHash(genesisHash, expectedHash))
-            {
-                var expectedNetworkName = _networkConfiguration.GetNetwork().Name;
-                var fetchedNetworkName = _networkConfiguration.GetNetworkNameFromGenesisBlockHash(genesisHash);
-                notificationComponent.ShowErrorMessage($"The indexer is not compatible with the selected network. " +
-                $"Expected: {expectedNetworkName}, Provided: {fetchedNetworkName ?? "Unknown"}");
-                return;
-            }
-
-            // Add indexer to settings
-            settingsInfo.Indexers.Add(new SettingsUrl
-                {
-                    Url = newIndexerLink,
-                    LastCheck = DateTime.UtcNow,
-                    Status = UrlStatus.Online
-                });
-
-            _clientStorage.SetSettingsInfo(settingsInfo);
-            notificationComponent.ShowNotificationMessage("Indexer added successfully.");
-            newIndexerLink = string.Empty;
-
-            await Refresh(false);
+            notificationComponent.ShowErrorMessage("Indexer URL cannot be empty.");
+            return;
         }
+
+        if (!Uri.TryCreate(newIndexerLink, UriKind.Absolute, out Uri? uri))
+        {
+            notificationComponent.ShowErrorMessage($"Invalid URL: {newIndexerLink}");
+            return;
+        }
+
+        if (uri.Scheme is not ("http" or "https"))
+        {
+            notificationComponent.ShowErrorMessage($"Invalid URL schema. Must be HTTP or HTTPS.");
+            return;
+        }
+
+        newIndexerLink = $"{uri.Scheme}://{uri.Authority}".TrimEnd('/');
+
+        Logger.LogInformation($"Normalized URL: {newIndexerLink}");
+
+        if (settingsInfo.Indexers.Any(a => a.Url == newIndexerLink))
+        {
+            notificationComponent.ShowErrorMessage($"URL already exists: {newIndexerLink}");
+            return;
+        }
+
+        // Check indexer status and fetch genesis block hash
+        var (isOnline, genesisHash) = await _indexerService.CheckIndexerNetwork(newIndexerLink);
+        if (!isOnline)
+        {
+            notificationComponent.ShowErrorMessage("The indexer is offline or unreachable.");
+            return;
+        }
+
+        var expectedHash = _networkConfiguration.GetGenesisBlockHash();
+        if (!_indexerService.ValidateGenesisBlockHash(genesisHash, expectedHash))
+        {
+            var expectedNetworkName = _networkConfiguration.GetNetwork().Name;
+            var fetchedNetworkName = _networkConfiguration.GetNetworkNameFromGenesisBlockHash(genesisHash);
+            notificationComponent.ShowErrorMessage($"The indexer is not compatible with the selected network. " +
+            $"Expected: {expectedNetworkName}, Provided: {fetchedNetworkName ?? "Unknown"}");
+            return;
+        }
+
+        // Add indexer to settings
+        settingsInfo.Indexers.Add(new SettingsUrl
+            {
+                Url = newIndexerLink,
+                LastCheck = DateTime.UtcNow,
+                Status = UrlStatus.Online
+            });
+
+        _clientStorage.SetSettingsInfo(settingsInfo);
+        notificationComponent.ShowNotificationMessage("Indexer added successfully.");
+        newIndexerLink = string.Empty;
+
+        await Refresh(false);
     }
 
     private async Task AddRelay()
     {
-        if (!string.IsNullOrWhiteSpace(newRelayLink))
+        if (string.IsNullOrWhiteSpace(newRelayLink))
         {
-            if (!Uri.TryCreate(newRelayLink, UriKind.Absolute, out Uri? uri))
-            {
-                notificationComponent.ShowErrorMessage($"invalid url {newRelayLink}");
-                return;
-            }
-
-            if (uri.Scheme is not ("ws" or "wss"))
-            {
-                notificationComponent.ShowErrorMessage($"invalid url {newRelayLink} schema must be ws or wss");
-                return;
-            }
-
-            newRelayLink = new Uri($"{uri.Scheme}://{uri.Host}").AbsoluteUri.TrimEnd('/');
-
-            if (settingsInfo.Relays.Any(a => a.Url == newRelayLink))
-            {
-                notificationComponent.ShowErrorMessage($"url exists {newRelayLink}");
-                return;
-            }
-
-            settingsInfo.Relays.Add(new SettingsUrl { Url = newRelayLink, IsPrimary = !settingsInfo.Relays.Any() });
-            _clientStorage.SetSettingsInfo(settingsInfo);
-            newRelayLink = string.Empty;
+            notificationComponent.ShowErrorMessage("Relay URL cannot be empty.");
+            return;
         }
 
-        await Refresh(false);
+        if (!Uri.TryCreate(newRelayLink, UriKind.Absolute, out Uri? uri))
+        {
+            notificationComponent.ShowErrorMessage($"invalid url {newRelayLink}");
+            return;
+        }
+
+        if (uri.Scheme is not ("ws" or "wss"))
+        {
+            notificationComponent.ShowErrorMessage($"invalid url {newRelayLink} schema must be ws or wss");
+            return;
+        }
+
+        newRelayLink = new Uri($"{uri.Scheme}://{uri.Host}").AbsoluteUri.TrimEnd('/');
+
+        if (settingsInfo.Relays.Any(a => a.Url == newRelayLink))
+        {
+            notificationComponent.ShowErrorMessage($"url exists {newRelayLink}");
+            return;
+        }
+
+        settingsInfo.Relays.Add(new SettingsUrl { Url = newRelayLink, IsPrimary = !settingsInfo.Relays.Any() });
+        _clientStorage.SetSettingsInfo(settingsInfo);
+        newRelayLink = string.Empty;
     }
 
     private async Task AddExplorer()
@@ -752,45 +756,48 @@
 
     private async Task AddChatApp()
     {
-        if (!string.IsNullOrWhiteSpace(newChatAppLink))
+        if (string.IsNullOrWhiteSpace(newChatAppLink))
         {
-            if (!Uri.TryCreate(newChatAppLink, UriKind.Absolute, out Uri? uri))
-            {
-                notificationComponent.ShowErrorMessage($"Invalid URL: {newChatAppLink}");
-                return;
-            }
-
-            if (uri.Scheme is not ("http" or "https"))
-            {
-                notificationComponent.ShowErrorMessage($"Invalid URL schema. Must be HTTP or HTTPS.");
-                return;
-            }
-
-            newChatAppLink = $"{uri.Scheme}://{uri.Authority}{uri.AbsolutePath}";
-           
-            if (settingsInfo.ChatApps.Any(a => a.Url == newChatAppLink))
-            {
-                notificationComponent.ShowErrorMessage($"URL already exists: {newChatAppLink}");
-                return;
-            }
-
-            var newChatApp = new SettingsUrl
-            {
-                Url = newChatAppLink,
-                Name = uri.Host,
-                LastCheck = DateTime.UtcNow,
-                Status = UrlStatus.Online,
-                IsPrimary = !settingsInfo.ChatApps.Any(c => c.IsPrimary)
-            };
-
-            settingsInfo.ChatApps.Add(newChatApp);
-
-            _clientStorage.SetSettingsInfo(settingsInfo);
-            notificationComponent.ShowNotificationMessage("Chat application added successfully.");
-            newChatAppLink = string.Empty;
-
-            await Refresh(false);
+            notificationComponent.ShowErrorMessage("Chat application URL cannot be empty.");
+            return;
         }
+
+        if (!Uri.TryCreate(newChatAppLink, UriKind.Absolute, out Uri? uri))
+        {
+            notificationComponent.ShowErrorMessage($"Invalid URL: {newChatAppLink}");
+            return;
+        }
+
+        if (uri.Scheme is not ("http" or "https"))
+        {
+            notificationComponent.ShowErrorMessage($"Invalid URL schema. Must be HTTP or HTTPS.");
+            return;
+        }
+
+        newChatAppLink = $"{uri.Scheme}://{uri.Authority}{uri.AbsolutePath}";
+       
+        if (settingsInfo.ChatApps.Any(a => a.Url == newChatAppLink))
+        {
+            notificationComponent.ShowErrorMessage($"URL already exists: {newChatAppLink}");
+            return;
+        }
+
+        var newChatApp = new SettingsUrl
+        {
+            Url = newChatAppLink,
+            Name = uri.Host,
+            LastCheck = DateTime.UtcNow,
+            Status = UrlStatus.Online,
+            IsPrimary = !settingsInfo.ChatApps.Any(c => c.IsPrimary)
+        };
+
+        settingsInfo.ChatApps.Add(newChatApp);
+
+        _clientStorage.SetSettingsInfo(settingsInfo);
+        notificationComponent.ShowNotificationMessage("Chat application added successfully.");
+        newChatAppLink = string.Empty;
+
+        await Refresh(false);
     }
 
     private void RemoveIndexer(string url)

--- a/src/Angor/Client/Pages/Settings.razor
+++ b/src/Angor/Client/Pages/Settings.razor
@@ -707,6 +707,8 @@
         settingsInfo.Relays.Add(new SettingsUrl { Url = newRelayLink, IsPrimary = !settingsInfo.Relays.Any() });
         _clientStorage.SetSettingsInfo(settingsInfo);
         newRelayLink = string.Empty;
+
+        await Refresh(false);
     }
 
     private async Task AddExplorer()


### PR DESCRIPTION
Add error popup for empty input in Indexer, Nostr Relays, and Chat Applications (consistent with Explorer)
![Screenshot (451)](https://github.com/user-attachments/assets/9216829c-75e3-41ce-be57-88c8acde3754)
![Screenshot (452)](https://github.com/user-attachments/assets/5dce2c4a-20d2-46a3-8a19-e4f71689707f)
![Screenshot (453)](https://github.com/user-attachments/assets/d3061a69-4b9b-4982-89a8-3c311a17d328)
