### PR TITLE
Adding concurrency to spend.razor

### DIFF
--- a/src/Angor/Client/Pages/Spend.razor
+++ b/src/Angor/Client/Pages/Spend.razor
@@ -8,12 +8,14 @@
 @using Blockcore.NBitcoin
 @using Blockcore.NBitcoin.DataEncoders
 @using Angor.Shared.Utilities
+@using ConcurrentCollections
 @using ITransactionSignature = NBitcoin.ITransactionSignature
 @using System.Text.Json
 @using Angor.Client.Models
 @using Angor.Client.Shared
 @using Angor.Client.Components
 @using Angor.Shared.Protocol
+@using System.Collections.Concurrent
 
 
 @inject IClientStorage storage;
@@ -786,7 +788,48 @@
             _cacheStorage.SetUnconfirmedOutboundFunds(unconfirmedOutbound);
         }
     }
-
+    private ConcurrentHashSet<string> txids = [];
+    private ConcurrentDictionary<string, QueryTransaction> queryTransactionCache = [];
+    private ConcurrentDictionary<string, Transaction> transactionCache = [];
+    private ConcurrentDictionary<string, SemaphoreSlim> semaphoreStore = [];
+    private async Task<T> GetCache<T>(string txid, string type){
+        bool fetchTransaction = false;//false;
+        string txid_type = txid + type;
+        lock(txids){
+            txids.TryGetValue(txid_type, out string? txid_out);
+            if(txid_out == null){
+                fetchTransaction = true;
+                txids.Add(txid_type);
+                SemaphoreSlim semaphore = new(1);
+                semaphoreStore[txid_type] = semaphore;
+                semaphoreStore[txid_type].Wait();
+            }
+        }
+        bool isQueryTransaction = (typeof(T) == typeof(QueryTransaction));
+        if(fetchTransaction){
+            if(isQueryTransaction){
+                QueryTransaction? queryTransaction = await _IndexerService.GetTransactionInfoByIdAsync(txid);
+                queryTransactionCache.TryAdd(txid_type, queryTransaction);
+                semaphoreStore[txid_type].Release();
+                return (T)(object)queryTransaction;
+            }else{
+                var fetchTrx = await _IndexerService.GetTransactionHexByIdAsync(txid);
+                var investmentTransaction = network.CreateTransaction(fetchTrx);
+                transactionCache.TryAdd(txid_type, investmentTransaction);
+                semaphoreStore[txid_type].Release();
+                return (T)(object)investmentTransaction;
+            }
+        }
+        await semaphoreStore[txid_type].WaitAsync();
+        semaphoreStore[txid_type].Release();
+        return isQueryTransaction ? (T)(object)queryTransactionCache[txid_type] : (T)(object)transactionCache[txid_type]; 
+    }
+    private async Task<QueryTransaction> GetQueryTransactionCache(string txid){
+        return await GetCache<QueryTransaction>(txid, "qtrx");
+    }
+    private async Task<Transaction> GetTransactionCache(string txid){
+        return await GetCache<Transaction>(txid, "trx");
+    }
     private async Task processStageItem(StageDataTrx item, List<QueryTransaction> trxs, StageData stageData, List<Outpoint> unconfirmedOutbound){
         // if the item is already spent by founder or investor, we skip it
         // because we have already processed this item and we know the outcome.
@@ -810,12 +853,11 @@
             updateUnconfirmedOutbound |= unconfirmedOutbound.TryRemoveOutpoint(new Outpoint(item.Trxid, item.Outputindex));
 
             // try to resolve the destination
-            var spentInTransaction = await _IndexerService.GetTransactionInfoByIdAsync(output.SpentInTransaction);
+            var spentInTransaction = await GetQueryTransactionCache(output.SpentInTransaction); //await _IndexerService.GetTransactionInfoByIdAsync(output.SpentInTransaction);
 
             var input = spentInTransaction?.Inputs.FirstOrDefault(input => input.InputTransactionId == item.Trxid && input.InputIndex == item.Outputindex);
             
-            var fetchTrx = await _IndexerService.GetTransactionHexByIdAsync(item.Trxid);
-            var investmentTransaction = network.CreateTransaction(fetchTrx);
+            var investmentTransaction = await GetTransactionCache(item.Trxid); //network.CreateTransaction(fetchTrx);
     
             if (input != null && investmentTransaction != null)
             {

--- a/src/Angor/Client/Pages/Spend.razor
+++ b/src/Angor/Client/Pages/Spend.razor
@@ -718,8 +718,8 @@
             .Where(a => trxList.All(b => b.TrxId != a.TransactionId))
             .Select(async _ =>
             {
-                var hex = await _IndexerService.GetTransactionHexByIdAsync(_.TransactionId);
-                return new { hex, _.TransactionId };
+                Transaction trx = await GetTransactionCache(_.TransactionId); // await _IndexerService.GetTransactionHexByIdAsync(_.TransactionId);
+                return new { trx, _.TransactionId };
             });
 
         var trxHexList = await Task.WhenAll(tasks);
@@ -729,7 +729,7 @@
 
         foreach (var trx in trxHexList)
         {
-            trxList.Add((network.CreateTransaction(trx.hex), trx.TransactionId));
+            trxList.Add((trx.trx, trx.TransactionId));
         }
 
         if (!stageDatas.Any())
@@ -785,47 +785,32 @@
             _cacheStorage.SetUnconfirmedOutboundFunds(unconfirmedOutbound);
         }
     }
