### PR TITLE
Indicator for Unseen messages on Approve Investment button

### DIFF
--- a/src/Angor/Client/Pages/View.razor
+++ b/src/Angor/Client/Pages/View.razor
@@ -878,7 +878,6 @@
             {
                 founder = true;
                 NavMenuState.SetActivePage("founder");
-                // If project belongs to founder, fetch pending signatures
                 if (project is FounderProject founderProject)
                 {
                     await _RelayService.LookupSignaturesDirectMessagesForPubKeyAsync(founderProject.ProjectInfo.NostrPubKey, founderProject.LastRequestForSignaturesTime?.AddSeconds(1), 1,
@@ -934,14 +933,14 @@
 
                                 if (project is { ProjectInfo: null }) { project.ProjectInfo = projectInfo; }
                             },
-                            async () =>
+                            () =>
                             {
                                 _RelayService.LookupNostrProfileForNPub(
                                     (projectNpub, metadata) =>
                                     {
                                         if (project is { Metadata: null }) { project.Metadata = metadata; }
                                     },
-                                    async () =>
+                                    () =>
                                     {
                                         findInProgress = false;
                                         if (project?.ProjectInfo != null)
@@ -961,7 +960,7 @@
                                     },
                                     project.ProjectInfo.NostrPubKey);
 
-                                await SetProjectLinksAndRefreshBalance();
+                                SetProjectLinksAndRefreshBalance();
 
                             }, projectIndexerData.NostrEventId);
             }


### PR DESCRIPTION
Indicator appears on the button if there are pending messages. After reading them, the indicator goes away

<img width="871" alt="Screenshot 2025-06-07 at 5 10 38 AM" src="https://github.com/user-attachments/assets/7e75792b-b221-487a-89b3-63576a78bb68" />

https://github.com/user-attachments/assets/98442778-f68a-4779-a199-fc0cf77257cf

