### PR TITLE
Handle project data loading exceptions

### DIFF
--- a/src/Angor/Avalonia/Angor.Contexts.Funding.Tests/ProjectAppServiceTests.cs
+++ b/src/Angor/Avalonia/Angor.Contexts.Funding.Tests/ProjectAppServiceTests.cs
@@ -16,7 +16,9 @@ public class ProjectAppServiceTests(ITestOutputHelper output)
     {
         var sut = CreateSut();
         var result = await sut.Latest();
-        Assert.NotEmpty(result);
+        
+        Assert.True(result.IsSuccess);
+        Assert.NotEmpty(result.Value);
     }
     
     [Fact]

--- a/src/Angor/Avalonia/Angor.Contexts.Funding/Projects/Domain/IProjectRepository.cs
+++ b/src/Angor/Avalonia/Angor.Contexts.Funding/Projects/Domain/IProjectRepository.cs
@@ -5,7 +5,7 @@ namespace Angor.Contexts.Funding.Projects.Domain;
 public interface IProjectRepository
 {
     Task<Result<Project>> Get(ProjectId id);
-    Task<IList<Project>> Latest();
+    Task<Result<IList<Project>>> Latest();
 
     Task<Result<Maybe<Project>>> TryGet(ProjectId projectId);
 }

--- a/src/Angor/Avalonia/Angor.Contexts.Funding/Projects/Infrastructure/Impl/ProjectAppService.cs
+++ b/src/Angor/Avalonia/Angor.Contexts.Funding/Projects/Infrastructure/Impl/ProjectAppService.cs
@@ -14,11 +14,9 @@ public class ProjectAppService(
     : IProjectAppService
 {
     [MemoizeTimed]
-    public async Task<IList<ProjectDto>> Latest()
+    public async Task<Result<IEnumerable<ProjectDto>>> Latest()
     {
-        var projects = await projectRepository.Latest();
-        var projectDtos = projects.Select(project => project.ToDto());
-        return projectDtos.ToList();
+        return await projectRepository.Latest().Map(t => t.AsEnumerable()).MapEach(project => project.ToDto());
     }
 
     public Task<Maybe<ProjectDto>> FindById(ProjectId projectId)

--- a/src/Angor/Avalonia/Angor.Contexts.Funding/Projects/Infrastructure/Impl/ProjectRepository.cs
+++ b/src/Angor/Avalonia/Angor.Contexts.Funding/Projects/Infrastructure/Impl/ProjectRepository.cs
@@ -18,9 +18,9 @@ public class ProjectRepository(
         return TryGet(id).Bind(maybe => maybe.ToResult("Project not found"));
     }
 
-    public Task<IList<Project>> Latest()
+    public Task<Result<IList<Project>>> Latest()
     {
-        return ProjectsFrom(indexerService.GetLatest()).ToList().ToTask();
+        return Result.Try(() => ProjectsFrom(indexerService.GetLatest()).ToList().ToTask());
     }
 
     public Task<Result<Maybe<Project>>> TryGet(ProjectId projectId)

--- a/src/Angor/Avalonia/Angor.Contexts.Funding/Projects/Infrastructure/Interfaces/IProjectAppService.cs
+++ b/src/Angor/Avalonia/Angor.Contexts.Funding/Projects/Infrastructure/Interfaces/IProjectAppService.cs
@@ -6,7 +6,7 @@ namespace Angor.Contexts.Funding.Projects.Infrastructure.Interfaces;
 
 public interface IProjectAppService
 {
-    Task<IList<ProjectDto>> Latest();
+    Task<Result<IEnumerable<ProjectDto>>> Latest();
     Task<Maybe<ProjectDto>> FindById(ProjectId projectId);
     Task<Result<IEnumerable<ProjectDto>>> GetFounderProjects(Guid walletId);
 }

--- a/src/Angor/Avalonia/AngorApp/Sections/Browse/BrowseSectionViewModel.cs
+++ b/src/Angor/Avalonia/AngorApp/Sections/Browse/BrowseSectionViewModel.cs
@@ -1,10 +1,14 @@
+using System.Linq;
 using Angor.Contexts.Funding.Projects.Infrastructure.Interfaces;
 using Angor.Contexts.Wallet.Application;
 using AngorApp.Features.Invest;
 using AngorApp.Sections.Browse.ProjectLookup;
 using AngorApp.UI.Services;
 using ReactiveUI.SourceGenerators;
+using Zafiro.CSharpFunctionalExtensions;
+using Zafiro.Mixins;
 using Zafiro.Reactive;
+using Zafiro.UI;
 using Zafiro.UI.Navigation;
 
 namespace AngorApp.Sections.Browse;
@@ -13,7 +17,7 @@ public partial class BrowseSectionViewModel : ReactiveObject, IBrowseSectionView
 {
     [Reactive] private string? projectId;
 
-    [ObservableAsProperty] private IList<IProjectViewModel>? projects;
+    [ObservableAsProperty] private IEnumerable<IProjectViewModel>? projects;
 
     public BrowseSectionViewModel(IWalletAppService walletAppService, 
         IProjectAppService projectService, INavigator navigator,
@@ -23,14 +27,14 @@ public partial class BrowseSectionViewModel : ReactiveObject, IBrowseSectionView
         ProjectLookupViewModel = new ProjectLookupViewModel(projectService, walletAppService, navigator, investWizard, uiServices);
 
         LoadLatestProjects = ReactiveCommand.CreateFromObservable(() => Observable.FromAsync(projectService.Latest)
-            .Flatten()
-            .Select(dto => dto.ToProject())
-            .Select(IProjectViewModel (project) => new ProjectViewModel(walletAppService, project, navigator, uiServices, investWizard))
-            .ToList());
+            .Map(list => list.Select(dto => dto.ToProject()))
+            .Map(list => list.Select(project => new ProjectViewModel(walletAppService, project, navigator, uiServices, investWizard))));
+
+        LoadLatestProjects.HandleErrorsWith(uiServices.NotificationService, "Could not load projects");
 
         OpenHub = ReactiveCommand.CreateFromTask(() =>
             uiServices.LauncherService.LaunchUri(new Uri("https://www.angor.io")));
-        projectsHelper = LoadLatestProjects.ToProperty(this, x => x.Projects);
+        projectsHelper = LoadLatestProjects.Successes().ToProperty(this, x => x.Projects);
         IsLoading = LoadLatestProjects.IsExecuting;
         LoadLatestProjects.Execute().Subscribe();
     }
@@ -39,7 +43,7 @@ public partial class BrowseSectionViewModel : ReactiveObject, IBrowseSectionView
 
     public IProjectLookupViewModel ProjectLookupViewModel { get; }
 
-    public ReactiveCommand<Unit, IList<IProjectViewModel>> LoadLatestProjects { get; }
+    public ReactiveCommand<Unit, Result<IEnumerable<ProjectViewModel>>> LoadLatestProjects { get; }
 
     public ReactiveCommand<Unit, Unit> OpenHub { get; set; }
 }

--- a/src/Angor/Avalonia/AngorApp/Sections/Browse/BrowseSectionViewModelDesign.cs
+++ b/src/Angor/Avalonia/AngorApp/Sections/Browse/BrowseSectionViewModelDesign.cs
@@ -13,7 +13,7 @@ public class BrowseSectionViewModelDesign : IBrowseSectionViewModel
         Projects = SampleData.GetProjects().Select(IProjectViewModel (project) => new ProjectViewModelDesign(project)).ToList();
     }
 
