### PR TITLE
styles: Make the bg-danger class background opaque.

### DIFF
--- a/src/Angor/Client/wwwroot/assets/css/app.css
+++ b/src/Angor/Client/wwwroot/assets/css/app.css
@@ -1284,7 +1284,7 @@ a p {
 }
 
 .bg-danger {
-    background-color: rgba(255, 71, 87, 0.8) !important;
+    background-color: rgba(255, 71, 87, 0.98) !important;
     color: white;
 }
 


### PR DESCRIPTION
| Before | After |
|-----|--------|
| <img width="689" alt="Screenshot 2025-05-01 at 1 02 01 AM" src="https://github.com/user-attachments/assets/bc495c9f-a13d-4e15-815e-3165c695bb76" /> | <img width="646" alt="Screenshot 2025-05-01 at 1 06 48 AM" src="https://github.com/user-attachments/assets/959bc0b7-979c-40c4-a0b0-cbc9cb1fbc69" /> |