-    private HashSet<string> txids = [];
-    private Dictionary<string, QueryTransaction> queryTransactionCache = [];
-    private Dictionary<string, Transaction> transactionCache = [];
-    private Dictionary<string, SemaphoreSlim> semaphoreStore = [];
+    private Dictionary<string, Task<QueryTransaction>> queryTransactionCache = [];
+    private Dictionary<string, Task<Transaction>> transactionCache = [];
 
-    private async Task<T> GetCache<T>(string txid, string type){
-        bool fetchTransaction = false;
-        string txid_type = txid + type;
-        lock(txids){
-            txids.TryGetValue(txid_type, out string? txid_out);
-            if(txid_out == null){
-                fetchTransaction = true;
-                txids.Add(txid_type);
-                SemaphoreSlim semaphore = new(0);
-                semaphoreStore[txid_type] = semaphore;
-            }
-        }
-        bool isQueryTransaction = (typeof(T) == typeof(QueryTransaction));
-        if(fetchTransaction){
-            if(isQueryTransaction){
-                QueryTransaction? queryTransaction = await _IndexerService.GetTransactionInfoByIdAsync(txid);
-                queryTransactionCache.TryAdd(txid_type, queryTransaction);
-                semaphoreStore[txid_type].Release();
-                return (T)(object)queryTransaction;
-            }else{
-                var fetchTrx = await _IndexerService.GetTransactionHexByIdAsync(txid);
-                var investmentTransaction = network.CreateTransaction(fetchTrx);
-                transactionCache.TryAdd(txid_type, investmentTransaction);
-                semaphoreStore[txid_type].Release();
-                return (T)(object)investmentTransaction;
-            }
-        }
-        await semaphoreStore[txid_type].WaitAsync();
-        semaphoreStore[txid_type].Release();
-        return isQueryTransaction ? (T)(object)queryTransactionCache[txid_type] : (T)(object)transactionCache[txid_type]; 
+    private async Task<QueryTransaction> GetQueryTransactionCache(string txid)
+    {
+        if (queryTransactionCache.TryGetValue(txid, out var cachedTask))
+            return await cachedTask;
+
+        var task = _IndexerService.GetTransactionInfoByIdAsync(txid);
+        queryTransactionCache[txid] = task;
+        return await task;
     }
-    private async Task<QueryTransaction> GetQueryTransactionCache(string txid){
-        return await GetCache<QueryTransaction>(txid, "qtrx");
-    }
-    private async Task<Transaction> GetTransactionCache(string txid){
-        return await GetCache<Transaction>(txid, "trx");
+
+    private async Task<Transaction> GetTransactionCache(string txid)
+    {
+        if (transactionCache.TryGetValue(txid, out var cachedTask))
+            return await cachedTask;
+
+        var task = Task.Run(async () =>
+        {
+            var fetchTrx = await _IndexerService.GetTransactionHexByIdAsync(txid);
+            return network.CreateTransaction(fetchTrx);
+        });
+        
+        transactionCache[txid] = task;
+        return await task;
     }
     private async Task processStageItem(StageDataTrx item, StageData stageData, List<Outpoint> unconfirmedOutbound){
         // if the item is already spent by founder or investor, we skip it

--- a/src/Angor/Client/Pages/Spend.razor
+++ b/src/Angor/Client/Pages/Spend.razor
@@ -8,14 +8,12 @@
 @using Blockcore.NBitcoin
 @using Blockcore.NBitcoin.DataEncoders
 @using Angor.Shared.Utilities
-@using ConcurrentCollections
 @using ITransactionSignature = NBitcoin.ITransactionSignature
 @using System.Text.Json
 @using Angor.Client.Models
 @using Angor.Client.Shared
 @using Angor.Client.Components
 @using Angor.Shared.Protocol
-@using System.Collections.Concurrent
 
 
 @inject IClientStorage storage;
@@ -771,7 +769,6 @@
     private bool updateUnconfirmedOutbound = false;
     private async Task CheckSpentFund()
     {
-        List<QueryTransaction> trxs = new();
         var unconfirmedOutbound = _cacheStorage.GetUnconfirmedOutboundFunds();
         bool updateUnconfirmedOutbound = false;
         List<Task> tasks = [];
@@ -779,7 +776,7 @@
         {
             foreach (var item in stageData.Items)
             {
-                tasks.Add(processStageItem(item, trxs, stageData, unconfirmedOutbound));
+                tasks.Add(processStageItem(item, stageData, unconfirmedOutbound));
             }
         }
         await Task.WhenAll(tasks);
@@ -788,21 +785,21 @@
             _cacheStorage.SetUnconfirmedOutboundFunds(unconfirmedOutbound);
         }
     }
-    private ConcurrentHashSet<string> txids = [];
-    private ConcurrentDictionary<string, QueryTransaction> queryTransactionCache = [];
-    private ConcurrentDictionary<string, Transaction> transactionCache = [];
-    private ConcurrentDictionary<string, SemaphoreSlim> semaphoreStore = [];
+    private HashSet<string> txids = [];
+    private Dictionary<string, QueryTransaction> queryTransactionCache = [];
+    private Dictionary<string, Transaction> transactionCache = [];
+    private Dictionary<string, SemaphoreSlim> semaphoreStore = [];
+
     private async Task<T> GetCache<T>(string txid, string type){
-        bool fetchTransaction = false;//false;
+        bool fetchTransaction = false;
         string txid_type = txid + type;
         lock(txids){
             txids.TryGetValue(txid_type, out string? txid_out);
             if(txid_out == null){
                 fetchTransaction = true;
                 txids.Add(txid_type);
-                SemaphoreSlim semaphore = new(1);
+                SemaphoreSlim semaphore = new(0);
                 semaphoreStore[txid_type] = semaphore;
-                semaphoreStore[txid_type].Wait();
             }
         }
         bool isQueryTransaction = (typeof(T) == typeof(QueryTransaction));
@@ -830,20 +827,13 @@
     private async Task<Transaction> GetTransactionCache(string txid){
         return await GetCache<Transaction>(txid, "trx");
     }
-    private async Task processStageItem(StageDataTrx item, List<QueryTransaction> trxs, StageData stageData, List<Outpoint> unconfirmedOutbound){
+    private async Task processStageItem(StageDataTrx item, StageData stageData, List<Outpoint> unconfirmedOutbound){
         // if the item is already spent by founder or investor, we skip it
         // because we have already processed this item and we know the outcome.
         if (item.IsSpent && ((item.SpentType != "founder") || (item.SpentType != "investor")))
             return;
 
-        QueryTransaction? trx = trxs.FirstOrDefault(f => f.TransactionId == item.Trxid);
-
-        if (trx == null)
-        {
-            trx = await _IndexerService.GetTransactionInfoByIdAsync(item.Trxid);
-            trxs.Add(trx);
-        }
-
+        var trx = await GetQueryTransactionCache(item.Trxid);
         var output = trx.Outputs.First(outp => outp.Index == item.Outputindex);
 
         if (!string.IsNullOrEmpty(output.SpentInTransaction))

--- a/src/Angor/Client/Pages/Spend.razor
+++ b/src/Angor/Client/Pages/Spend.razor
@@ -766,89 +766,87 @@
         }
     }
 
-    Dictionary<string, Transaction> trxsHexCache = new();
-
+    private bool updateUnconfirmedOutbound = false;
     private async Task CheckSpentFund()
     {
         List<QueryTransaction> trxs = new();
         var unconfirmedOutbound = _cacheStorage.GetUnconfirmedOutboundFunds();
         bool updateUnconfirmedOutbound = false;
-
+        List<Task> tasks = [];
         foreach (StageData stageData in stageDatas)
         {
             foreach (var item in stageData.Items)
             {
-                // if the item is already spent by founder or investor, we skip it
-                // because we have already processed this item and we know the outcome.
-                if (item.IsSpent && ((item.SpentType != "founder") || (item.SpentType != "investor")))
-                    continue;
-
-                QueryTransaction? trx = trxs.FirstOrDefault(f => f.TransactionId == item.Trxid);
-
-                if (trx == null)
-                {
-                    trx = await _IndexerService.GetTransactionInfoByIdAsync(item.Trxid);
-                    trxs.Add(trx);
-                }
-
-                var output = trx.Outputs.First(outp => outp.Index == item.Outputindex);
-
-                if (!string.IsNullOrEmpty(output.SpentInTransaction))
-                {
-                    item.IsSpent = true;
-
-                    updateUnconfirmedOutbound |= unconfirmedOutbound.TryRemoveOutpoint(new Outpoint(item.Trxid, item.Outputindex));
-
-                    // try to resolve the destination
-                    var spentInTransaction = await _IndexerService.GetTransactionInfoByIdAsync(output.SpentInTransaction);
-
-                    var input = spentInTransaction?.Inputs.FirstOrDefault(input => input.InputTransactionId == item.Trxid && input.InputIndex == item.Outputindex);
-
-                    var investmentTransaction = trxsHexCache.TryGet(item.Trxid);
-                    if (investmentTransaction == null)
-                    {
-                        var fetchTrx = await _IndexerService.GetTransactionHexByIdAsync(item.Trxid);
-                        investmentTransaction = network.CreateTransaction(fetchTrx);
-                        trxsHexCache.Add(item.Trxid, investmentTransaction);
-                    }
-
-                    if (input != null && investmentTransaction != null)
-                    {
-                        item.ProjectScriptType = _InvestorTransactionActions.DiscoverUsedScript(project, investmentTransaction, stageData.StageIndex - 1, input.WitScript);
-
-                        switch (item.ProjectScriptType.ScriptType)
-                        {
-                            case ProjectScriptTypeEnum.Founder:
-                            {
-                                item.SpentType = "founder";
-                                break;
-                            }
-                            case ProjectScriptTypeEnum.InvestorWithPenalty:
-                            case ProjectScriptTypeEnum.EndOfProject:
-                            case ProjectScriptTypeEnum.InvestorNoPenalty:
-                            {
-                                item.SpentType = "investor";
-                                break;
-                            }
-                        }
-                    }
-
-                    continue;
-                }
-
-                item.IsSpent = unconfirmedOutbound.ContainsOutpoint(new Outpoint(item.Trxid, item.Outputindex));
-                if (item.IsSpent)
-                {
-                    // the trx is unconfirmed, we wait till
-                    // it gets confirmed to discover who spent it
-                    item.SpentType = "pending"; 
-                }
+                tasks.Add(processStageItem(item, trxs, stageData, unconfirmedOutbound));
             }
         }
-
+        await Task.WhenAll(tasks);
         if (updateUnconfirmedOutbound)
         {
             _cacheStorage.SetUnconfirmedOutboundFunds(unconfirmedOutbound);
+        }
+    }
+
+    private async Task processStageItem(StageDataTrx item, List<QueryTransaction> trxs, StageData stageData, List<Outpoint> unconfirmedOutbound){
+        // if the item is already spent by founder or investor, we skip it
+        // because we have already processed this item and we know the outcome.
+        if (item.IsSpent && ((item.SpentType != "founder") || (item.SpentType != "investor")))
+            return;
+
+        QueryTransaction? trx = trxs.FirstOrDefault(f => f.TransactionId == item.Trxid);
+
+        if (trx == null)
+        {
+            trx = await _IndexerService.GetTransactionInfoByIdAsync(item.Trxid);
+            trxs.Add(trx);
+        }
+
+        var output = trx.Outputs.First(outp => outp.Index == item.Outputindex);
+
+        if (!string.IsNullOrEmpty(output.SpentInTransaction))
+        {
+            item.IsSpent = true;
+
+            updateUnconfirmedOutbound |= unconfirmedOutbound.TryRemoveOutpoint(new Outpoint(item.Trxid, item.Outputindex));
+
+            // try to resolve the destination
+            var spentInTransaction = await _IndexerService.GetTransactionInfoByIdAsync(output.SpentInTransaction);
+
+            var input = spentInTransaction?.Inputs.FirstOrDefault(input => input.InputTransactionId == item.Trxid && input.InputIndex == item.Outputindex);
+            
+            var fetchTrx = await _IndexerService.GetTransactionHexByIdAsync(item.Trxid);
+            var investmentTransaction = network.CreateTransaction(fetchTrx);
+    
+            if (input != null && investmentTransaction != null)
+            {
+                item.ProjectScriptType = _InvestorTransactionActions.DiscoverUsedScript(project, investmentTransaction, stageData.StageIndex - 1, input.WitScript);
+
+                switch (item.ProjectScriptType.ScriptType)
+                {
+                    case ProjectScriptTypeEnum.Founder:
+                    {
+                        item.SpentType = "founder";
+                        break;
+                    }
+                    case ProjectScriptTypeEnum.InvestorWithPenalty:
+                    case ProjectScriptTypeEnum.EndOfProject:
+                    case ProjectScriptTypeEnum.InvestorNoPenalty:
+                    {
+                        item.SpentType = "investor";
+                        break;
+                    }
+                }
+            }
+
+            return;
+        }
+
+        item.IsSpent = unconfirmedOutbound.ContainsOutpoint(new Outpoint(item.Trxid, item.Outputindex));
+        if (item.IsSpent)
+        {
+            // the trx is unconfirmed, we wait till
+            // it gets confirmed to discover who spent it
+            item.SpentType = "pending"; 
         }
     }
 


### PR DESCRIPTION
# Add cache and concurrency to checkFunds
- Changed the checkFunds function to use concurrent Tasks, 
- Added required caching for requests using semaphore list for preventing race conditions