### PR TITLE
Switch to new GraphWizard API

### DIFF
--- a/src/avalonia/AngorApp/UI/Flows/CreateProject/CreateProjectFlow.cs
+++ b/src/avalonia/AngorApp/UI/Flows/CreateProject/CreateProjectFlow.cs
@@ -10,13 +10,11 @@ using AngorApp.UI.Flows.CreateProject.Wizard.InvestmentProject.Stages;
 using AngorApp.UI.Flows.CreateProject.Wizard.FundProject;
 using AngorApp.UI.Flows.CreateProject.Wizard.FundProject.Model;
 using AngorApp.UI.Flows.CreateProject.Wizard.FundProject.Payouts;
+using System.Reactive.Threading.Tasks;
 using Serilog;
 using Zafiro.Avalonia.Dialogs;
-using Zafiro.Avalonia.Controls.Wizards.Slim;
+using Zafiro.Avalonia.Wizards.Graph.Core;
 using Zafiro.UI.Navigation;
-using Zafiro.UI.Wizards.Slim;
-using Zafiro.UI.Wizards.Slim.Builder;
-using Avalonia.Threading;
 
 namespace AngorApp.UI.Flows.CreateProject
 {
@@ -41,16 +39,8 @@ namespace AngorApp.UI.Flows.CreateProject
 
         private async Task<Result<Maybe<string>>> Create(WalletId walletId, ProjectSeedDto seed)
         {
-            SlimWizard<string> rootWizard = WizardBuilder
-                                            .StartWith(() => new WelcomeViewModel()).NextCommand(model => model.Start)
-                                            .Then(_ => new ProjectTypeViewModel())
-                                            .NextCommand<Unit, ProjectTypeViewModel, string>(vm => CreateProjectOfType(
-                                                vm,
-                                                walletId,
-                                                seed))
-                                            .Build(StepKind.Commit);
-
-            var result = await rootWizard.Navigate(navigator);
+            var wizard = CreateProjectWizard(walletId, seed);
+            var result = await wizard.Navigate(navigator);
 
             if (result.HasValue)
             {
@@ -65,81 +55,131 @@ namespace AngorApp.UI.Flows.CreateProject
             return result;
         }
 
-        private IEnhancedCommand<Result<string>> CreateProjectOfType(
-            ProjectTypeViewModel vm,
-            WalletId walletId,
-            ProjectSeedDto seed
-        )
+        private GraphWizard<string> CreateProjectWizard(WalletId walletId, ProjectSeedDto seed)
         {
-            var canExecute = vm.WhenAnyValue(x => x.ProjectType).Select(x => x != null);
+            var flow = GraphWizard.For<string>();
+            var investmentWizard = CreateInvestmentProjectWizard(walletId, seed);
+            var fundWizard = CreateFundProjectWizard(walletId, seed);
 
-            return ReactiveCommand.CreateFromTask(async () =>
-            {
-                var projectType = vm.ProjectType;
-                return await Dispatcher.UIThread.InvokeAsync(() => projectType.Name switch
-                {
-                    "Investment" => CreateInvestmentProjectWizard(walletId, seed).Navigate(navigator).ToResult("Wizard was cancelled by user"),
-                    "Fund" => CreateFundProjectWizard(walletId, seed).Navigate(navigator).ToResult("Wizard was cancelled by user"),
-                    _ => throw new NotImplementedException($"Project type {projectType.Name} not implemented")
-                });
-            }, canExecute).Enhance();
+            var projectType = new ProjectTypeViewModel();
+            var projectTypeNode = flow
+                .Step(projectType, projectType.Title)
+                .Next(
+                    vm => vm.ProjectType.Name switch
+                    {
+                        "Investment" => investmentWizard,
+                        "Fund" => fundWizard,
+                        _ => throw new NotImplementedException($"Project type {vm.ProjectType.Name} not implemented"),
+                    },
+                    canExecute: projectType.WhenAnyValue(x => x.ProjectType).Select(x => x != null))
+                .Build();
+
+            var welcome = new WelcomeViewModel();
+            var welcomeNode = flow
+                .Step(welcome, welcome.Title)
+                .Next(_ => projectTypeNode, nextLabel: "Start")
+                .Build();
+
+            return new GraphWizard<string>(welcomeNode);
         }
 
-        private SlimWizard<string> CreateInvestmentProjectWizard(WalletId walletId, ProjectSeedDto seed)
+        private IWizardNode<string> CreateInvestmentProjectWizard(WalletId walletId, ProjectSeedDto seed)
         {
+            var flow = GraphWizard.For<string>();
             var isDebug = !uiServices.EnableProductionValidations();
             var environment = isDebug ? ValidationEnvironment.Debug : ValidationEnvironment.Production;
             InvestmentProjectConfigBase newProject = isDebug ? new InvestmentProjectConfigDebug() : new InvestmentProjectConfig();
 
             Action? prefillAction = isDebug ? () => PopulateInvestDebugDefaults(newProject) : null;
 
-            SlimWizard<string> wizard = WizardBuilder
-                                        .StartWith(() => new ProjectProfileViewModel(newProject, prefillAction)).NextUnit().WhenValid()
-                                        .Then(_ => new ProjectImagesViewModel(newProject, imagePicker)).NextUnit().Always()
-                                        .Then(_ => new FundingConfigurationViewModel(newProject, environment)).NextUnit().WhenValid()
-                                        .Then(_ => new StagesViewModel(newProject)).NextUnit().WhenValid()
-                                        .Then(_ => new ReviewAndDeployViewModel(
-                                                  newProject,
-                                                  new ProjectDeploymentOrchestrator(
-                                                      projectAppService,
-                                                      founderAppService,
-                                                      uiServices,
-                                                      logger),
-                                                  walletId,
-                                                  seed,
-                                                  uiServices))
-                                        .NextCommand(review => review.DeployCommand)
-                                        .Build(StepKind.Commit);
+            var review = new ReviewAndDeployViewModel(
+                newProject,
+                new ProjectDeploymentOrchestrator(
+                    projectAppService,
+                    founderAppService,
+                    uiServices,
+                    logger),
+                walletId,
+                seed,
+                uiServices);
 
-            return wizard;
+            var reviewNode = flow
+                .Step(review, review.Title)
+                .Finish(vm => vm.DeployCommand.Execute().ToTask(), review.DeployCommand.CanExecute, "Deploy")
+                .Build();
+
+            var stages = new StagesViewModel(newProject);
+            var stagesNode = flow
+                .Step(stages, stages.Title)
+                .Next(_ => reviewNode, stages.IsValid)
+                .Build();
+
+            var funding = new FundingConfigurationViewModel(newProject, environment);
+            var fundingNode = flow
+                .Step(funding, funding.Title)
+                .Next(_ => stagesNode, funding.IsValid)
+                .Build();
+
+            var images = new ProjectImagesViewModel(newProject, imagePicker);
+            var imagesNode = flow
+                .Step(images, images.Title)
+                .Next(_ => fundingNode)
+                .Build();
+
+            var profile = new ProjectProfileViewModel(newProject, prefillAction);
+            return flow
+                .Step(profile, profile.Title)
+                .Next(_ => imagesNode, profile.IsValid)
+                .Build();
         }
 
-        private SlimWizard<string> CreateFundProjectWizard(WalletId walletId, ProjectSeedDto seed)
+        private IWizardNode<string> CreateFundProjectWizard(WalletId walletId, ProjectSeedDto seed)
         {
+            var flow = GraphWizard.For<string>();
             var isDebug = !uiServices.EnableProductionValidations();
             var newProject = new FundProjectConfig();
 
             Action? prefillAction = isDebug ? () => PopulateFundDebugDefaults(newProject) : null;
 
-            SlimWizard<string> wizard = WizardBuilder
-                                         .StartWith(() => new ProjectProfileViewModel(newProject, prefillAction)).NextUnit().WhenValid()
-                                         .Then(_ => new ProjectImagesViewModel(newProject, imagePicker)).NextUnit().Always()
-                                         .Then(_ => new GoalViewModel(newProject)).NextUnit().WhenValid()
-                                         .Then(_ => new FundPayoutsViewModel(newProject)).NextUnit().WhenValid()
-                                         .Then(_ => new FundReviewAndDeployViewModel(
-                                                   newProject,
-                                                   new ProjectDeploymentOrchestrator(
-                                                       projectAppService,
-                                                       founderAppService,
-                                                       uiServices,
-                                                       logger),
-                                                   walletId,
-                                                   seed,
-                                                   uiServices))
-                                         .NextCommand(review => review.DeployCommand)
-                                         .Build(StepKind.Commit);
+            var review = new FundReviewAndDeployViewModel(
+                newProject,
+                new ProjectDeploymentOrchestrator(
+                    projectAppService,
+                    founderAppService,
+                    uiServices,
+                    logger),
+                walletId,
+                seed,
+                uiServices);
 
-            return wizard;
+            var reviewNode = flow
+                .Step(review, review.Title)
+                .Finish(vm => vm.DeployCommand.Execute().ToTask(), review.DeployCommand.CanExecute, "Deploy")
+                .Build();
+
+            var payouts = new FundPayoutsViewModel(newProject);
+            var payoutsNode = flow
+                .Step(payouts, payouts.Title)
+                .Next(_ => reviewNode, payouts.IsValid)
+                .Build();
+
+            var goal = new GoalViewModel(newProject);
+            var goalNode = flow
+                .Step(goal, goal.Title)
+                .Next(_ => payoutsNode, goal.IsValid)
+                .Build();
+
+            var images = new ProjectImagesViewModel(newProject, imagePicker);
+            var imagesNode = flow
+                .Step(images, images.Title)
+                .Next(_ => goalNode)
+                .Build();
+
+            var profile = new ProjectProfileViewModel(newProject, prefillAction);
+            return flow
+                .Step(profile, profile.Title)
+                .Next(_ => imagesNode, profile.IsValid)
+                .Build();
         }
 
         private static void PopulateFundDebugDefaults(FundProjectConfig project)

--- a/src/avalonia/AngorApp/UI/Flows/SendWalletMoney/SendMoneyFlow.cs
+++ b/src/avalonia/AngorApp/UI/Flows/SendWalletMoney/SendMoneyFlow.cs
@@ -1,9 +1,9 @@
 using Angor.Sdk.Wallet.Application;
+using Angor.Sdk.Wallet.Domain;
 using AngorApp.Model.Contracts.Flows;
+using System.Reactive.Threading.Tasks;
 using Zafiro.Avalonia.Dialogs;
-using Zafiro.Avalonia.Dialogs.Wizards.Slim;
-using Zafiro.UI.Wizards.Slim;
-using Zafiro.UI.Wizards.Slim.Builder;
+using Zafiro.Avalonia.Wizards.Graph.Core;
 using AddressAndAmountViewModel = AngorApp.UI.Flows.SendWalletMoney.AddressAndAmount.AddressAndAmountViewModel;
 using TransactionDraftViewModel = AngorApp.UI.Flows.SendWalletMoney.TransactionDraft.TransactionDraftViewModel;
 
@@ -13,12 +13,9 @@ public class SendMoneyFlow(IWalletAppService walletAppService, UIServices uiServ
 {
     public async Task SendMoney(IWallet sourceWallet)
     {
-        var wizard = WizardBuilder
-            .StartWith(() => new AddressAndAmountViewModel(sourceWallet), "Amount and address").Next(model => (model.Amount, model.Address)).WhenValid<AddressAndAmountViewModel>()
-            .Then(sendData => new TransactionDraftViewModel(sourceWallet.Id, walletAppService, new SendAmount("Test", sendData.Amount.Value, sendData.Address), uiServices), "Summary").NextCommand(model => model.Confirm.Enhance("Confirm"))
-            .Build(StepKind.Commit);
+        var wizard = CreateWizard(sourceWallet);
 
-        var result = await uiServices.Dialog.ShowWizard(wizard, "Send");
+        var result = await wizard.ShowInDialog(uiServices.Dialog, "Send");
 
         if (result.HasValue)
         {
@@ -29,5 +26,32 @@ public class SendMoneyFlow(IWalletAppService walletAppService, UIServices uiServ
                 new Icon("fa-check"),
                 DialogTone.Success);
         }
+    }
+
+    private GraphWizard<TxId> CreateWizard(IWallet sourceWallet)
+    {
+        var flow = GraphWizard.For<TxId>();
+        var addressAndAmount = new AddressAndAmountViewModel(sourceWallet);
+
+        var addressNode = flow
+            .Step(addressAndAmount, "Amount and address")
+            .Next(
+                model =>
+                {
+                    var draft = new TransactionDraftViewModel(
+                        sourceWallet.Id,
+                        walletAppService,
+                        new SendAmount("Test", model.Amount!.Value, model.Address!),
+                        uiServices);
+
+                    return flow
+                        .Step(draft, "Summary")
+                        .Finish(vm => vm.Confirm.Execute().ToTask(), draft.Confirm.CanExecute, "Confirm")
+                        .Build();
+                },
+                canExecute: addressAndAmount.IsValid)
+            .Build();
+
+        return new GraphWizard<TxId>(addressNode);
     }
 }

--- a/src/avalonia/AngorApp/UI/Themes/V2/Controls/Wizard.axaml
+++ b/src/avalonia/AngorApp/UI/Themes/V2/Controls/Wizard.axaml
@@ -1,21 +1,46 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:slim="clr-namespace:Zafiro.Avalonia.Controls.Wizards.Slim;assembly=Zafiro.Avalonia">
+        xmlns:view="clr-namespace:Zafiro.Avalonia.Wizards.Graph.View;assembly=Zafiro.Avalonia">
 
     <Design.PreviewWith>
-        <WizardFooter Width="500" />
+        <StackPanel Spacing="20">
+            <view:GraphWizardHeaderView Width="500" />
+            <view:GraphWizardFooterView Width="500" />
+        </StackPanel>
     </Design.PreviewWith>
     
     <Style Selector="EnhancedButton.ReverseIcon ContentPresenter#IconPresenter">
         <Setter Property="DockPanel.Dock" Value="Right" />
     </Style>
 
-    <Style Selector="SlimWizardControl ScrollViewer">
+    <Style Selector="view|GraphWizardView ScrollViewer">
         <Setter Property="Padding" Value="0" />
     </Style>
 
     <Styles.Resources>
-        <ControlTheme x:Key="{x:Type slim:WizardFooter}" TargetType="slim:WizardFooter">
+        <ControlTheme x:Key="{x:Type view:GraphWizardHeaderView}" TargetType="view:GraphWizardHeaderView">
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Grid ColumnDefinitions="*,Auto,*" Margin="0 0 0 12">
+                        <ContentPresenter Grid.Column="1"
+                                          Content="{Binding $parent[view:GraphWizardHeaderView].CurrentHeader}"
+                                          HorizontalAlignment="Center">
+                            <ContentPresenter.DataTemplates>
+                                <DataTemplate DataType="x:String">
+                                    <TextBlock Text="{Binding}"
+                                               FontSize="25"
+                                               FontWeight="Bold"
+                                               Foreground="{DynamicResource TextStrong}"
+                                               TextAlignment="Center" />
+                                </DataTemplate>
+                            </ContentPresenter.DataTemplates>
+                        </ContentPresenter>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+        </ControlTheme>
+
+        <ControlTheme x:Key="{x:Type view:GraphWizardFooterView}" TargetType="view:GraphWizardFooterView">
             <Setter Property="Template">
                 <ControlTemplate>
                     <Grid ColumnDefinitions="*, Auto, *">
@@ -23,18 +48,20 @@
                                         Classes="White"
                                         Grid.Column="0"
                                         HorizontalAlignment="Left"
-                                        Command="{Binding $parent[slim:WizardFooter].Cancel}" />
-                        <ContentPresenter Grid.Column="1" Content="{Binding $parent[slim:WizardFooter].CurrentFooter}" HorizontalAlignment="Center" />
+                                        Command="{Binding $parent[view:GraphWizardFooterView].Wizard.Cancel}" />
+                        <ContentPresenter Grid.Column="1"
+                                          Content="{Binding $parent[view:GraphWizardFooterView].CurrentFooter}"
+                                          HorizontalAlignment="Center" />
                         <StackPanel Grid.Column="2"
                                     Orientation="Horizontal"
                                     Spacing="8"
                                     HorizontalAlignment="Right">
                             <EnhancedButton Content="Back"
                                             Classes="VisibleWhenEnabled Secondary"
-                                            Command="{Binding $parent[slim:WizardFooter].Wizard.Back}" />
-                            <EnhancedButton Content="{Binding $parent[slim:WizardFooter].Wizard.Next.Text, TargetNullValue='Next'}"
+                                            Command="{Binding $parent[view:GraphWizardFooterView].Wizard.Back}" />
+                            <EnhancedButton Content="{Binding $parent[view:GraphWizardFooterView].Wizard.NextTitle^, TargetNullValue='Next'}"
                                             Classes="Primary"
-                                            Command="{Binding $parent[slim:WizardFooter].Wizard.Next}" />
+                                            Command="{Binding $parent[view:GraphWizardFooterView].Wizard.Next}" />
                         </StackPanel>
                     </Grid>
                 </ControlTemplate>


### PR DESCRIPTION
**IMPORTANT: Fixes the bug where going "Back" in the project creation wizard made the "Next" button unresponsive.**

Replaces the old `SlimWizard`/`WizardBuilder` API with the new `GraphWizard` API from Zafiro.

This is a rebased version of #713 (which couldn't be reopened after force-push due to file renames in main).

**Changes:**
- `CreateProjectFlow.cs` — Refactored all wizard construction to use `GraphWizard.For<T>()` with step/node graph builder
- `SendMoneyFlow.cs` — Same migration to `GraphWizard` API
- `Wizard.axaml` — Updated control themes from `SlimWizardControl`/`WizardFooter` to `GraphWizardView`/`GraphWizardHeaderView`/`GraphWizardFooterView`

