### PR TITLE
fix: set fixed project card height

### DIFF
--- a/src/Angor/Client/wwwroot/assets/css/app.css
+++ b/src/Angor/Client/wwwroot/assets/css/app.css
@@ -3641,13 +3641,6 @@ input[type=number] {
     font-weight: 600;
     color: var(--form-text);
     margin: 0;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    -webkit-line-clamp: 2;
-    line-height: 1.5;
-    min-height: 3em;
-    margin-bottom: 0.5rem;
 }
 
 .project-stats {

--- a/src/Angor/Client/wwwroot/assets/css/app.css
+++ b/src/Angor/Client/wwwroot/assets/css/app.css
@@ -779,7 +779,10 @@ tr[style*="cursor: pointer;"]:hover {
     display: -webkit-box;
     -webkit-box-orient: vertical;
     overflow: hidden;
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 2;
+    line-height: 1.5;
+    height: 3em;
+    margin-bottom: 0.5rem;
 }
 
 .modal-wrapper {
@@ -3638,6 +3641,13 @@ input[type=number] {
     font-weight: 600;
     color: var(--form-text);
     margin: 0;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    -webkit-line-clamp: 2;
+    line-height: 1.5;
+    min-height: 3em;
+    margin-bottom: 0.5rem;
 }
 
 .project-stats {


### PR DESCRIPTION
Set a fixed height for project descriptions to show exactly 2 lines with ellipsis if it's too long.

Changes

1. Clamped description to 2 lines
2. Set fixed height based on line-height
3. Added ellipsis for overflow
4. Minor spacing tweaks for alignment

Impact

1. All cards now look uniform
2. Cleaner layout in both grid and list views

Before (non-uniform project cards):
![Screenshot (458)](https://github.com/user-attachments/assets/5beaed03-55cf-4376-9c76-e40263245621)

After (uniform project cards).... [independent of project discription length]
![Screenshot (457)](https://github.com/user-attachments/assets/e435de31-80c7-4e7c-bdf0-e323349b51c8)