-    public IList<IProjectViewModel> Projects { get; }
+    public IEnumerable<IProjectViewModel> Projects { get; }
     public ReactiveCommand<Unit, Unit> OpenHub { get; set; }
     public string? ProjectId { get; set; }
     public IObservable<bool> IsBusy { get; set; }

--- a/src/Angor/Avalonia/AngorApp/Sections/Browse/IBrowseSectionViewModel.cs
+++ b/src/Angor/Avalonia/AngorApp/Sections/Browse/IBrowseSectionViewModel.cs
@@ -7,7 +7,7 @@ namespace AngorApp.Sections.Browse;
 
 public interface IBrowseSectionViewModel
 {
-    public IList<IProjectViewModel> Projects { get; }
+    public IEnumerable<IProjectViewModel> Projects { get; }
     ReactiveCommand<Unit, Unit> OpenHub { get; set; }
     public IProjectLookupViewModel ProjectLookupViewModel { get; }
     IObservable<bool> IsLoading { get; }


### PR DESCRIPTION
Currently, if the indexer fails the application crashes. This handles any possible exception and makes project retrieval fail-proof.

- Switch `Latest` methods in repositories, services, and view models to return `Result<T>` for error propagation and better handling.
- Replace `IList` with `IEnumerable` in project-related properties and methods for enhanced flexibility.
- Update command and property behaviors in `BrowseSectionViewModel` to handle successes and errors.
- Adjust unit tests to validate `Result<T>` success and values.