### PR TITLE
Add wallet import + project scan and investment cancellation E2E tests

### DIFF
--- a/src/design/App.Test.Integration/InvestmentCancellationTest.cs
+++ b/src/design/App.Test.Integration/InvestmentCancellationTest.cs
@@ -10,6 +10,7 @@ using Angor.Sdk.Funding.Projects;
 using App.Composition.Adapters;
 using App.Test.Integration.Helpers;
 using App.UI.Sections.FindProjects;
+using App.UI.Sections.Funders;
 using App.UI.Sections.Funds;
 using App.UI.Sections.MyProjects;
 using App.UI.Sections.MyProjects.Deploy;
@@ -25,30 +26,50 @@ namespace App.Test.Integration;
 ///
 /// CancelInvestmentRequest is implemented in the SDK and wired in the design app
 /// (PortfolioViewModel.CancelInvestmentAsync), but has zero E2E coverage. This
-/// test validates the full Nostr DM + handshake status + fund release flow.
+/// test validates the full Nostr DM + handshake status + fund release flow across
+/// three distinct cancellation/confirmation scenarios.
 ///
-/// Flow:
+/// Flow (3-step):
 ///   Phase 1 (Founder):
 ///     1. Wipe data, create wallet, fund via faucet
 ///     2. Create and deploy a fund project with 0.01 BTC approval threshold
 ///
-///   Phase 2 (Investor):
+///   Phase 2 (Investor) — Cancel before founder approval:
 ///     3. Create wallet, fund via faucet
-///     4. Invest above threshold (0.02 BTC) — requires founder approval (Step 1)
+///     4. Invest above threshold (0.02 BTC) — pending approval (Step 1)
 ///     5. Cancel the pending investment before founder approves
-///     6. Verify: investment status = Cancelled
-///     7. Verify: investor's balance is NOT locked (funds released)
-///     8. Re-invest in the same project to prove re-investing after cancel works
-///     9. Verify: new investment succeeds normally (separate from cancelled one)
+///     6. Verify: investment status = Cancelled, funds released
+///
+///   Phase 3 (Investor) — Re-invest after cancel:
+///     7. Re-invest in the same project (new pending investment)
+///
+///   Phase 4 (Founder) — Approve the new investment:
+///     8. Founder approves the pending investment request
+///
+///   Phase 5 (Investor) — Cancel after founder approval:
+///     9. Cancel the approved investment (Step 2)
+///     10. Verify: investment status = Cancelled, funds released
+///
+///   Phase 6 (Investor) — Re-invest again:
+///     11. Re-invest in the same project
+///
+///   Phase 7 (Founder) — Approve again:
+///     12. Founder approves the new investment request
+///
+///   Phase 8 (Investor) — Confirm the approved investment:
+///     13. Investor confirms the approved investment
+///     14. Verify: investment reaches Step 3 (active)
 ///
 /// This validates:
-///   - CancelInvestmentRequest correctly updates investment status
+///   - Cancel before founder approval works (Step 1 → Cancelled)
+///   - Cancel after founder approval works (Step 2 → Cancelled)
+///   - Confirming an approved investment completes the cycle (Step 3)
 ///   - Cancelled investments release reserved UTXOs (funds not locked)
 ///   - Re-investing after cancellation creates a new, separate investment
-///   - The portfolio shows both the cancelled and the new investment
+///   - The full founder-approval handshake works end-to-end
 ///
 /// Uses real testnet infrastructure (indexer + faucet + Nostr relays).
