### PR TITLE
tuned continue-on-error to false

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       run: dotnet publish -c Release -r ${{matrix.runtime}} /p:Version=${{ env.VERSION }}.${{ github.run_number }} -v m -o publish  ${{env.PROJECT_PATH}}
 
     - name: Run Tests
-      continue-on-error: true
+      continue-on-error: false 
       run: dotnet test -c Release -r ${{matrix.runtime}} --verbosity normal  ${{env.SOLUTION_PATH}} 
 
     - name: Zip Release

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -76,7 +76,7 @@ jobs:
         
     # Run tests to make sure PR doesn't break anything
     - name: Run Tests
-      continue-on-error: true
+      continue-on-error: false 
       run: dotnet test -c Release --verbosity normal ${{env.SOLUTION_PATH}} --filter "Category!=E2E"
       
     # Prepare for deployment


### PR DESCRIPTION
- this will stop the gh-actions workflow if there is an error while running tests