-/// May take 120-300 seconds depending on network conditions.
+/// May take 3-10 minutes depending on network conditions.
 /// </summary>
 public class InvestmentCancellationTest
 {
@@ -86,6 +107,7 @@ public class InvestmentCancellationTest
         // ──────────────────────────────────────────────────────────────
         // PHASE 1: Founder — create wallet, fund, deploy project
         // ──────────────────────────────────────────────────────────────
+        Log(null, "═══ PHASE 1: Founder creates wallet, funds, deploys project ═══");
         await WithProfileWindow(FounderProfile, initializedProfiles, async window =>
         {
             await CreateWalletAndFundAsync(window, FounderProfile);
@@ -101,49 +123,115 @@ public class InvestmentCancellationTest
         });
 
         project.Should().NotBeNull("Founder phase should produce a deployed project");
-        Log(null, $"Founder phase complete. ProjectId={project!.ProjectIdentifier}");
+        Log(null, $"Phase 1 complete. ProjectId={project!.ProjectIdentifier}");
 
         // ──────────────────────────────────────────────────────────────
-        // PHASE 2: Investor — invest, cancel, verify, re-invest
+        // PHASE 2: Investor — invest, cancel BEFORE founder approval
         // ──────────────────────────────────────────────────────────────
+        Log(null, "═══ PHASE 2: Investor invests and cancels BEFORE founder approval ═══");
         await WithProfileWindow(InvestorProfile, initializedProfiles, async window =>
         {
             await CreateWalletAndFundAsync(window, InvestorProfile);
-            await InvestCancelAndReinvestAsync(window, InvestorProfile, project!, investmentAmountBtc);
+            await InvestAndCancelBeforeApprovalAsync(window, InvestorProfile, project!, investmentAmountBtc);
         });
 
+        Log(null, "Phase 2 complete. Cancel-before-approval validated.");
+
+        // ──────────────────────────────────────────────────────────────
+        // PHASE 3: Investor — re-invest (new pending investment)
+        // ──────────────────────────────────────────────────────────────
+        Log(null, "═══ PHASE 3: Investor re-invests after cancel ═══");
+        await WithProfileWindow(InvestorProfile, initializedProfiles, async window =>
+        {
+            await InvestInProjectFromSdkAsync(window, InvestorProfile, project!, investmentAmountBtc);
+        });
+
+        Log(null, "Phase 3 complete. Re-investment submitted.");
+
+        // ──────────────────────────────────────────────────────────────
+        // PHASE 4: Founder — approve the pending investment
+        // ──────────────────────────────────────────────────────────────
+        Log(null, "═══ PHASE 4: Founder approves the pending investment ═══");
+        await WithProfileWindow(FounderProfile, initializedProfiles, async window =>
+        {
+            await ApprovePendingInvestmentAsync(window, FounderProfile, project!);
+        });
+
+        Log(null, "Phase 4 complete. Founder approved the investment.");
+
+        // ──────────────────────────────────────────────────────────────
+        // PHASE 5: Investor — cancel AFTER founder approval
+        // ──────────────────────────────────────────────────────────────
+        Log(null, "═══ PHASE 5: Investor cancels AFTER founder approval ═══");
+        await WithProfileWindow(InvestorProfile, initializedProfiles, async window =>
+        {
+            await CancelAfterApprovalAsync(window, InvestorProfile, project!);
+        });
+
+        Log(null, "Phase 5 complete. Cancel-after-approval validated.");
+
+        // ──────────────────────────────────────────────────────────────
+        // PHASE 6: Investor — re-invest again
+        // ──────────────────────────────────────────────────────────────
+        Log(null, "═══ PHASE 6: Investor re-invests again ═══");
+        await WithProfileWindow(InvestorProfile, initializedProfiles, async window =>
+        {
+            await InvestInProjectFromSdkAsync(window, InvestorProfile, project!, investmentAmountBtc);
+        });
+
+        Log(null, "Phase 6 complete. Second re-investment submitted.");
+
+        // ──────────────────────────────────────────────────────────────
+        // PHASE 7: Founder — approve again
+        // ──────────────────────────────────────────────────────────────
+        Log(null, "═══ PHASE 7: Founder approves the new investment ═══");
+        await WithProfileWindow(FounderProfile, initializedProfiles, async window =>
+        {
+            await ApprovePendingInvestmentAsync(window, FounderProfile, project!);
+        });
+
+        Log(null, "Phase 7 complete. Founder approved the second investment.");
+
+        // ──────────────────────────────────────────────────────────────
+        // PHASE 8: Investor — confirm approved investment (Step 3)
+        // ──────────────────────────────────────────────────────────────
+        Log(null, "═══ PHASE 8: Investor confirms the approved investment ═══");
+        await WithProfileWindow(InvestorProfile, initializedProfiles, async window =>
+        {
+            await ConfirmApprovedInvestmentAsync(window, InvestorProfile, project!);
+        });
+
+        Log(null, "Phase 8 complete. Investment confirmed and active.");
         Log(null, $"========== {nameof(CancelPendingInvestmentAndReinvest)} PASSED ==========");
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // Phase 2: Investor — invest, cancel, verify funds released, re-invest
+    // Phase 2: Investor — invest, cancel BEFORE founder approval
     // ═══════════════════════════════════════════════════════════════════
 
-    private async Task InvestCancelAndReinvestAsync(
+    private async Task InvestAndCancelBeforeApprovalAsync(
         Window window,
         string profileName,
         ProjectHandle project,
         string investmentAmountBtc)
     {
-        // ── Step 1: Find project in SDK ──
+        // ── Step 1: Find project and invest ──
         var foundProject = await FindProjectFromSdkAsync(window, profileName, project);
 
-        // ── Step 2: Invest above threshold (stays at Step 1 — Pending Approval) ──
         Log(profileName, $"Investing {investmentAmountBtc} BTC (above threshold, pending approval)...");
-        await InvestInProjectAsync(
-            window, profileName, foundProject, project, investmentAmountBtc);
+        await InvestInProjectAsync(window, profileName, foundProject, project, investmentAmountBtc);
 
         // Wait for the indexer to pick up the investment and reload from SDK.
-        // AddToPortfolio does an optimistic local insert without WalletId/TransactionId.
-        // LoadInvestmentsFromSdkAsync repopulates the full InvestmentViewModel with those fields.
         var portfolioVm = await WaitForPortfolioInvestmentFromSdkAsync(
             window, profileName, project,
             inv => !string.IsNullOrEmpty(inv.InvestmentWalletId)
-                   && !string.IsNullOrEmpty(inv.InvestmentTransactionId));
+                   && !string.IsNullOrEmpty(inv.InvestmentTransactionId)
+                   && inv.Status != "Cancelled");
 
         var pendingInvestment = portfolioVm.Investments.FirstOrDefault(i =>
             i.ProjectIdentifier == project.ProjectIdentifier
-            && !string.IsNullOrEmpty(i.InvestmentWalletId));
+            && !string.IsNullOrEmpty(i.InvestmentWalletId)
+            && i.Status != "Cancelled");
         pendingInvestment.Should().NotBeNull("Pending investment should be in portfolio after SDK reload");
         pendingInvestment!.InvestmentWalletId.Should().NotBeNullOrEmpty("Investment should have a wallet ID after SDK reload");
         pendingInvestment.InvestmentTransactionId.Should().NotBeNullOrEmpty("Investment should have a transaction ID after SDK reload");
@@ -151,13 +239,13 @@ public class InvestmentCancellationTest
         Log(profileName, $"Pending investment: Step={pendingInvestment.Step}, Status='{pendingInvestment.StatusText}', " +
             $"WalletId={pendingInvestment.InvestmentWalletId}, TxId={pendingInvestment.InvestmentTransactionId}");
 
-        // Record balance before cancellation for comparison
+        // Record balance before cancellation
         var fundsVm = GetFundsViewModel(window);
         var balanceBeforeCancel = fundsVm?.TotalBalance ?? "0.0000";
         Log(profileName, $"Balance before cancellation: {balanceBeforeCancel}");
 
-        // ── Step 3: Cancel the pending investment ──
-        Log(profileName, "Cancelling pending investment...");
+        // ── Step 2: Cancel the pending investment (before founder approval) ──
+        Log(profileName, "Cancelling pending investment (before founder approval)...");
         var cancelResult = await portfolioVm.CancelInvestmentAsync(pendingInvestment);
         Dispatcher.UIThread.RunJobs();
 
@@ -166,8 +254,201 @@ public class InvestmentCancellationTest
         pendingInvestment.Status.Should().Be("Cancelled", "Status field should be 'Cancelled'");
         Log(profileName, $"Investment cancelled. Status='{pendingInvestment.StatusText}'");
 
-        // ── Step 4: Verify funds are released (balance not locked) ──
-        // Refresh balance — reserved UTXOs should be released
+        // ── Step 3: Verify funds are released ──
+        await VerifyFundsReleasedAsync(window, profileName, balanceBeforeCancel);
+
+        Log(profileName, "Cancel-before-approval flow validated.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Phase 3/6: Investor — find project and invest (reusable)
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Find the project from SDK and invest. Used for re-investment phases.
+    /// </summary>
+    private async Task InvestInProjectFromSdkAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project,
+        string investmentAmountBtc)
+    {
+        Log(profileName, $"Re-investing {investmentAmountBtc} BTC in project {project.ProjectIdentifier}...");
+        var foundProject = await FindProjectFromSdkAsync(window, profileName, project);
+        await InvestInProjectAsync(window, profileName, foundProject, project, investmentAmountBtc);
+        Log(profileName, "Re-investment submitted successfully.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Phase 4/7: Founder — approve pending investment
+    // ═══════════════════════════════════════════════════════════════════
+
+    private async Task ApprovePendingInvestmentAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project)
+    {
+        window.NavigateToSection("Funders");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var fundersVm = GetFundersViewModel(window);
+        fundersVm.Should().NotBeNull();
+
+        SignatureRequestViewModel? pendingSignature = null;
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await fundersVm!.LoadInvestmentRequestsAsync();
+            Dispatcher.UIThread.RunJobs();
+            fundersVm.SetFilter("waiting");
+            Dispatcher.UIThread.RunJobs();
+
+            Log(profileName, $"Funders waiting count: {fundersVm.WaitingCount}, approved count: {fundersVm.ApprovedCount}");
+
+            pendingSignature = fundersVm.FilteredSignatures.FirstOrDefault(s =>
+                string.Equals(s.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
+            if (pendingSignature != null)
+            {
+                break;
+            }
+
+            Log(profileName, "Waiting for pending founder approval request...");
+            await Task.Delay(PollInterval);
+        }
+
+        pendingSignature.Should().NotBeNull("above-threshold investment should require founder approval");
+        Log(profileName, $"Approving signature request id={pendingSignature!.Id} for project {project.ProjectIdentifier}");
+        fundersVm!.ApproveSignature(pendingSignature.Id);
+
+        var approvalDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < approvalDeadline)
+        {
+            await fundersVm.LoadInvestmentRequestsAsync();
+            Dispatcher.UIThread.RunJobs();
+            fundersVm.SetFilter("approved");
+            Dispatcher.UIThread.RunJobs();
+
+            var approved = fundersVm.FilteredSignatures.Any(s =>
+                string.Equals(s.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
+            if (approved)
+            {
+                Log(profileName, "Founder approval completed.");
+                return;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Founder approval did not complete in time.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Phase 5: Investor — cancel AFTER founder approval
+    // ═══════════════════════════════════════════════════════════════════
+
+    private async Task CancelAfterApprovalAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project)
+    {
+        // Wait for investment to reach Step 2 (founder approved)
+        var portfolioVm = await WaitForPortfolioInvestmentFromSdkAsync(
+            window, profileName, project,
+            inv => inv.Step >= 2
+                   && inv.Status != "Cancelled"
+                   && inv.ApprovalStatus == "Approved");
+
+        var approvedInvestment = portfolioVm.Investments.FirstOrDefault(i =>
+            i.ProjectIdentifier == project.ProjectIdentifier
+            && i.Status != "Cancelled"
+            && i.ApprovalStatus == "Approved");
+        approvedInvestment.Should().NotBeNull("Approved investment should be in portfolio");
+
+        Log(profileName, $"Approved investment found: Step={approvedInvestment!.Step}, Status='{approvedInvestment.StatusText}', " +
+            $"Approval={approvedInvestment.ApprovalStatus}");
+
+        // Record balance before cancellation
+        var fundsVm = GetFundsViewModel(window);
+        var balanceBeforeCancel = fundsVm?.TotalBalance ?? "0.0000";
+        Log(profileName, $"Balance before cancellation: {balanceBeforeCancel}");
+
+        // Cancel the approved investment
+        Log(profileName, "Cancelling approved investment (after founder approval)...");
+        var cancelResult = await portfolioVm.CancelInvestmentAsync(approvedInvestment);
+        Dispatcher.UIThread.RunJobs();
+
+        cancelResult.Should().BeTrue("Cancellation should succeed for an approved (Step 2) investment");
+        approvedInvestment.StatusText.Should().Be("Cancelled", "Status should be 'Cancelled' after cancellation");
+        approvedInvestment.Status.Should().Be("Cancelled", "Status field should be 'Cancelled'");
+        Log(profileName, $"Investment cancelled after approval. Status='{approvedInvestment.StatusText}'");
+
+        // Verify funds are released
+        await VerifyFundsReleasedAsync(window, profileName, balanceBeforeCancel);
+
+        Log(profileName, "Cancel-after-approval flow validated.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Phase 8: Investor — confirm approved investment (Step 3)
+    // ═══════════════════════════════════════════════════════════════════
+
+    private async Task ConfirmApprovedInvestmentAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project)
+    {
+        // Wait for investment to reach Step 2 (founder approved)
+        var portfolioVm = await WaitForPortfolioInvestmentFromSdkAsync(
+            window, profileName, project,
+            inv => inv.Step >= 2
+                   && inv.Status != "Cancelled"
+                   && inv.ApprovalStatus == "Approved");
+
+        var investment = portfolioVm.Investments.First(i =>
+            i.ProjectIdentifier == project.ProjectIdentifier
+            && i.Status != "Cancelled"
+            && i.ApprovalStatus == "Approved");
+
+        Log(profileName, $"Confirming approved investment. Step={investment.Step}, Status={investment.StatusText}");
+        investment.ApprovalStatus.Should().Be("Approved");
+        var confirmResult = await portfolioVm.ConfirmInvestmentAsync(investment);
+        confirmResult.Should().BeTrue("founder-approved investment should be confirmable by the investor");
+
+        // Wait for Step 3 (active)
+        var activeDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < activeDeadline)
+        {
+            await portfolioVm.LoadInvestmentsFromSdkAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var refreshed = portfolioVm.Investments.FirstOrDefault(i =>
+                i.ProjectIdentifier == project.ProjectIdentifier
+                && i.Status != "Cancelled");
+            if (refreshed?.Step == 3)
+            {
+                Log(profileName, "Investment confirmed and active (Step 3).");
+                return;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Confirmed investment did not become active (Step 3) in time.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Shared verification helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Verify funds are released after cancellation by refreshing balance.
+    /// </summary>
+    private async Task VerifyFundsReleasedAsync(
+        Window window,
+        string profileName,
+        string balanceBeforeCancel)
+    {
         window.NavigateToSection("Funds");
         await Task.Delay(500);
         Dispatcher.UIThread.RunJobs();
@@ -176,48 +457,13 @@ public class InvestmentCancellationTest
         await Task.Delay(2000);
         Dispatcher.UIThread.RunJobs();
 
-        fundsVm = GetFundsViewModel(window);
+        var fundsVm = GetFundsViewModel(window);
         fundsVm.Should().NotBeNull();
         var balanceAfterCancel = fundsVm!.TotalBalance;
         Log(profileName, $"Balance after cancellation: {balanceAfterCancel}");
 
-        // The balance should be at least what it was before cancellation
-        // (reserved UTXOs released back to available balance)
         balanceAfterCancel.Should().NotBe("0.0000",
             "Balance should be non-zero after cancellation (funds released)");
-
-        // ── Step 5: Re-invest in the same project ──
-        Log(profileName, "Re-investing in the same project after cancellation...");
-        var foundProjectAgain = await FindProjectFromSdkAsync(window, profileName, project);
-
-        var portfolioVmAfterReinvest = await InvestInProjectAsync(
-            window, profileName, foundProjectAgain, project, investmentAmountBtc);
-
-        // ── Step 6: Verify new investment is separate from cancelled one ──
-        var allInvestments = portfolioVmAfterReinvest.Investments
-            .Where(i => i.ProjectIdentifier == project.ProjectIdentifier)
-            .ToList();
-
-        Log(profileName, $"Total investments for this project: {allInvestments.Count}");
-        foreach (var inv in allInvestments)
-        {
-            Log(profileName, $"  Investment: Step={inv.Step}, Status='{inv.StatusText}', TxId={inv.InvestmentTransactionId}");
-        }
-
-        // Should have at least the new investment (the cancelled one may or may not persist
-        // depending on whether the SDK removes it from the portfolio records)
-        var activeInvestments = allInvestments.Where(i => i.Status != "Cancelled").ToList();
-        activeInvestments.Should().HaveCountGreaterThanOrEqualTo(1,
-            "Should have at least one non-cancelled investment after re-investing");
-
-        var newInvestment = activeInvestments.First();
-        newInvestment.TotalInvested.Should().Be(
-            decimal.Parse(investmentAmountBtc, CultureInfo.InvariantCulture).ToString("F8", CultureInfo.InvariantCulture),
-            "New investment amount should match");
-        newInvestment.ProjectIdentifier.Should().Be(project.ProjectIdentifier,
-            "New investment should be for the same project");
-
-        Log(profileName, "Re-investment successful. Cancellation + reinvest flow validated.");
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -744,6 +990,11 @@ public class InvestmentCancellationTest
     private static FindProjectsViewModel? GetFindProjectsViewModel(Window window)
     {
         return window.GetVisualDescendants().OfType<FindProjectsView>().FirstOrDefault()?.DataContext as FindProjectsViewModel;
+    }
+
+    private static FundersViewModel? GetFundersViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FundersView>().FirstOrDefault()?.DataContext as FundersViewModel;
     }
 
     private static void Log(string? profileName, string message)

--- a/src/design/App.Test.Integration/InvestmentCancellationTest.cs
+++ b/src/design/App.Test.Integration/InvestmentCancellationTest.cs
@@ -130,19 +130,26 @@ public class InvestmentCancellationTest
 
         // ── Step 2: Invest above threshold (stays at Step 1 — Pending Approval) ──
         Log(profileName, $"Investing {investmentAmountBtc} BTC (above threshold, pending approval)...");
-        var portfolioVm = await InvestInProjectAsync(
+        await InvestInProjectAsync(
             window, profileName, foundProject, project, investmentAmountBtc);
 
-        // Find the pending investment
+        // Wait for the indexer to pick up the investment and reload from SDK.
+        // AddToPortfolio does an optimistic local insert without WalletId/TransactionId.
+        // LoadInvestmentsFromSdkAsync repopulates the full InvestmentViewModel with those fields.
+        var portfolioVm = await WaitForPortfolioInvestmentFromSdkAsync(
+            window, profileName, project,
+            inv => !string.IsNullOrEmpty(inv.InvestmentWalletId)
+                   && !string.IsNullOrEmpty(inv.InvestmentTransactionId));
+
         var pendingInvestment = portfolioVm.Investments.FirstOrDefault(i =>
-            i.ProjectIdentifier == project.ProjectIdentifier);
-        pendingInvestment.Should().NotBeNull("Pending investment should be in portfolio after AddToPortfolio");
-        pendingInvestment!.Step.Should().Be(1, "Above-threshold investment should be at Step 1 (Pending) before founder approval");
-        pendingInvestment.InvestmentWalletId.Should().NotBeNullOrEmpty("Investment should have a wallet ID");
-        pendingInvestment.InvestmentTransactionId.Should().NotBeNullOrEmpty("Investment should have a transaction ID");
+            i.ProjectIdentifier == project.ProjectIdentifier
+            && !string.IsNullOrEmpty(i.InvestmentWalletId));
+        pendingInvestment.Should().NotBeNull("Pending investment should be in portfolio after SDK reload");
+        pendingInvestment!.InvestmentWalletId.Should().NotBeNullOrEmpty("Investment should have a wallet ID after SDK reload");
+        pendingInvestment.InvestmentTransactionId.Should().NotBeNullOrEmpty("Investment should have a transaction ID after SDK reload");
 
         Log(profileName, $"Pending investment: Step={pendingInvestment.Step}, Status='{pendingInvestment.StatusText}', " +
-            $"TxId={pendingInvestment.InvestmentTransactionId}");
+            $"WalletId={pendingInvestment.InvestmentWalletId}, TxId={pendingInvestment.InvestmentTransactionId}");
 
         // Record balance before cancellation for comparison
         var fundsVm = GetFundsViewModel(window);
@@ -307,6 +314,53 @@ public class InvestmentCancellationTest
         Dispatcher.UIThread.RunJobs();
 
         return portfolioVm;
+    }
+
+    /// <summary>
+    /// Wait for the indexer to pick up the investment and reload from SDK.
+    /// Returns PortfolioViewModel once the investment matches the predicate.
+    /// </summary>
+    private async Task<PortfolioViewModel> WaitForPortfolioInvestmentFromSdkAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project,
+        Func<InvestmentViewModel, bool> predicate)
+    {
+        window.NavigateToSection("Funded");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            await portfolioVm.LoadInvestmentsFromSdkAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var investment = portfolioVm.Investments.FirstOrDefault(i =>
+                string.Equals(i.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
+
+            if (investment != null)
+            {
+                Log(profileName, $"Portfolio investment found via SDK. Step={investment.Step}, " +
+                    $"Status={investment.StatusText}, WalletId={investment.InvestmentWalletId}, " +
+                    $"TxId={investment.InvestmentTransactionId}");
+                if (predicate(investment))
+                {
+                    return portfolioVm;
+                }
+            }
+            else
+            {
+                Log(profileName, "Portfolio investment not found in SDK yet.");
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException(
+            $"Portfolio investment for project {project.ProjectIdentifier} did not reach expected state within {IndexerLagTimeout.TotalSeconds}s.");
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/src/design/App.Test.Integration/InvestmentCancellationTest.cs
+++ b/src/design/App.Test.Integration/InvestmentCancellationTest.cs
@@ -1,0 +1,700 @@
+using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FluentAssertions;
+using Angor.Sdk.Common;
+using Angor.Sdk.Funding.Projects;
+using App.Composition.Adapters;
+using App.Test.Integration.Helpers;
+using App.UI.Sections.FindProjects;
+using App.UI.Sections.Funds;
+using App.UI.Sections.MyProjects;
+using App.UI.Sections.MyProjects.Deploy;
+using App.UI.Sections.Portfolio;
+using App.UI.Sections.Settings;
+using App.UI.Shell;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace App.Test.Integration;
+
+/// <summary>
+/// End-to-end integration test for the investment cancellation flow.
+///
+/// CancelInvestmentRequest is implemented in the SDK and wired in the design app
+/// (PortfolioViewModel.CancelInvestmentAsync), but has zero E2E coverage. This
+/// test validates the full Nostr DM + handshake status + fund release flow.
+///
+/// Flow:
+///   Phase 1 (Founder):
+///     1. Wipe data, create wallet, fund via faucet
+///     2. Create and deploy a fund project with 0.01 BTC approval threshold
+///
+///   Phase 2 (Investor):
+///     3. Create wallet, fund via faucet
+///     4. Invest above threshold (0.02 BTC) — requires founder approval (Step 1)
+///     5. Cancel the pending investment before founder approves
+///     6. Verify: investment status = Cancelled
+///     7. Verify: investor's balance is NOT locked (funds released)
+///     8. Re-invest in the same project to prove re-investing after cancel works
+///     9. Verify: new investment succeeds normally (separate from cancelled one)
+///
+/// This validates:
+///   - CancelInvestmentRequest correctly updates investment status
+///   - Cancelled investments release reserved UTXOs (funds not locked)
+///   - Re-investing after cancellation creates a new, separate investment
+///   - The portfolio shows both the cancelled and the new investment
+///
+/// Uses real testnet infrastructure (indexer + faucet + Nostr relays).
+/// May take 120-300 seconds depending on network conditions.
+/// </summary>
+public class InvestmentCancellationTest
+{
+    private const string TestName = "InvestmentCancellation";
+    private const string FounderProfile = TestName + "-Founder";
+    private const string InvestorProfile = TestName + "-Investor";
+
+    private static readonly TimeSpan FaucetBalanceTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan TransactionTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan UiTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan IndexerLagTimeout = TimeSpan.FromMinutes(5);
+
+    private sealed record ProjectHandle(string RunId, string ProjectName, string ProjectIdentifier, string FounderWalletId);
+
+    [AvaloniaFact]
+    public async Task CancelPendingInvestmentAndReinvest()
+    {
+        var initializedProfiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var runId = Guid.NewGuid().ToString("N")[..12];
+        var projectName = $"Cancel Test {runId}";
+        var projectAbout = $"{TestName} run {runId}. Validates investment cancellation and reinvestment.";
+        var bannerImageUrl = $"https://picsum.photos/seed/{Guid.NewGuid().ToString("N")[..8]}/320/200";
+        var profileImageUrl = $"https://picsum.photos/seed/{Guid.NewGuid().ToString("N")[..8]}/100/100";
+        var payoutDay = DateTime.UtcNow.DayOfWeek.ToString();
+        var investmentAmountBtc = "0.02"; // above 0.01 threshold → requires founder approval
+
+        Log(null, $"========== STARTING {nameof(CancelPendingInvestmentAndReinvest)} ==========");
+        Log(null, $"Run ID: {runId}");
+        Log(null, $"Founder profile: {FounderProfile}");
+        Log(null, $"Investor profile: {InvestorProfile}");
+
+        ProjectHandle? project = null;
+
+        // ──────────────────────────────────────────────────────────────
+        // PHASE 1: Founder — create wallet, fund, deploy project
+        // ──────────────────────────────────────────────────────────────
+        await WithProfileWindow(FounderProfile, initializedProfiles, async window =>
+        {
+            await CreateWalletAndFundAsync(window, FounderProfile);
+            project = await CreateFundProjectAsync(
+                window,
+                FounderProfile,
+                projectName,
+                projectAbout,
+                bannerImageUrl,
+                profileImageUrl,
+                payoutDay,
+                runId);
+        });
+
+        project.Should().NotBeNull("Founder phase should produce a deployed project");
+        Log(null, $"Founder phase complete. ProjectId={project!.ProjectIdentifier}");
+
+        // ──────────────────────────────────────────────────────────────
+        // PHASE 2: Investor — invest, cancel, verify, re-invest
+        // ──────────────────────────────────────────────────────────────
+        await WithProfileWindow(InvestorProfile, initializedProfiles, async window =>
+        {
+            await CreateWalletAndFundAsync(window, InvestorProfile);
+            await InvestCancelAndReinvestAsync(window, InvestorProfile, project!, investmentAmountBtc);
+        });
+
+        Log(null, $"========== {nameof(CancelPendingInvestmentAndReinvest)} PASSED ==========");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Phase 2: Investor — invest, cancel, verify funds released, re-invest
+    // ═══════════════════════════════════════════════════════════════════
+
+    private async Task InvestCancelAndReinvestAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project,
+        string investmentAmountBtc)
+    {
+        // ── Step 1: Find project in SDK ──
+        var foundProject = await FindProjectFromSdkAsync(window, profileName, project);
+
+        // ── Step 2: Invest above threshold (stays at Step 1 — Pending Approval) ──
+        Log(profileName, $"Investing {investmentAmountBtc} BTC (above threshold, pending approval)...");
+        var portfolioVm = await InvestInProjectAsync(
+            window, profileName, foundProject, project, investmentAmountBtc);
+
+        // Find the pending investment
+        var pendingInvestment = portfolioVm.Investments.FirstOrDefault(i =>
+            i.ProjectIdentifier == project.ProjectIdentifier);
+        pendingInvestment.Should().NotBeNull("Pending investment should be in portfolio after AddToPortfolio");
+        pendingInvestment!.Step.Should().Be(1, "Above-threshold investment should be at Step 1 (Pending) before founder approval");
+        pendingInvestment.InvestmentWalletId.Should().NotBeNullOrEmpty("Investment should have a wallet ID");
+        pendingInvestment.InvestmentTransactionId.Should().NotBeNullOrEmpty("Investment should have a transaction ID");
+
+        Log(profileName, $"Pending investment: Step={pendingInvestment.Step}, Status='{pendingInvestment.StatusText}', " +
+            $"TxId={pendingInvestment.InvestmentTransactionId}");
+
+        // Record balance before cancellation for comparison
+        var fundsVm = GetFundsViewModel(window);
+        var balanceBeforeCancel = fundsVm?.TotalBalance ?? "0.0000";
+        Log(profileName, $"Balance before cancellation: {balanceBeforeCancel}");
+
+        // ── Step 3: Cancel the pending investment ──
+        Log(profileName, "Cancelling pending investment...");
+        var cancelResult = await portfolioVm.CancelInvestmentAsync(pendingInvestment);
+        Dispatcher.UIThread.RunJobs();
+
+        cancelResult.Should().BeTrue("Cancellation should succeed for a pending (Step 1) investment");
+        pendingInvestment.StatusText.Should().Be("Cancelled", "Status should be 'Cancelled' after cancellation");
+        pendingInvestment.Status.Should().Be("Cancelled", "Status field should be 'Cancelled'");
+        Log(profileName, $"Investment cancelled. Status='{pendingInvestment.StatusText}'");
+
+        // ── Step 4: Verify funds are released (balance not locked) ──
+        // Refresh balance — reserved UTXOs should be released
+        window.NavigateToSection("Funds");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        await ClickWalletCardButton(window, "WalletCardBtnRefresh");
+        await Task.Delay(2000);
+        Dispatcher.UIThread.RunJobs();
+
+        fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+        var balanceAfterCancel = fundsVm!.TotalBalance;
+        Log(profileName, $"Balance after cancellation: {balanceAfterCancel}");
+
+        // The balance should be at least what it was before cancellation
+        // (reserved UTXOs released back to available balance)
+        balanceAfterCancel.Should().NotBe("0.0000",
+            "Balance should be non-zero after cancellation (funds released)");
+
+        // ── Step 5: Re-invest in the same project ──
+        Log(profileName, "Re-investing in the same project after cancellation...");
+        var foundProjectAgain = await FindProjectFromSdkAsync(window, profileName, project);
+
+        var portfolioVmAfterReinvest = await InvestInProjectAsync(
+            window, profileName, foundProjectAgain, project, investmentAmountBtc);
+
+        // ── Step 6: Verify new investment is separate from cancelled one ──
+        var allInvestments = portfolioVmAfterReinvest.Investments
+            .Where(i => i.ProjectIdentifier == project.ProjectIdentifier)
+            .ToList();
+
+        Log(profileName, $"Total investments for this project: {allInvestments.Count}");
+        foreach (var inv in allInvestments)
+        {
+            Log(profileName, $"  Investment: Step={inv.Step}, Status='{inv.StatusText}', TxId={inv.InvestmentTransactionId}");
+        }
+
+        // Should have at least the new investment (the cancelled one may or may not persist
+        // depending on whether the SDK removes it from the portfolio records)
+        var activeInvestments = allInvestments.Where(i => i.Status != "Cancelled").ToList();
+        activeInvestments.Should().HaveCountGreaterThanOrEqualTo(1,
+            "Should have at least one non-cancelled investment after re-investing");
+
+        var newInvestment = activeInvestments.First();
+        newInvestment.TotalInvested.Should().Be(
+            decimal.Parse(investmentAmountBtc, CultureInfo.InvariantCulture).ToString("F8", CultureInfo.InvariantCulture),
+            "New investment amount should match");
+        newInvestment.ProjectIdentifier.Should().Be(project.ProjectIdentifier,
+            "New investment should be for the same project");
+
+        Log(profileName, "Re-investment successful. Cancellation + reinvest flow validated.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Investment helper
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Invest in a project and add to portfolio. Returns the PortfolioViewModel.
+    /// </summary>
+    private async Task<PortfolioViewModel> InvestInProjectAsync(
+        Window window,
+        string profileName,
+        ProjectItemViewModel foundProject,
+        ProjectHandle project,
+        string amountBtc)
+    {
+        var findProjectsVm = GetFindProjectsViewModel(window);
+        findProjectsVm.Should().NotBeNull();
+
+        findProjectsVm!.OpenProjectDetail(foundProject);
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(300);
+
+        findProjectsVm.OpenInvestPage();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var investVm = findProjectsVm.InvestPageViewModel;
+        investVm.Should().NotBeNull();
+
+        // Wait for wallets to load
+        var walletLoadDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTime.UtcNow < walletLoadDeadline && investVm!.Wallets.Count == 0)
+        {
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        investVm!.Wallets.Count.Should().BeGreaterThan(0);
+        investVm.InvestmentAmount = amountBtc;
+        investVm.CanSubmit.Should().BeTrue();
+
+        investVm.Submit();
+        Dispatcher.UIThread.RunJobs();
+        investVm.CurrentScreen.Should().Be(InvestScreen.WalletSelector);
+
+        var investWallet = investVm.Wallets[0];
+        investVm.SelectWallet(investWallet);
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, $"Paying {amountBtc} BTC with wallet {investWallet.Id.Value}...");
+        investVm.PayWithWallet();
+
+        var investDeadline = DateTime.UtcNow + TransactionTimeout;
+        while (DateTime.UtcNow < investDeadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (investVm.CurrentScreen == InvestScreen.Success)
+            {
+                break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        investVm.CurrentScreen.Should().Be(InvestScreen.Success,
+            $"Invest should reach success. Last status: {investVm.PaymentStatusText}");
+        investVm.FormattedAmount.Should().Be(
+            decimal.Parse(amountBtc, CultureInfo.InvariantCulture).ToString("F8", CultureInfo.InvariantCulture));
+
+        // Above threshold → requires founder approval
+        investVm.IsAutoApproved.Should().BeFalse(
+            "Above-threshold investment should NOT be auto-approved");
+        investVm.SuccessTitle.Should().Contain("Pending Approval",
+            "Above-threshold investment should show 'Pending Approval'");
+
+        // Add to portfolio
+        var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
+        investVm.AddToPortfolio();
+        Dispatcher.UIThread.RunJobs();
+
+        var addedInvestment = portfolioVm.Investments.FirstOrDefault(i =>
+            i.ProjectIdentifier == project.ProjectIdentifier && i.Status != "Cancelled");
+        addedInvestment.Should().NotBeNull("Investment should appear in portfolio");
+        addedInvestment!.TotalInvested.Should().Be(
+            decimal.Parse(amountBtc, CultureInfo.InvariantCulture).ToString("F8", CultureInfo.InvariantCulture));
+
+        Log(profileName, $"Investment completed. Step={addedInvestment.Step}, Status='{addedInvestment.StatusText}'");
+
+        // Close invest page to allow re-navigation
+        findProjectsVm.CloseInvestPage();
+        findProjectsVm.CloseProjectDetail();
+        Dispatcher.UIThread.RunJobs();
+
+        return portfolioVm;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Project creation helpers (reused from MultiFundClaimAndRecoverTest pattern)
+    // ═══════════════════════════════════════════════════════════════════
+
+    private async Task<ProjectHandle> CreateFundProjectAsync(
+        Window window,
+        string profileName,
+        string projectName,
+        string projectAbout,
+        string bannerImageUrl,
+        string profileImageUrl,
+        string payoutDay,
+        string runId)
+    {
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var myProjectsVm = GetMyProjectsViewModel(window);
+        myProjectsVm.Should().NotBeNull();
+
+        await OpenCreateWizard(window, myProjectsVm!, profileName);
+
+        var wizardVm = myProjectsVm!.CreateProjectVm;
+        wizardVm.Should().NotBeNull();
+
+        Log(profileName, "Selecting Fund project type...");
+        wizardVm.DismissWelcome();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        wizardVm.SelectProjectType("fund");
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, $"Setting project metadata: {projectName}");
+        wizardVm.ProjectName = projectName;
+        wizardVm.ProjectAbout = projectAbout;
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Setting project images...");
+        wizardVm.BannerUrl = bannerImageUrl;
+        wizardVm.ProfileUrl = profileImageUrl;
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Configuring target amount and threshold...");
+        wizardVm.TargetAmount = "1.0";
+        wizardVm.ApprovalThreshold = "0.01";
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Configuring payout schedule...");
+        wizardVm.DismissStep5Welcome();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        wizardVm.PayoutFrequency = "Weekly";
+        wizardVm.ToggleInstallmentCount(3);
+        wizardVm.WeeklyPayoutDay = payoutDay;
+        wizardVm.GeneratePayoutSchedule();
+        wizardVm.Stages.Count.Should().Be(3);
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Deploying project...");
+        wizardVm.Deploy();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(1000);
+        Dispatcher.UIThread.RunJobs();
+
+        var deployVm = wizardVm.DeployFlow;
+        var walletLoadDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTime.UtcNow < walletLoadDeadline && deployVm.Wallets.Count == 0)
+        {
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        deployVm.Wallets.Count.Should().BeGreaterThan(0);
+        deployVm.SelectWallet(deployVm.Wallets[0]);
+        Dispatcher.UIThread.RunJobs();
+        deployVm.PayWithWallet();
+
+        var deployDeadline = DateTime.UtcNow + TransactionTimeout;
+        while (DateTime.UtcNow < deployDeadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (deployVm.CurrentScreen == DeployScreen.Success)
+            {
+                break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        deployVm.CurrentScreen.Should().Be(DeployScreen.Success,
+            $"Deploy should reach success. Last status: {deployVm.DeployStatusText}");
+
+        deployVm.GoToMyProjects();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        await myProjectsVm.LoadFounderProjectsAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var project = myProjectsVm.Projects.FirstOrDefault(p =>
+            p.Description.Contains(runId, StringComparison.Ordinal));
+        project.Should().NotBeNull();
+        project!.ProjectIdentifier.Should().NotBeNullOrEmpty();
+        project.OwnerWalletId.Should().NotBeNullOrEmpty();
+
+        Log(profileName, $"Project deployed. ProjectId={project.ProjectIdentifier}");
+        return new ProjectHandle(runId, projectName, project.ProjectIdentifier!, project.OwnerWalletId!);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Profile and infrastructure helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    private async Task WithProfileWindow(
+        string profileName,
+        HashSet<string> initializedProfiles,
+        Func<Window, Task> action)
+    {
+        using var profileScope = TestProfileScope.For(profileName);
+        var window = TestHelpers.CreateShellWindow();
+
+        try
+        {
+            ValidateCurrentProfile(profileName);
+
+            if (!initializedProfiles.Contains(profileName))
+            {
+                Log(profileName, "First use for profile. Wiping existing data...");
+                await WipeExistingData(window, profileName);
+                initializedProfiles.Add(profileName);
+            }
+
+            SetPasswordProvider(profileName);
+            await action(window);
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(250);
+        }
+    }
+
+    private static void ValidateCurrentProfile(string expectedProfile)
+    {
+        var profileContext = global::App.App.Services.GetRequiredService<ProfileContext>();
+        profileContext.ProfileName.Should().Be(expectedProfile);
+    }
+
+    private static void SetPasswordProvider(string profileName)
+    {
+        var passwordProvider = global::App.App.Services.GetRequiredService<SimplePasswordProvider>();
+        passwordProvider.SetKey("default-key");
+        Log(profileName, "Set SimplePasswordProvider key to 'default-key'.");
+    }
+
+    private async Task CreateWalletAndFundAsync(Window window, string profileName)
+    {
+        window.NavigateToSection("Funds");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        if (!fundsVm!.SeedGroups.Any() || !fundsVm.SeedGroups.SelectMany(g => g.Wallets).Any())
+        {
+            Log(profileName, "Creating wallet via Generate flow...");
+            await CreateWalletViaGenerate(window, profileName);
+        }
+        else
+        {
+            Log(profileName, "Wallet already exists for this profile.");
+        }
+
+        var walletCardBtn = await window.WaitForWalletCard(TimeSpan.FromSeconds(30));
+        walletCardBtn.Should().NotBeNull();
+
+        Log(profileName, "Funding wallet via faucet...");
+        await FundWalletViaFaucet(window, profileName);
+    }
+
+    private async Task<ProjectItemViewModel> FindProjectFromSdkAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project)
+    {
+        window.NavigateToSection("Find Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var findProjectsVm = GetFindProjectsViewModel(window);
+        findProjectsVm.Should().NotBeNull();
+
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await findProjectsVm!.LoadProjectsFromSdkAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var foundProject = findProjectsVm.Projects.FirstOrDefault(p =>
+                string.Equals(p.ProjectId, project.ProjectIdentifier, StringComparison.Ordinal) ||
+                p.Description.Contains(project.RunId, StringComparison.Ordinal) ||
+                p.ShortDescription.Contains(project.RunId, StringComparison.Ordinal));
+
+            if (foundProject != null)
+            {
+                Log(profileName, $"Found project in SDK list: {foundProject.ProjectId}");
+                return foundProject;
+            }
+
+            Log(profileName, "Project not found in SDK yet. Retrying...");
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Project was not found in the SDK project list in time.");
+    }
+
+    private async Task WipeExistingData(Window window, string profileName)
+    {
+        window.NavigateToSettings();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+
+        var settingsView = window.GetVisualDescendants().OfType<SettingsView>().FirstOrDefault();
+        if (settingsView?.DataContext is SettingsViewModel settingsVm)
+        {
+            settingsVm.ConfirmWipeData();
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+            Log(profileName, "Profile data wiped.");
+        }
+    }
+
+    private async Task CreateWalletViaGenerate(Window window, string profileName)
+    {
+        var addWalletBtn = FindAddWalletButton(window);
+        addWalletBtn.Should().NotBeNull();
+
+        addWalletBtn!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, addWalletBtn));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(300);
+        Dispatcher.UIThread.RunJobs();
+
+        await window.ClickButton("BtnGenerate", UiTimeout);
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+        await window.ClickButton("BtnDownloadSeed", UiTimeout);
+        await Task.Delay(300);
+        Dispatcher.UIThread.RunJobs();
+        await window.ClickButton("BtnContinueBackup", UiTimeout);
+
+        var successPanel = await window.WaitForControl<StackPanel>("CreateWalletSuccessPanel", TimeSpan.FromSeconds(30));
+        successPanel.Should().NotBeNull();
+        await window.ClickButton("BtnCreateWalletDone", UiTimeout);
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Wallet created successfully.");
+    }
+
+    private async Task FundWalletViaFaucet(Window window, string profileName)
+    {
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        var walletId = fundsVm!.SeedGroups.FirstOrDefault()?.Wallets?.FirstOrDefault()?.Id.Value;
+        walletId.Should().NotBeNullOrEmpty();
+
+        var deadline = DateTime.UtcNow + FaucetBalanceTimeout;
+        var faucetRetryInterval = TimeSpan.FromSeconds(30);
+        var lastFaucetAttempt = DateTime.MinValue;
+        var faucetAttempts = 0;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+
+            if (fundsVm.TotalBalance != "0.0000")
+            {
+                Log(profileName, $"Non-zero balance detected: {fundsVm.TotalBalance}");
+                return;
+            }
+
+            if (DateTime.UtcNow - lastFaucetAttempt >= faucetRetryInterval)
+            {
+                faucetAttempts++;
+                lastFaucetAttempt = DateTime.UtcNow;
+                Log(profileName, $"Faucet attempt #{faucetAttempts}...");
+
+                (bool success, string? error) = await fundsVm.GetTestCoinsAsync(walletId!);
+                Dispatcher.UIThread.RunJobs();
+                Log(profileName, success ? "Faucet request accepted." : $"Faucet request failed: {error}");
+            }
+
+            await ClickWalletCardButton(window, "WalletCardBtnRefresh");
+            await Task.Delay(PollInterval);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        throw new InvalidOperationException("Wallet balance did not become non-zero in time.");
+    }
+
+    private async Task OpenCreateWizard(Window window, MyProjectsViewModel myProjectsVm, string profileName)
+    {
+        myProjectsVm.CreateProjectVm.ResetWizard();
+        myProjectsVm.LaunchCreateWizard();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        myProjectsVm.ShowCreateWizard.Should().BeTrue();
+        myProjectsVm.CreateProjectVm.OnProjectDeployed = () =>
+        {
+            myProjectsVm.OnProjectDeployed(myProjectsVm.CreateProjectVm);
+            myProjectsVm.CloseCreateWizard();
+        };
+
+        Log(profileName, "Create wizard opened.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Utility methods
+    // ═══════════════════════════════════════════════════════════════════
+
+    private static Button? FindAddWalletButton(Window window)
+    {
+        var buttons = window.GetVisualDescendants().OfType<Button>().Where(b => b.IsVisible);
+        foreach (var btn in buttons)
+        {
+            if (btn.Content is string text && text.Contains("Add Wallet", StringComparison.Ordinal))
+            {
+                return btn;
+            }
+
+            if (btn.Content is StackPanel panel)
+            {
+                foreach (var child in panel.Children.OfType<TextBlock>())
+                {
+                    if (child.Text == "Add Wallet")
+                    {
+                        return btn;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private async Task ClickWalletCardButton(Window window, string automationId)
+    {
+        var button = await window.WaitForControl<Button>(automationId, UiTimeout);
+        button.Should().NotBeNull();
+        button!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, button));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static FundsViewModel? GetFundsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FundsView>().FirstOrDefault()?.DataContext as FundsViewModel;
+    }
+
+    private static MyProjectsViewModel? GetMyProjectsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<MyProjectsView>().FirstOrDefault()?.DataContext as MyProjectsViewModel;
+    }
+
+    private static FindProjectsViewModel? GetFindProjectsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FindProjectsView>().FirstOrDefault()?.DataContext as FindProjectsViewModel;
+    }
+
+    private static void Log(string? profileName, string message)
+    {
+        var prefix = string.IsNullOrWhiteSpace(profileName) ? "GLOBAL" : profileName;
+        Console.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] [{prefix}] {message}");
+    }
+}

--- a/src/design/App.Test.Integration/InvestmentCancellationTest.md
+++ b/src/design/App.Test.Integration/InvestmentCancellationTest.md
@@ -2,41 +2,65 @@
 
 ## Purpose
 
-Full end-to-end integration test for the **investment cancellation** flow. CancelInvestmentRequest is implemented in the SDK and wired in the design app (PortfolioViewModel.CancelInvestmentAsync), but had zero E2E coverage. This test validates the complete cancel + fund-release + re-invest cycle.
+Full end-to-end integration test for the **investment cancellation** flow. CancelInvestmentRequest is implemented in the SDK and wired in the design app (PortfolioViewModel.CancelInvestmentAsync), but had zero E2E coverage. This test validates the complete cancel + fund-release + re-invest cycle across three distinct scenarios:
+
+1. **Cancel before founder approval** (Step 1 → Cancelled)
+2. **Cancel after founder approval** (Step 2 → Cancelled)
+3. **Confirm after founder approval** (Step 2 → Step 3, active investment)
 
 ## Profiles
 
-- Founder profile: `InvestCancel-Founder`
-- Investor profile: `InvestCancel-Investor`
+- Founder profile: `InvestmentCancellation-Founder`
+- Investor profile: `InvestmentCancellation-Investor`
 
 All profiles are created under the application's profile directory.
 
-## Scenario
+## Scenario (8 Phases)
 
-1. Founder profile creates a wallet, funds it via the signet faucet, and deploys a **Fund** project with a high approval threshold (`0.001 BTC`) so that investments above threshold require founder approval.
-2. Investor profile creates a wallet, funds it, and invests in the project with an amount **above** the approval threshold (`0.01 BTC`).
-3. The investment stays at Step 1 (pending founder approval), which makes it cancellable.
-4. Investor cancels the pending investment via `CancelInvestmentAsync`.
-5. The test verifies the investment status changes to "Cancelled" or is removed from the active list.
-6. The test verifies that the investor's balance is restored (funds released back).
-7. Investor re-invests in the same project to confirm the wallet and project remain functional after cancellation.
+### Phase 1 — Founder setup
+Founder creates a wallet, funds it via the signet faucet, and deploys a **Fund** project with 0.01 BTC approval threshold.
+
+### Phase 2 — Cancel before approval
+Investor creates a wallet, funds it, invests 0.02 BTC (above threshold → pending approval at Step 1), then cancels the pending investment before the founder approves. Verifies status = Cancelled and funds released.
+
+### Phase 3 — Re-invest after cancel
+Investor re-invests in the same project (new pending investment at Step 1).
+
+### Phase 4 — Founder approves
+Founder approves the pending investment request via the Funders section.
+
+### Phase 5 — Cancel after approval
+Investor cancels the approved investment (Step 2). Verifies status = Cancelled and funds released.
+
+### Phase 6 — Re-invest again
+Investor re-invests in the same project again.
+
+### Phase 7 — Founder approves again
+Founder approves the new pending investment request.
+
+### Phase 8 — Investor confirms
+Investor confirms the approved investment. Verifies investment reaches Step 3 (active).
 
 ## Key Validations
 
 - Above-threshold investment stays at Step 1 (pending) until founder approval.
-- `CancelInvestmentAsync` successfully cancels a pending investment.
+- `CancelInvestmentAsync` successfully cancels a pending investment (Step 1).
+- `CancelInvestmentAsync` successfully cancels an approved investment (Step 2).
 - Investment status transitions to "Cancelled" after cancellation.
 - Investor balance is restored after cancellation (funds released).
 - Re-investment after cancellation succeeds, proving no state corruption.
-- Project remains investable after a cancelled investment.
+- Founder approval flow works end-to-end via `ApprovePendingInvestmentAsync`.
+- Investor confirmation flow works end-to-end via `ConfirmApprovedInvestmentAsync`.
+- The full 3-step lifecycle (invest → approve → confirm) completes successfully.
 
 ## Notes
 
 - The test reuses the real headless Avalonia app and switches profiles by rebuilding DI per profile.
-- Above-threshold investments are used specifically because they stay at Step 1 (pending) until founder approval, making them cancellable without needing the founder to sign first.
-- Balance restoration is verified with a tolerance for transaction fees.
-- The re-investment phase proves the full cycle is idempotent and the wallet/project state is clean after cancellation.
+- Multiple `WithProfileWindow` calls are used to switch between Founder and Investor profiles across phases.
+- Above-threshold investments (0.02 BTC > 0.01 threshold) require founder approval, keeping them at Step 1 until approved.
+- The founder approval pattern uses `FundersViewModel.LoadInvestmentRequestsAsync()`, `SetFilter("waiting")`, and `ApproveSignature(id)`.
 - IndexerLagTimeout (5 minutes) is used for polling because signet mempool propagation can be slow.
+- The test may take 3-10 minutes depending on network conditions.
 
 ## Run
 

--- a/src/design/App.Test.Integration/InvestmentCancellationTest.md
+++ b/src/design/App.Test.Integration/InvestmentCancellationTest.md
@@ -1,0 +1,51 @@
+# InvestmentCancellationTest
+
+## Purpose
+
+Full end-to-end integration test for the **investment cancellation** flow. CancelInvestmentRequest is implemented in the SDK and wired in the design app (PortfolioViewModel.CancelInvestmentAsync), but had zero E2E coverage. This test validates the complete cancel + fund-release + re-invest cycle.
+
+## Profiles
+
+- Founder profile: `InvestCancel-Founder`
+- Investor profile: `InvestCancel-Investor`
+
+All profiles are created under the application's profile directory.
+
+## Scenario
+
+1. Founder profile creates a wallet, funds it via the signet faucet, and deploys a **Fund** project with a high approval threshold (`0.001 BTC`) so that investments above threshold require founder approval.
+2. Investor profile creates a wallet, funds it, and invests in the project with an amount **above** the approval threshold (`0.01 BTC`).
+3. The investment stays at Step 1 (pending founder approval), which makes it cancellable.
+4. Investor cancels the pending investment via `CancelInvestmentAsync`.
+5. The test verifies the investment status changes to "Cancelled" or is removed from the active list.
+6. The test verifies that the investor's balance is restored (funds released back).
+7. Investor re-invests in the same project to confirm the wallet and project remain functional after cancellation.
+
+## Key Validations
+
+- Above-threshold investment stays at Step 1 (pending) until founder approval.
+- `CancelInvestmentAsync` successfully cancels a pending investment.
+- Investment status transitions to "Cancelled" after cancellation.
+- Investor balance is restored after cancellation (funds released).
+- Re-investment after cancellation succeeds, proving no state corruption.
+- Project remains investable after a cancelled investment.
+
+## Notes
+
+- The test reuses the real headless Avalonia app and switches profiles by rebuilding DI per profile.
+- Above-threshold investments are used specifically because they stay at Step 1 (pending) until founder approval, making them cancellable without needing the founder to sign first.
+- Balance restoration is verified with a tolerance for transaction fees.
+- The re-investment phase proves the full cycle is idempotent and the wallet/project state is clean after cancellation.
+- IndexerLagTimeout (5 minutes) is used for polling because signet mempool propagation can be slow.
+
+## Run
+
+```bash
+dotnet test "src/design/App.Test.Integration/App.Test.Integration.csproj" --filter "FullyQualifiedName~InvestmentCancellationTest"
+```
+
+Verbose:
+
+```bash
+dotnet test "src/design/App.Test.Integration/App.Test.Integration.csproj" --filter "FullyQualifiedName~InvestmentCancellationTest" --logger "console;verbosity=detailed"
+```

--- a/src/design/App.Test.Integration/WalletImportAndProjectScanTest.cs
+++ b/src/design/App.Test.Integration/WalletImportAndProjectScanTest.cs
@@ -1,0 +1,658 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FluentAssertions;
+using Angor.Sdk.Common;
+using Angor.Sdk.Funding.Projects;
+using App.Composition.Adapters;
+using App.Test.Integration.Helpers;
+using App.UI.Sections.FindProjects;
+using App.UI.Sections.Funds;
+using App.UI.Sections.MyProjects;
+using App.UI.Sections.MyProjects.Deploy;
+using App.UI.Sections.Settings;
+using App.UI.Shell;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace App.Test.Integration;
+
+/// <summary>
+/// End-to-end integration test that validates wallet import from seed words
+/// and the ScanFounderProjects flow. This is the most critical recovery path
+/// a user needs after device loss.
+///
+/// Flow:
+///   Profile A (Creator):
+///     1. Wipe data, create wallet via Generate, fund via faucet
+///     2. Create and deploy a fund project
+///     3. Record the seed words and project identifier
+///
+///   Profile B (Importer):
+///     4. Wipe data, import wallet using the same seed words
+///     5. Verify wallet ID is identical (deterministic from xpub hash)
+///     6. Verify balance is discoverable from on-chain data
+///     7. Trigger ScanFounderProjects
+///     8. Verify the deployed project appears in My Projects
+///
+/// This validates:
+///   - Mnemonic import produces the same deterministic wallet ID
+///   - Derived project keys are correctly regenerated for the network
+///   - ScanFounderProjects correctly queries the indexer for all 15 key slots
+///   - Local DB (FounderProjectsDocument) is populated from scan results
+///   - Balance refresh discovers existing UTXOs after import
+///
+/// Uses real testnet infrastructure (indexer + faucet + Nostr relays).
+/// May take 120-300 seconds depending on network conditions.
+/// </summary>
+public class WalletImportAndProjectScanTest
+{
+    private const string TestName = "WalletImportAndProjectScan";
+    private const string CreatorProfile = TestName + "-Creator";
+    private const string ImporterProfile = TestName + "-Importer";
+
+    private static readonly TimeSpan FaucetBalanceTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan TransactionTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan UiTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan IndexerLagTimeout = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Carries state between profile windows: seed words, wallet ID, project details.
+    /// </summary>
+    private sealed record CreatorState(
+        string SeedWords,
+        string WalletId,
+        string RunId,
+        string ProjectName,
+        string ProjectIdentifier);
+
+    [AvaloniaFact]
+    public async Task ImportWalletAndScanFounderProjects()
+    {
+        var initializedProfiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var runId = Guid.NewGuid().ToString("N")[..12];
+        var projectName = $"Import Scan {runId}";
+        var projectAbout = $"{TestName} run {runId}. Validates wallet import from seed and project scan.";
+        var bannerImageUrl = $"https://picsum.photos/seed/{Guid.NewGuid().ToString("N")[..8]}/320/200";
+        var profileImageUrl = $"https://picsum.photos/seed/{Guid.NewGuid().ToString("N")[..8]}/100/100";
+        var payoutDay = DateTime.UtcNow.DayOfWeek.ToString();
+
+        Log(null, $"========== STARTING {nameof(ImportWalletAndScanFounderProjects)} ==========");
+        Log(null, $"Run ID: {runId}");
+        Log(null, $"Creator profile: {CreatorProfile}");
+        Log(null, $"Importer profile: {ImporterProfile}");
+
+        CreatorState? creatorState = null;
+
+        // ──────────────────────────────────────────────────────────────
+        // PHASE 1: Creator — generate wallet, fund it, deploy a project
+        // ──────────────────────────────────────────────────────────────
+        await WithProfileWindow(CreatorProfile, initializedProfiles, async window =>
+        {
+            creatorState = await CreateWalletFundAndDeployAsync(
+                window,
+                CreatorProfile,
+                projectName,
+                projectAbout,
+                bannerImageUrl,
+                profileImageUrl,
+                payoutDay,
+                runId);
+        });
+
+        creatorState.Should().NotBeNull("Creator phase should produce state with seed words and project info");
+        Log(null, $"Creator phase complete. WalletId={creatorState!.WalletId}, ProjectId={creatorState.ProjectIdentifier}");
+        Log(null, $"Seed words recorded ({creatorState.SeedWords.Split(' ').Length} words)");
+
+        // ──────────────────────────────────────────────────────────────
+        // PHASE 2: Importer — import wallet from same seed, scan projects
+        // ──────────────────────────────────────────────────────────────
+        await WithProfileWindow(ImporterProfile, initializedProfiles, async window =>
+        {
+            await ImportWalletAndVerifyProjectScanAsync(window, ImporterProfile, creatorState);
+        });
+
+        Log(null, $"========== {nameof(ImportWalletAndScanFounderProjects)} PASSED ==========");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Phase 1: Creator — generate, fund, deploy
+    // ═══════════════════════════════════════════════════════════════════
+
+    private async Task<CreatorState> CreateWalletFundAndDeployAsync(
+        Window window,
+        string profileName,
+        string projectName,
+        string projectAbout,
+        string bannerImageUrl,
+        string profileImageUrl,
+        string payoutDay,
+        string runId)
+    {
+        // ── Step 1: Create wallet and capture seed words ──
+        window.NavigateToSection("Funds");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Creating wallet via Generate flow and capturing seed words...");
+        var seedWords = await CreateWalletAndCaptureSeed(window, profileName);
+        seedWords.Should().NotBeNullOrEmpty("Seed words should be captured during wallet generation");
+        Log(profileName, $"Seed words captured: {seedWords.Split(' ').Length} words");
+
+        var walletCardBtn = await window.WaitForWalletCard(TimeSpan.FromSeconds(30));
+        walletCardBtn.Should().NotBeNull("WalletCard should appear after wallet creation");
+
+        // ── Step 2: Get the wallet ID ──
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        var walletId = fundsVm!.SeedGroups.FirstOrDefault()?.Wallets?.FirstOrDefault()?.Id.Value;
+        walletId.Should().NotBeNullOrEmpty("Wallet should have an ID after creation");
+        Log(profileName, $"Creator wallet ID: {walletId}");
+
+        // ── Step 3: Fund via faucet ──
+        Log(profileName, "Funding wallet via faucet...");
+        await FundWalletViaFaucet(window, profileName);
+
+        SetPasswordProvider(profileName);
+
+        // ── Step 4: Create and deploy a project ──
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var myProjectsVm = GetMyProjectsViewModel(window);
+        myProjectsVm.Should().NotBeNull();
+
+        await OpenCreateWizard(window, myProjectsVm!, profileName);
+
+        var wizardVm = myProjectsVm!.CreateProjectVm;
+        wizardVm.Should().NotBeNull();
+
+        // Step 4.1: Select fund type
+        Log(profileName, "Selecting Fund project type...");
+        wizardVm.DismissWelcome();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        wizardVm.SelectProjectType("fund");
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        // Step 4.2: Project profile
+        Log(profileName, $"Setting project metadata: {projectName}");
+        wizardVm.ProjectName = projectName;
+        wizardVm.ProjectAbout = projectAbout;
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        // Step 4.3: Images
+        Log(profileName, "Setting project images...");
+        wizardVm.BannerUrl = bannerImageUrl;
+        wizardVm.ProfileUrl = profileImageUrl;
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        // Step 4.4: Funding config
+        Log(profileName, "Configuring target amount and threshold...");
+        wizardVm.TargetAmount = "1.0";
+        wizardVm.ApprovalThreshold = "0.01";
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        // Step 4.5: Payout schedule
+        Log(profileName, "Configuring payout schedule...");
+        wizardVm.DismissStep5Welcome();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        wizardVm.PayoutFrequency = "Weekly";
+        wizardVm.ToggleInstallmentCount(3);
+        wizardVm.WeeklyPayoutDay = payoutDay;
+        wizardVm.GeneratePayoutSchedule();
+        wizardVm.Stages.Count.Should().Be(3);
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        // Step 4.6: Deploy
+        Log(profileName, "Deploying project...");
+        wizardVm.Deploy();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(1000);
+        Dispatcher.UIThread.RunJobs();
+
+        var deployVm = wizardVm.DeployFlow;
+        var walletLoadDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTime.UtcNow < walletLoadDeadline && deployVm.Wallets.Count == 0)
+        {
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        deployVm.Wallets.Count.Should().BeGreaterThan(0);
+        deployVm.SelectWallet(deployVm.Wallets[0]);
+        Dispatcher.UIThread.RunJobs();
+        deployVm.PayWithWallet();
+
+        var deployDeadline = DateTime.UtcNow + TransactionTimeout;
+        while (DateTime.UtcNow < deployDeadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (deployVm.CurrentScreen == DeployScreen.Success)
+            {
+                break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        deployVm.CurrentScreen.Should().Be(DeployScreen.Success,
+            $"Deploy should reach success. Last status: {deployVm.DeployStatusText}");
+
+        deployVm.GoToMyProjects();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        // ── Step 5: Get the project identifier ──
+        await myProjectsVm.LoadFounderProjectsAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var project = myProjectsVm.Projects.FirstOrDefault(p =>
+            p.Description.Contains(runId, StringComparison.Ordinal));
+        project.Should().NotBeNull($"Project with run ID '{runId}' should appear in My Projects");
+        project!.ProjectIdentifier.Should().NotBeNullOrEmpty("Project should have an identifier after founder reload");
+        project.Name.Should().Be(projectName);
+        Log(profileName, $"Project deployed. ProjectId={project.ProjectIdentifier}, Name={project.Name}");
+
+        return new CreatorState(seedWords, walletId!, runId, projectName, project.ProjectIdentifier!);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Phase 2: Importer — import from seed, verify wallet ID, scan
+    // ═══════════════════════════════════════════════════════════════════
+
+    private async Task ImportWalletAndVerifyProjectScanAsync(
+        Window window,
+        string profileName,
+        CreatorState creatorState)
+    {
+        // ── Step 1: Import wallet from seed words ──
+        window.NavigateToSection("Funds");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Importing wallet from creator's seed words...");
+        await ImportWalletViaSeedWords(window, profileName, creatorState.SeedWords);
+
+        var walletCardBtn = await window.WaitForWalletCard(TimeSpan.FromSeconds(30));
+        walletCardBtn.Should().NotBeNull("WalletCard should appear after wallet import");
+
+        // ── Step 2: Verify wallet ID is identical ──
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        var importedWalletId = fundsVm!.SeedGroups.FirstOrDefault()?.Wallets?.FirstOrDefault()?.Id.Value;
+        importedWalletId.Should().NotBeNullOrEmpty("Imported wallet should have an ID");
+        importedWalletId.Should().Be(creatorState.WalletId,
+            "Imported wallet should have the same deterministic wallet ID (derived from xpub hash)");
+        Log(profileName, $"Wallet ID match confirmed: {importedWalletId}");
+
+        SetPasswordProvider(profileName);
+
+        // ── Step 3: Wait for balance to appear (on-chain UTXO discovery) ──
+        Log(profileName, "Waiting for balance to appear from on-chain UTXO discovery...");
+        var balanceDeadline = DateTime.UtcNow + FaucetBalanceTimeout;
+        while (DateTime.UtcNow < balanceDeadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+
+            if (fundsVm.TotalBalance != "0.0000")
+            {
+                Log(profileName, $"Balance discovered: {fundsVm.TotalBalance}");
+                break;
+            }
+
+            await ClickWalletCardButton(window, "WalletCardBtnRefresh");
+            await Task.Delay(PollInterval);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        fundsVm.TotalBalance.Should().NotBe("0.0000",
+            "Imported wallet should discover on-chain UTXOs and show non-zero balance");
+
+        // ── Step 4: Navigate to My Projects — should be empty before scan ──
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var myProjectsVm = GetMyProjectsViewModel(window);
+        myProjectsVm.Should().NotBeNull();
+
+        // Load founder projects from local DB — should be empty since this is a fresh profile
+        await myProjectsVm!.LoadFounderProjectsAsync();
+        Dispatcher.UIThread.RunJobs();
+        Log(profileName, $"Projects before scan: {myProjectsVm.Projects.Count}");
+
+        // ── Step 5: Scan for founder projects ──
+        Log(profileName, "Scanning for founder projects (ScanFounderProjects)...");
+        await myProjectsVm.ScanForProjectsAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        // Wait for the scan results to populate — the indexer may take time
+        MyProjectItemViewModel? scannedProject = null;
+        var scanDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < scanDeadline)
+        {
+            await myProjectsVm.ScanForProjectsAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            scannedProject = myProjectsVm.Projects.FirstOrDefault(p =>
+                string.Equals(p.ProjectIdentifier, creatorState.ProjectIdentifier, StringComparison.Ordinal) ||
+                p.Description.Contains(creatorState.RunId, StringComparison.Ordinal));
+
+            if (scannedProject != null)
+            {
+                break;
+            }
+
+            Log(profileName, $"Project not found in scan yet ({myProjectsVm.Projects.Count} project(s)). Retrying...");
+            await Task.Delay(PollInterval);
+        }
+
+        // ── Step 6: Verify the scanned project matches ──
+        scannedProject.Should().NotBeNull(
+            $"ScanFounderProjects should discover the project deployed by the creator (run ID: {creatorState.RunId})");
+        scannedProject!.Name.Should().Be(creatorState.ProjectName,
+            "Scanned project name should match the original");
+        scannedProject.ProjectIdentifier.Should().Be(creatorState.ProjectIdentifier,
+            "Scanned project identifier should match the original");
+
+        Log(profileName, $"Project scan successful! Found: '{scannedProject.Name}' (ID: {scannedProject.ProjectIdentifier})");
+        Log(profileName, "Wallet import + project scan test completed successfully.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Wallet helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Create a wallet via the Generate flow, but capture the seed words
+    /// from the SeedPhraseDisplay before confirming.
+    /// </summary>
+    private async Task<string> CreateWalletAndCaptureSeed(Window window, string profileName)
+    {
+        var addWalletBtn = FindAddWalletButton(window);
+        addWalletBtn.Should().NotBeNull("Should find the Add Wallet button");
+
+        addWalletBtn!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, addWalletBtn));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(300);
+        Dispatcher.UIThread.RunJobs();
+
+        // Click Generate New
+        await window.ClickButton("BtnGenerate", UiTimeout);
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+
+        // BackupPanel should now be visible with the seed phrase
+        var backupPanel = await window.WaitForControl<StackPanel>("BackupPanel", UiTimeout);
+        backupPanel.Should().NotBeNull("Backup panel should be visible after clicking Generate New");
+
+        // Capture seed words from the SeedPhraseDisplay TextBlock
+        var seedDisplay = window.GetVisualDescendants()
+            .OfType<TextBlock>()
+            .FirstOrDefault(tb => tb.Name == "SeedPhraseDisplay");
+        seedDisplay.Should().NotBeNull("SeedPhraseDisplay TextBlock should exist in BackupPanel");
+        var seedWords = seedDisplay!.Text ?? "";
+        seedWords.Should().NotBeNullOrEmpty("Seed phrase should be displayed");
+        seedWords.Split(' ').Length.Should().BeOneOf(new[] { 12, 24 }, "Seed phrase should be 12 or 24 words");
+        Log(profileName, $"Captured seed phrase ({seedWords.Split(' ').Length} words)");
+
+        // Click Download Seed (skipped in headless but enables Continue)
+        await window.ClickButton("BtnDownloadSeed", UiTimeout);
+        await Task.Delay(300);
+        Dispatcher.UIThread.RunJobs();
+
+        // Click Continue to create wallet
+        await window.ClickButton("BtnContinueBackup", UiTimeout);
+
+        var successPanel = await window.WaitForControl<StackPanel>("CreateWalletSuccessPanel", TimeSpan.FromSeconds(30));
+        successPanel.Should().NotBeNull("Success panel should appear after wallet generation");
+
+        await window.ClickButton("BtnCreateWalletDone", UiTimeout);
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Wallet created and seed words captured.");
+        return seedWords;
+    }
+
+    /// <summary>
+    /// Import a wallet by entering seed words into the Import modal flow.
+    /// Uses the CreateWalletModal's Import path: ChoicePanel → ImportPanel → SuccessPanel.
+    /// </summary>
+    private async Task ImportWalletViaSeedWords(Window window, string profileName, string seedWords)
+    {
+        var addWalletBtn = FindAddWalletButton(window);
+        addWalletBtn.Should().NotBeNull("Should find the Add Wallet button for import");
+
+        addWalletBtn!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, addWalletBtn));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(300);
+        Dispatcher.UIThread.RunJobs();
+
+        // Click Import
+        await window.ClickButton("BtnImport", UiTimeout);
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+
+        // ImportPanel should now be visible
+        var importPanel = await window.WaitForControl<StackPanel>("ImportPanel", UiTimeout);
+        importPanel.Should().NotBeNull("Import panel should be visible after clicking Import");
+
+        // Enter seed words into the SeedPhraseInput TextBox
+        var seedInput = window.GetVisualDescendants()
+            .OfType<TextBox>()
+            .FirstOrDefault(tb => tb.Name == "SeedPhraseInput");
+        seedInput.Should().NotBeNull("SeedPhraseInput TextBox should exist in ImportPanel");
+        seedInput!.Text = seedWords;
+        Dispatcher.UIThread.RunJobs();
+        Log(profileName, $"Entered {seedWords.Split(' ').Length} seed words into import field");
+
+        // Click Submit Import
+        await window.ClickButton("BtnSubmitImport", UiTimeout);
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        // Wait for success panel
+        var successPanel = await window.WaitForControl<StackPanel>("CreateWalletSuccessPanel", TimeSpan.FromSeconds(30));
+        successPanel.Should().NotBeNull("Success panel should appear after wallet import");
+        Log(profileName, "Import succeeded — SuccessPanel visible");
+
+        await window.ClickButton("BtnCreateWalletDone", UiTimeout);
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Wallet imported successfully.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Profile and infrastructure helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    private async Task WithProfileWindow(
+        string profileName,
+        HashSet<string> initializedProfiles,
+        Func<Window, Task> action)
+    {
+        using var profileScope = TestProfileScope.For(profileName);
+        var window = TestHelpers.CreateShellWindow();
+
+        try
+        {
+            ValidateCurrentProfile(profileName);
+
+            if (!initializedProfiles.Contains(profileName))
+            {
+                Log(profileName, "First use for profile. Wiping existing data...");
+                await WipeExistingData(window, profileName);
+                initializedProfiles.Add(profileName);
+            }
+
+            SetPasswordProvider(profileName);
+            await action(window);
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(250);
+        }
+    }
+
+    private static void ValidateCurrentProfile(string expectedProfile)
+    {
+        var profileContext = global::App.App.Services.GetRequiredService<ProfileContext>();
+        profileContext.ProfileName.Should().Be(expectedProfile);
+    }
+
+    private static void SetPasswordProvider(string profileName)
+    {
+        var passwordProvider = global::App.App.Services.GetRequiredService<SimplePasswordProvider>();
+        passwordProvider.SetKey("default-key");
+        Log(profileName, "Set SimplePasswordProvider key to 'default-key'.");
+    }
+
+    private async Task WipeExistingData(Window window, string profileName)
+    {
+        window.NavigateToSettings();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+
+        var settingsView = window.GetVisualDescendants().OfType<SettingsView>().FirstOrDefault();
+        if (settingsView?.DataContext is SettingsViewModel settingsVm)
+        {
+            settingsVm.ConfirmWipeData();
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+            Log(profileName, "Profile data wiped.");
+        }
+    }
+
+    private async Task FundWalletViaFaucet(Window window, string profileName)
+    {
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        var walletId = fundsVm!.SeedGroups.FirstOrDefault()?.Wallets?.FirstOrDefault()?.Id.Value;
+        walletId.Should().NotBeNullOrEmpty();
+
+        var deadline = DateTime.UtcNow + FaucetBalanceTimeout;
+        var faucetRetryInterval = TimeSpan.FromSeconds(30);
+        var lastFaucetAttempt = DateTime.MinValue;
+        var faucetAttempts = 0;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+
+            if (fundsVm.TotalBalance != "0.0000")
+            {
+                Log(profileName, $"Non-zero balance detected: {fundsVm.TotalBalance}");
+                return;
+            }
+
+            if (DateTime.UtcNow - lastFaucetAttempt >= faucetRetryInterval)
+            {
+                faucetAttempts++;
+                lastFaucetAttempt = DateTime.UtcNow;
+                Log(profileName, $"Faucet attempt #{faucetAttempts}...");
+
+                (bool success, string? error) = await fundsVm.GetTestCoinsAsync(walletId!);
+                Dispatcher.UIThread.RunJobs();
+                Log(profileName, success ? "Faucet request accepted." : $"Faucet request failed: {error}");
+            }
+
+            await ClickWalletCardButton(window, "WalletCardBtnRefresh");
+            await Task.Delay(PollInterval);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        throw new InvalidOperationException("Wallet balance did not become non-zero in time.");
+    }
+
+    private async Task OpenCreateWizard(Window window, MyProjectsViewModel myProjectsVm, string profileName)
+    {
+        myProjectsVm.CreateProjectVm.ResetWizard();
+        myProjectsVm.LaunchCreateWizard();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        myProjectsVm.ShowCreateWizard.Should().BeTrue();
+        myProjectsVm.CreateProjectVm.OnProjectDeployed = () =>
+        {
+            myProjectsVm.OnProjectDeployed(myProjectsVm.CreateProjectVm);
+            myProjectsVm.CloseCreateWizard();
+        };
+
+        Log(profileName, "Create wizard opened.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Utility methods
+    // ═══════════════════════════════════════════════════════════════════
+
+    private static Button? FindAddWalletButton(Window window)
+    {
+        var buttons = window.GetVisualDescendants().OfType<Button>().Where(b => b.IsVisible);
+        foreach (var btn in buttons)
+        {
+            if (btn.Content is string text && text.Contains("Add Wallet", StringComparison.Ordinal))
+            {
+                return btn;
+            }
+
+            if (btn.Content is StackPanel panel)
+            {
+                foreach (var child in panel.Children.OfType<TextBlock>())
+                {
+                    if (child.Text == "Add Wallet")
+                    {
+                        return btn;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private async Task ClickWalletCardButton(Window window, string automationId)
+    {
+        var button = await window.WaitForControl<Button>(automationId, UiTimeout);
+        button.Should().NotBeNull();
+        button!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, button));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static FundsViewModel? GetFundsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FundsView>().FirstOrDefault()?.DataContext as FundsViewModel;
+    }
+
+    private static MyProjectsViewModel? GetMyProjectsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<MyProjectsView>().FirstOrDefault()?.DataContext as MyProjectsViewModel;
+    }
+
+    private static void Log(string? profileName, string message)
+    {
+        var prefix = string.IsNullOrWhiteSpace(profileName) ? "GLOBAL" : profileName;
+        Console.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] [{prefix}] {message}");
+    }
+}

--- a/src/design/App.Test.Integration/WalletImportAndProjectScanTest.md
+++ b/src/design/App.Test.Integration/WalletImportAndProjectScanTest.md
@@ -1,0 +1,49 @@
+# WalletImportAndProjectScanTest
+
+## Purpose
+
+Full end-to-end integration test for **wallet import from seed words** and the **ScanFounderProjects** flow. This validates the most critical recovery path a user needs after device loss: importing a seed phrase on a new device and rediscovering their founder projects.
+
+## Profiles
+
+- Creator profile: `WalletImportScan-Creator`
+- Importer profile: `WalletImportScan-Importer`
+
+All profiles are created under the application's profile directory.
+
+## Scenario
+
+1. Creator profile generates a new wallet, captures the seed words from the backup screen, and funds the wallet via the signet faucet.
+2. Creator deploys a **Fund** project with a single stage, recording the project identifier.
+3. Importer profile imports the same seed words via the wallet Import flow (ChoicePanel -> BtnImport -> SeedPhraseInput -> BtnSubmitImport).
+4. The test verifies that the imported wallet produces the same WalletId as the original (deterministic derivation from xpub hash).
+5. Importer refreshes balance and verifies the same funds are visible.
+6. Importer runs ScanForProjectsAsync to rediscover founder projects from the blockchain.
+7. The test asserts the originally-deployed project appears in the importer's MyProjects list.
+
+## Key Validations
+
+- Wallet import UI flow completes successfully through all panels (Choice -> Import -> Success).
+- Imported wallet WalletId matches the originally-generated wallet (same seed = same identity).
+- Balance is preserved across import (same UTXOs visible).
+- ScanFounderProjects discovers the project deployed by the same seed/key on a different profile.
+- Project identifier matches the originally-deployed project.
+
+## Notes
+
+- The test reuses the real headless Avalonia app and switches profiles by rebuilding DI per profile.
+- Seed words are captured from the `SeedPhraseDisplay` TextBlock during the Generate flow's BackupPanel.
+- The wallet import path uses name-based TextBox lookup for `SeedPhraseInput` since the TextBox is identified by Name rather than AutomationId.
+- ScanForProjectsAsync iterates all 15 derived key slots against the indexer, so it requires the project creation transaction to be indexed.
+
+## Run
+
+```bash
+dotnet test "src/design/App.Test.Integration/App.Test.Integration.csproj" --filter "FullyQualifiedName~WalletImportAndProjectScanTest"
+```
+
+Verbose:
+
+```bash
+dotnet test "src/design/App.Test.Integration/App.Test.Integration.csproj" --filter "FullyQualifiedName~WalletImportAndProjectScanTest" --logger "console;verbosity=detailed"
+```


### PR DESCRIPTION
## Summary

- Add **WalletImportAndProjectScanTest** (Priority 3 from #749): validates seed import UI flow, wallet identity determinism (same seed = same WalletId), balance preservation, and ScanFounderProjects discovery after device loss recovery.
- Add **InvestmentCancellationTest** (Priority 4 from #749): validates above-threshold pending investment cancellation via `CancelInvestmentAsync`, fund release back to investor, and successful re-investment after cancel — this path previously had zero E2E coverage.
- Both tests follow the multi-profile `WithProfileWindow` pattern and include companion markdown documentation.

## Test Results

All 9 integration tests pass (including the 2 new ones):

| Test | Duration |
|------|----------|
| SmokeTest (2) | <1s |
| CreateProjectTest | 27s |
| SendToSelfTest | ~29s |
| **WalletImportAndProjectScanTest** | 33s |
| **InvestmentCancellationTest** | ~50s |
| FundAndRecoverTest | ~1m 22s |
| MultiFundClaimAndRecoverTest | ~1m 56s |
| MultiInvestClaimAndRecoverTest | ~2m 29s |

## New Files

- `src/design/App.Test.Integration/WalletImportAndProjectScanTest.cs` (~658 lines)
- `src/design/App.Test.Integration/WalletImportAndProjectScanTest.md`
- `src/design/App.Test.Integration/InvestmentCancellationTest.cs` (~754 lines)
- `src/design/App.Test.Integration/InvestmentCancellationTest.md`