### PR TITLE
Improve recovery flows and move integration tests to UI actions

### DIFF
--- a/src/design/App.Test.Integration/FundAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/FundAndRecoverTest.cs
@@ -321,6 +321,11 @@ public class FundAndRecoverTest
         foundProject.Should().NotBeNull($"Should find our project (run ID '{runId}') in Find Projects from SDK");
         Log($"[STEP 5] Found project: '{foundProject!.ProjectName}' (ID: {foundProject.ProjectId})");
 
+        // Additional VM assertions on the found project
+        foundProject.ProjectName.Should().Be(projectName, "ProjectName should match what we set in the wizard");
+        foundProject.ProjectType.Should().Be("Fund", "Fund-type project should have ProjectType 'Fund'");
+        foundProject.ProjectId.Should().NotBeNullOrEmpty("ProjectId should be populated from SDK");
+
         // ──────────────────────────────────────────────────────────────
         // STEP 6: Open invest page → invest above threshold
         // ──────────────────────────────────────────────────────────────
@@ -394,7 +399,7 @@ public class FundAndRecoverTest
             $"Invest should reach success. Last status: {investVm.PaymentStatusText}");
 
         // ──────────────────────────────────────────────────────────────
-        // STEP 7: Add investment to portfolio
+        // STEP 7: Add investment to portfolio + verify no duplicates
         // ──────────────────────────────────────────────────────────────
         Log("[STEP 7] Adding investment to portfolio...");
         investVm.AddToPortfolio();
@@ -403,6 +408,37 @@ public class FundAndRecoverTest
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         portfolioVm.HasInvestments.Should().BeTrue("Portfolio should have at least one investment after AddToPortfolio");
         Log($"[STEP 7] Portfolio now has {portfolioVm.Investments.Count} investment(s)");
+
+        // ── Enhancement 1: Portfolio duplicate check ──
+        // After AddToPortfolio the local collection has 1 optimistic entry.
+        // Reload from SDK and verify only ONE entry for our project (no duplicates).
+        Log("[STEP 7.1] Verifying no duplicate investments after SDK reload...");
+        await portfolioVm.LoadInvestmentsFromSdkAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var matchingInvestments = portfolioVm.Investments
+            .Where(i => i.ProjectIdentifier == foundProject.ProjectId || i.ProjectName == foundProject.ProjectName)
+            .ToList();
+        matchingInvestments.Count.Should().Be(1,
+            "There should be exactly one investment entry for our project after AddToPortfolio + SDK reload (no duplicates)");
+
+        var localInvestment = matchingInvestments[0];
+        Log($"[STEP 7.1] Verified single investment entry: name='{localInvestment.ProjectName}', step={localInvestment.Step}, status='{localInvestment.StatusText}'");
+
+        // Verify investment VM properties after local add
+        localInvestment.ProjectName.Should().Be(foundProject.ProjectName, "Investment project name should match");
+        localInvestment.ProjectType.Should().Be("fund", "Fund-type project should have ProjectType 'fund'");
+        localInvestment.TypeLabel.Should().Be("Funding", "Fund-type investments should show 'Funding' type label");
+        localInvestment.Step.Should().Be(1, "Above-threshold fund investment should start at step 1 (awaiting approval)");
+        localInvestment.StatusText.Should().Be("Awaiting Approval", "Above-threshold investment should show 'Awaiting Approval'");
+        localInvestment.ApprovalStatus.Should().Be("Pending", "Investment should be Pending before founder approval");
+        localInvestment.ProjectIdentifier.Should().Be(foundProject.ProjectId, "Investment should reference our project ID");
+        localInvestment.CurrencySymbol.Should().NotBeNullOrEmpty("CurrencySymbol should be set (e.g. 'BTC' or 'TBTC')");
+        localInvestment.FundingAmount.Should().EndWith(localInvestment.CurrencySymbol,
+            "FundingAmount should include the active currency symbol");
+        double.TryParse(localInvestment.TotalInvested, NumberStyles.Float, CultureInfo.InvariantCulture, out var totalInvested)
+            .Should().BeTrue("TotalInvested should parse as a numeric BTC amount");
+        totalInvested.Should().BeGreaterThan(0, "TotalInvested should be positive after investing");
 
         // ──────────────────────────────────────────────────────────────
         // STEP 8: Founder approves pending investment request
@@ -506,6 +542,11 @@ public class FundAndRecoverTest
         confirmResult.Should().BeTrue("Investor confirmation should succeed after founder signatures are available and valid");
         signedInvestment.Step.Should().Be(3, "Confirmed investment should advance to the active state");
         signedInvestment.StatusText.Should().Be("Investment Active");
+        signedInvestment.StatusClass.Should().Be("active", "Active investment should have 'active' status class");
+        signedInvestment.IsStatusActive.Should().BeTrue("IsStatusActive should be true for confirmed investment");
+        signedInvestment.IsStep3.Should().BeTrue("IsStep3 should be true after confirmation");
+        signedInvestment.IsStepAtLeast3.Should().BeTrue("IsStepAtLeast3 should be true after confirmation");
+        signedInvestment.ProjectType.Should().Be("fund", "Fund-type project type should persist through confirmation");
         Log("[STEP 9] Investor confirmed signed investment successfully");
 
         // ──────────────────────────────────────────────────────────────
@@ -530,6 +571,66 @@ public class FundAndRecoverTest
 
         var manageVm = founderProjectsVm.SelectedManageProject;
         manageVm.Should().NotBeNull("ManageProjectViewModel should be created");
+
+        // ── Enhancement 2: ManageProject stage/UTXO assertions before spending ──
+        // Wait for claimable transactions to load, then verify stages look correct BEFORE the founder spends.
+        Log("[STEP 10.0] Verifying ManageProject stages before founder spend...");
+        var preSpendDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < preSpendDeadline)
+        {
+            await manageVm!.LoadClaimableTransactionsAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            if (manageVm.Stages.Count >= installmentCount)
+                break;
+
+            Log($"[STEP 10.0] Waiting for stages to populate... ({manageVm.Stages.Count}/{installmentCount})");
+            await Task.Delay(PollInterval);
+        }
+
+        manageVm!.Stages.Count.Should().Be(installmentCount,
+            $"ManageProject should show {installmentCount} stages matching the payout schedule");
+        Log($"[STEP 10.0] Stage count verified: {manageVm.Stages.Count}");
+
+        // Verify stage numbers are sequential
+        var stageNumbers = manageVm.Stages.Select(s => s.Number).OrderBy(n => n).ToList();
+        stageNumbers.Should().ContainInOrder(Enumerable.Range(1, installmentCount),
+            "Stage numbers should be sequential 1..N");
+
+        // Verify stage 1 is available / first spendable
+        var stage1Pre = manageVm.Stages.First(s => s.Number == 1);
+        stage1Pre.Available.Should().BeTrue("Stage 1 should be available (has UTXOs)");
+        stage1Pre.UnspentTransactionCount.Should().BeGreaterThan(0,
+            "Stage 1 should have at least one unspent transaction");
+        stage1Pre.SpentTransactionCount.Should().Be(0,
+            "Stage 1 should have zero spent transactions before founder claims");
+        stage1Pre.AmountLeft.Should().NotBe("0.00000000",
+            "Stage 1 AmountLeft should be non-zero before spending");
+        stage1Pre.CompletionDate.Should().NotBeNullOrEmpty(
+            "Stage 1 should have a completion date");
+
+        // Verify all stages have non-zero amounts
+        foreach (var stage in manageVm.Stages)
+        {
+            stage.AmountLeft.Should().NotBe("0.00000000",
+                $"Stage {stage.Number} should have a non-zero amount before any spending");
+            stage.UnspentTransactionCount.Should().BeGreaterThan(0,
+                $"Stage {stage.Number} should have unspent UTXOs");
+            stage.SpentTransactionCount.Should().Be(0,
+                $"Stage {stage.Number} should have no spent transactions yet");
+            Log($"[STEP 10.0] Stage #{stage.Number}: amount={stage.AmountLeft}, " +
+                $"unspent={stage.UnspentTransactionCount}, spent={stage.SpentTransactionCount}, " +
+                $"available={stage.Available}, canClaim={stage.CanClaim}, " +
+                $"buttonMode={stage.ButtonMode}, date='{stage.CompletionDate}'");
+        }
+
+        // Verify header statistics
+        manageVm.TotalStages.Should().Be(installmentCount,
+            "ManageProject TotalStages header stat should match installment count");
+        Log($"[STEP 10.0] Header stats: TotalInvestment={manageVm.TotalInvestment}, " +
+            $"AvailableBalance={manageVm.AvailableBalance}, TotalStages={manageVm.TotalStages}, " +
+            $"TransactionTotal={manageVm.TransactionTotal}, TransactionSpent={manageVm.TransactionSpent}, " +
+            $"TransactionAvailable={manageVm.TransactionAvailable}");
 
         var claimableDeadline = DateTime.UtcNow + IndexerLagTimeout;
         var claimPollCount = 0;
@@ -667,6 +768,50 @@ public class FundAndRecoverTest
             $"Recovery state should have an available action after the investment transaction is indexed. " +
             $"Polled {pollCount} times over {IndexerLagTimeout.TotalMinutes} minutes. " +
             $"Project: {targetInvestment.ProjectIdentifier}, WalletId: {targetInvestment.InvestmentWalletId}");
+
+        // ── Enhancement 3: Recovery stage display verification ──
+        // After LoadRecoveryStatusAsync, the investment's Stages collection should be populated
+        // with per-stage recovery data. Verify the stage count and statuses.
+        Log("[STEP 12.1] Verifying recovery stage display...");
+        targetInvestment.Stages.Count.Should().Be(installmentCount,
+            $"Recovery should show {installmentCount} stages matching the project's payout schedule");
+
+        foreach (var stage in targetInvestment.Stages)
+        {
+            stage.StageNumber.Should().BeGreaterThan(0, "Stage number should be positive");
+            stage.Amount.Should().NotBe("0.00000000", $"Stage {stage.StageNumber} should have a non-zero amount");
+            stage.Status.Should().BeOneOf("Released", "Pending", "Not Spent",
+                $"Stage {stage.StageNumber} status should be a valid value");
+            Log($"[STEP 12.1] Recovery Stage #{stage.StageNumber}: amount={stage.Amount}, status='{stage.Status}'");
+        }
+
+        // Stage 1 was spent by the founder — it should show as "Released"
+        var recoveryStage1 = targetInvestment.Stages.FirstOrDefault(s => s.StageNumber == 1);
+        recoveryStage1.Should().NotBeNull("Stage 1 should exist in recovery stages");
+        recoveryStage1!.Status.Should().Be("Released",
+            "Stage 1 should be 'Released' since the founder already spent it");
+
+        // Remaining stages should be unspent (either "Pending" or "Not Spent")
+        var unspentStages = targetInvestment.Stages.Where(s => s.StageNumber > 1).ToList();
+        unspentStages.Should().AllSatisfy(s =>
+            s.Status.Should().BeOneOf("Pending", "Not Spent",
+                $"Stage {s.StageNumber} should be unspent since only stage 1 was spent"));
+
+        // Verify computed recovery properties
+        targetInvestment.StagesToRecover.Should().BeGreaterThan(0,
+            "StagesToRecover should be positive since there are unreleased stages");
+        double.TryParse(targetInvestment.AmountToRecover, System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture, out var amountToRecover).Should().BeTrue();
+        amountToRecover.Should().BeGreaterThan(0,
+            "AmountToRecover should be positive for unreleased stages");
+
+        // Verify recovery button visibility
+        targetInvestment.ShowRecoverButton.Should().BeTrue(
+            "ShowRecoverButton should be true for an active investment with a recovery action available");
+        targetInvestment.PenaltyButtonText.Should().NotBeNullOrEmpty(
+            "PenaltyButtonText should have a label for the recovery action");
+        Log($"[STEP 12.1] Recovery display verified. StagesToRecover={targetInvestment.StagesToRecover}, " +
+            $"AmountToRecover={targetInvestment.AmountToRecover}, ButtonText='{targetInvestment.PenaltyButtonText}'");
 
         // Execute the appropriate recovery operation
         var actionKey = targetInvestment.RecoveryState.ActionKey;

--- a/src/design/App.Test.Integration/FundAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/FundAndRecoverTest.cs
@@ -813,39 +813,20 @@ public class FundAndRecoverTest
         Log($"[STEP 12.1] Recovery display verified. StagesToRecover={targetInvestment.StagesToRecover}, " +
             $"AmountToRecover={targetInvestment.AmountToRecover}, ButtonText='{targetInvestment.PenaltyButtonText}'");
 
-        // Execute the appropriate recovery operation
+        // Execute the recovery through the real UI button path
         var actionKey = targetInvestment.RecoveryState.ActionKey;
-        Log($"[STEP 12] Executing recovery action: '{actionKey}' ({targetInvestment.RecoveryState.ButtonLabel})...");
+        Log($"[STEP 12] Clicking recovery action button: '{actionKey}' ({targetInvestment.RecoveryState.ButtonLabel})...");
 
-        bool recoveryResult;
-        switch (actionKey)
-        {
-            case "recovery":
-                recoveryResult = await portfolioVm.RecoverFundsAsync(targetInvestment);
-                break;
-            case "unfundedRelease":
-                recoveryResult = await portfolioVm.ReleaseFundsAsync(targetInvestment);
-                break;
-            case "endOfProject":
-                recoveryResult = await portfolioVm.ClaimEndOfProjectAsync(targetInvestment);
-                break;
-            case "penaltyRelease":
-                recoveryResult = await portfolioVm.PenaltyReleaseFundsAsync(targetInvestment);
-                break;
-            default:
-                recoveryResult = false;
-                Log($"[STEP 12] ERROR: Unknown recovery action key: '{actionKey}'");
-                break;
-        }
+        await window.ClickRecoveryFlowAsync(portfolioVm, targetInvestment, TimeSpan.FromSeconds(30));
 
         Dispatcher.UIThread.RunJobs();
 
         // ──────────────────────────────────────────────────────────────
         // STEP 13: Verify recovery succeeded
         // ──────────────────────────────────────────────────────────────
-        Log($"[STEP 13] Recovery result: {recoveryResult}");
-        recoveryResult.Should().BeTrue(
-            $"Recovery operation '{actionKey}' should succeed (transaction built and published)");
+        Log("[STEP 13] Recovery flow completed through real UI button path");
+        targetInvestment.ShowSuccessModal.Should().BeTrue(
+            $"Recovery operation '{actionKey}' should succeed and show the success modal");
 
         Log($"[STEP 13] Post-recovery state: HasUnspent={targetInvestment.RecoveryState.HasUnspentItems}, " +
             $"InPenalty={targetInvestment.RecoveryState.HasSpendableItemsInPenalty}, " +

--- a/src/design/App.Test.Integration/FundAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/FundAndRecoverTest.cs
@@ -780,22 +780,22 @@ public class FundAndRecoverTest
         {
             stage.StageNumber.Should().BeGreaterThan(0, "Stage number should be positive");
             stage.Amount.Should().NotBe("0.00000000", $"Stage {stage.StageNumber} should have a non-zero amount");
-            stage.Status.Should().BeOneOf("Released", "Pending", "Not Spent",
+            stage.Status.Should().BeOneOf("Spent by founder", "Not Spent", "Pending",
                 $"Stage {stage.StageNumber} status should be a valid value");
             Log($"[STEP 12.1] Recovery Stage #{stage.StageNumber}: amount={stage.Amount}, status='{stage.Status}'");
         }
 
-        // Stage 1 was spent by the founder — it should show as "Released"
+        // Stage 1 was spent by the founder — it should show that exact text.
         var recoveryStage1 = targetInvestment.Stages.FirstOrDefault(s => s.StageNumber == 1);
         recoveryStage1.Should().NotBeNull("Stage 1 should exist in recovery stages");
-        recoveryStage1!.Status.Should().Be("Released",
-            "Stage 1 should be 'Released' since the founder already spent it");
+        recoveryStage1!.Status.Should().Be("Spent by founder",
+            "Stage 1 should say 'Spent by founder' after the founder spends that stage");
 
-        // Remaining stages should be unspent (either "Pending" or "Not Spent")
+        // Remaining stages should still be untouched before any penalty recovery occurs.
         var unspentStages = targetInvestment.Stages.Where(s => s.StageNumber > 1).ToList();
         unspentStages.Should().AllSatisfy(s =>
-            s.Status.Should().BeOneOf("Pending", "Not Spent",
-                $"Stage {s.StageNumber} should be unspent since only stage 1 was spent"));
+            s.Status.Should().Be("Not Spent",
+                $"Stage {s.StageNumber} should say 'Not Spent' since only stage 1 was spent"));
 
         // Verify computed recovery properties
         targetInvestment.StagesToRecover.Should().BeGreaterThan(0,

--- a/src/design/App.Test.Integration/FundAndRecoverTest.md
+++ b/src/design/App.Test.Integration/FundAndRecoverTest.md
@@ -45,12 +45,13 @@ Full end-to-end integration test that boots the real Avalonia app in headless mo
 7. **Reload founder projects from SDK** — Call `LoadFounderProjectsAsync()` to get the `ProjectIdentifier` and `OwnerWalletId` (not set by `OnProjectDeployed`).
 8. **Navigate to Find Projects** — Reload projects from SDK via `LoadProjectsFromSdkAsync()`, find our project by GUID match.
 9. **Invest 0.02 BTC** — Open invest page, set amount to "0.02" BTC (above the 0.01 BTC approval threshold), submit, select wallet, pay. The SDK pipeline: `BuildInvestmentDraft` -> `CheckPenaltyThreshold` (returns true for above-threshold) -> `SubmitInvestment` (request founder signatures).
-10. **Add investment to portfolio** — Call `AddToPortfolio()` on the invest page.
+10. **Add investment to portfolio** — Call `AddToPortfolio()` on the invest page, reload portfolio from SDK, and verify there is exactly one entry for the project (no duplicate optimistic + SDK entries).
 11. **Founder approves request** — Navigate to Funders, poll `LoadInvestmentRequestsAsync()` until the request appears in `waiting`, then call `ApproveSignature(...)` and verify it moves to `approved`.
 12. **Investor confirms signed investment** — Reload funded investments from SDK until the investment reaches `FounderSignaturesReceived`/step 2, then call `ConfirmInvestmentAsync(...)` and verify it advances to active/step 3.
 13. **Founder spends stage 1** — Via `ManageProjectViewModel`:
     - `OpenManageProject(project)` creates the manage VM
     - `LoadClaimableTransactionsAsync()` loads stages with UTXOs
+    - Verify `Stages.Count == 3`, stage numbers are sequential, every stage has non-zero amount/UTXO data, and stage 1 is the spendable stage before claim
     - Wait for stage 1 to have available transactions (indexer lag)
     - Select all available transactions for stage 1
     - `ClaimStageFundsAsync(1, selectedTxs, feeRate)` builds and broadcasts the spending tx
@@ -58,6 +59,7 @@ Full end-to-end integration test that boots the real Avalonia app in headless mo
     - Reload investments from SDK
     - Find our investment
     - `LoadRecoveryStatusAsync(investment)` — poll until recovery action available
+    - Verify the recovery-stage VM list is populated, stage 1 is `Released`, and the remaining stages are still unreleased
     - Execute the appropriate recovery action based on `RecoveryState.ActionKey`
 15. **Verify recovery succeeded** — Assert the recovery operation returned `true`.
 
@@ -72,6 +74,7 @@ Full end-to-end integration test that boots the real Avalonia app in headless mo
 - **Password provider**: Must set `SimplePasswordProvider` to `"default-key"` before deploy/invest/spend steps.
 - **Deploy callback wiring**: The test manually wires `OnProjectDeployed` (normally done by `MyProjectsView.OpenCreateWizard` code-behind).
 - **PortfolioViewModel is singleton**: The same instance is shared across the invest page (for `AddToPortfolio`) and the funded section.
+- **Extra VM assertions**: The test now also checks `ProjectType`, `TypeLabel`, `StatusClass`, `ShowRecoverButton`, `StagesToRecover`, `AmountToRecover`, `ButtonMode`, and pre-spend stage header stats to catch UI-model regressions earlier.
 
 **How to run**:
 ```bash

--- a/src/design/App.Test.Integration/Helpers/TestHelpers.cs
+++ b/src/design/App.Test.Integration/Helpers/TestHelpers.cs
@@ -8,6 +8,8 @@ using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using App.UI.Shell;
+using App.UI.Sections.Funders;
+using App.UI.Sections.MyProjects;
 using App.UI.Sections.Portfolio;
 using App.UI.Shared;
 using FluentAssertions;
@@ -289,5 +291,212 @@ public static class TestHelpers
 
         investment.ErrorMessage.Should().BeNullOrEmpty("Recovery flow should complete without UI error");
         investment.ShowSuccessModal.Should().BeTrue("Recovery success modal should be shown after successful recovery");
+    }
+
+    public static async Task ClickApproveSignatureAsync(
+        this Window window,
+        FundersViewModel fundersVm,
+        SignatureRequestViewModel signature,
+        TimeSpan? timeout = null)
+    {
+        var maxWait = timeout ?? TimeSpan.FromSeconds(15);
+
+        window.NavigateToSection("Funders");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        fundersVm.SetFilter("waiting");
+        Dispatcher.UIThread.RunJobs();
+
+        var buttonReady = await WaitForCondition(
+            () => window.GetVisualDescendants().OfType<Button>().Any(b =>
+                b.IsVisible &&
+                b.Name == "ApproveButton" &&
+                b.Tag is int tag &&
+                tag == signature.Id),
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!buttonReady)
+            throw new TimeoutException($"ApproveButton for signature {signature.Id} did not appear");
+
+        var approveButton = window.GetVisualDescendants().OfType<Button>().First(b =>
+            b.IsVisible &&
+            b.Name == "ApproveButton" &&
+            b.Tag is int tag &&
+            tag == signature.Id);
+
+        approveButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, approveButton));
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    public static async Task ClickInvestmentDetailActionAsync(
+        this Window window,
+        PortfolioViewModel portfolioVm,
+        InvestmentViewModel investment,
+        string buttonName,
+        TimeSpan? timeout = null)
+    {
+        var maxWait = timeout ?? TimeSpan.FromSeconds(30);
+
+        window.NavigateToSection("Funded");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        portfolioVm.OpenInvestmentDetail(investment);
+        Dispatcher.UIThread.RunJobs();
+
+        var detailOpened = await WaitForCondition(
+            () => ReferenceEquals(portfolioVm.SelectedInvestment, investment),
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!detailOpened)
+            throw new TimeoutException("Portfolio selected investment detail did not open");
+
+        var buttonVisible = await WaitForCondition(
+            () => window.GetVisualDescendants().OfType<Button>().Any(b => b.IsVisible && b.Name == buttonName),
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!buttonVisible)
+            throw new TimeoutException($"Investment detail action button '{buttonName}' did not appear");
+
+        var button = window.GetVisualDescendants().OfType<Button>().First(b => b.IsVisible && b.Name == buttonName);
+        button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, button));
+        Dispatcher.UIThread.RunJobs();
+
+        var actionCompleted = await WaitForCondition(
+            () => !investment.IsProcessing,
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!actionCompleted)
+            throw new TimeoutException($"Investment detail action '{buttonName}' did not complete");
+    }
+
+    public static async Task ClickManageProjectClaimStageAsync(
+        this Window window,
+        MyProjectsViewModel myProjectsVm,
+        MyProjectItemViewModel project,
+        int stageNumber,
+        TimeSpan? timeout = null)
+    {
+        var maxWait = timeout ?? TimeSpan.FromSeconds(30);
+
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        myProjectsVm.OpenManageProject(project);
+        Dispatcher.UIThread.RunJobs();
+
+        var manageOpened = await WaitForCondition(
+            () => myProjectsVm.SelectedManageProject != null,
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!manageOpened)
+            throw new TimeoutException("Manage project view did not open");
+
+        var claimButtonVisible = await WaitForCondition(
+            () => window.GetVisualDescendants().OfType<Button>().Any(b =>
+                b.IsVisible &&
+                b.Classes.Contains("StageClaimBtn") &&
+                b.Tag is int tag &&
+                tag == stageNumber),
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!claimButtonVisible)
+            throw new TimeoutException($"Claim button for stage {stageNumber} did not appear");
+
+        var claimButton = window.GetVisualDescendants().OfType<Button>().First(b =>
+            b.IsVisible &&
+            b.Classes.Contains("StageClaimBtn") &&
+            b.Tag is int tag &&
+            tag == stageNumber);
+        claimButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, claimButton));
+        Dispatcher.UIThread.RunJobs();
+
+        var claimSelectedBtn = await WaitForCondition(
+            () => window.FindByName<Button>("ClaimSelectedBtn")?.IsVisible == true,
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!claimSelectedBtn)
+            throw new TimeoutException("ClaimSelectedBtn did not appear");
+
+        var manageVm = myProjectsVm.SelectedManageProject!;
+
+        var selectionReady = await WaitForCondition(
+            () => manageVm.SelectedStage?.AvailableTransactions.Count > 0,
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!selectionReady)
+            throw new TimeoutException("Claim UTXO selection list did not populate");
+
+        foreach (var tx in manageVm.SelectedStage!.AvailableTransactions)
+            tx.IsSelected = true;
+        Dispatcher.UIThread.RunJobs();
+
+        var claimSelected = window.FindByName<Button>("ClaimSelectedBtn")!;
+        claimSelected.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, claimSelected));
+        Dispatcher.UIThread.RunJobs();
+
+        var feeConfirmButton = await window.WaitForControl<Button>("FeeConfirmButton", maxWait)
+            ?? throw new TimeoutException("FeeSelectionPopup did not appear for claim flow");
+        feeConfirmButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, feeConfirmButton));
+        Dispatcher.UIThread.RunJobs();
+
+        var completed = await WaitForCondition(
+            () => !manageVm.IsClaiming && manageVm.ShowSuccessModal,
+            TimeSpan.FromMinutes(3),
+            TimeSpan.FromMilliseconds(200));
+        if (!completed)
+            throw new TimeoutException("Claim stage flow did not complete");
+    }
+
+    public static async Task<bool> ClickManageProjectReleaseFundsAsync(
+        this Window window,
+        MyProjectsViewModel myProjectsVm,
+        MyProjectItemViewModel project,
+        TimeSpan? timeout = null)
+    {
+        var maxWait = timeout ?? TimeSpan.FromSeconds(30);
+
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        myProjectsVm.OpenManageProject(project);
+        Dispatcher.UIThread.RunJobs();
+
+        var manageOpened = await WaitForCondition(
+            () => myProjectsVm.SelectedManageProject != null,
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!manageOpened)
+            throw new TimeoutException("Manage project view did not open");
+
+        var manageVm = myProjectsVm.SelectedManageProject!;
+
+        var manageView = window.GetVisualDescendants().OfType<ManageProjectView>().FirstOrDefault(v => v.IsVisible)
+            ?? throw new InvalidOperationException("Visible ManageProjectView not found");
+        manageView.OpenReleaseFundsModal();
+        Dispatcher.UIThread.RunJobs();
+
+        var releaseButtonVisible = await WaitForCondition(
+            () => window.FindByName<Button>("ReleaseFundsConfirmBtn")?.IsVisible == true,
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!releaseButtonVisible)
+            throw new TimeoutException("ReleaseFundsConfirmBtn did not appear");
+
+        var releaseButton = window.FindByName<Button>("ReleaseFundsConfirmBtn")!;
+        releaseButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, releaseButton));
+        Dispatcher.UIThread.RunJobs();
+
+        var completed = await WaitForCondition(
+            () => !manageVm.IsReleasingFunds,
+            maxWait,
+            TimeSpan.FromMilliseconds(200));
+        if (!completed)
+            throw new TimeoutException("Release funds flow did not complete");
+
+        return manageVm.ShowReleaseFundsSuccessModal;
     }
 }

--- a/src/design/App.Test.Integration/Helpers/TestHelpers.cs
+++ b/src/design/App.Test.Integration/Helpers/TestHelpers.cs
@@ -8,6 +8,9 @@ using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using App.UI.Shell;
+using App.UI.Sections.Portfolio;
+using App.UI.Shared;
+using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace App.Test.Integration.Helpers;
@@ -213,5 +216,78 @@ public static class TestHelpers
         return root.GetVisualDescendants()
             .OfType<T>()
             .FirstOrDefault(c => c.Name == name);
+    }
+
+    /// <summary>
+    /// Drives the real recovery UI flow for an investment: opens detail,
+    /// clicks the recovery button, confirms the modal, confirms the fee popup,
+    /// and waits for the recovery action to complete.
+    /// </summary>
+    public static async Task ClickRecoveryFlowAsync(
+        this Window window,
+        PortfolioViewModel portfolioVm,
+        InvestmentViewModel investment,
+        TimeSpan? timeout = null)
+    {
+        var maxWait = timeout ?? TimeSpan.FromSeconds(30);
+
+        window.NavigateToSection("Funded");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        portfolioVm.OpenInvestmentDetail(investment);
+        Dispatcher.UIThread.RunJobs();
+
+        var detailOpened = await WaitForCondition(
+            () => ReferenceEquals(portfolioVm.SelectedInvestment, investment),
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!detailOpened)
+            throw new TimeoutException("Portfolio selected investment detail did not open");
+
+        var detailViewVisible = await WaitForCondition(
+            () => window.GetVisualDescendants().OfType<InvestmentDetailView>().Any(v => v.IsVisible),
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!detailViewVisible)
+            throw new TimeoutException("InvestmentDetailView did not appear");
+
+        var recoverButton = window.FindByName<Button>("RecoverFundsButton")
+            ?? throw new InvalidOperationException("RecoverFundsButton not found in detail view");
+        recoverButton.IsVisible.Should().BeTrue("RecoverFundsButton should be visible before clicking it");
+
+        recoverButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, recoverButton));
+        Dispatcher.UIThread.RunJobs();
+
+        var modalOpened = await WaitForCondition(
+            () => investment.ShowRecoveryModal || investment.ShowReleaseModal || investment.ShowClaimModal,
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!modalOpened)
+            throw new TimeoutException("Recovery modal did not open");
+
+        var confirmButton = window.FindByName<Button>("ConfirmRecoveryModal")
+            ?? window.FindByName<Button>("ConfirmReleaseModal")
+            ?? window.FindByName<Button>("ClaimPenaltyButton")
+            ?? throw new InvalidOperationException("No visible recovery confirm button found");
+
+        confirmButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, confirmButton));
+        Dispatcher.UIThread.RunJobs();
+
+        var feeConfirmButton = await window.WaitForControl<Button>("FeeConfirmButton", maxWait)
+            ?? throw new TimeoutException("FeeSelectionPopup did not appear");
+
+        feeConfirmButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, feeConfirmButton));
+        Dispatcher.UIThread.RunJobs();
+
+        var completed = await WaitForCondition(
+            () => !investment.IsProcessing && (investment.ShowSuccessModal || !string.IsNullOrEmpty(investment.ErrorMessage)),
+            TimeSpan.FromMinutes(3),
+            TimeSpan.FromMilliseconds(200));
+        if (!completed)
+            throw new TimeoutException("Recovery UI flow did not complete");
+
+        investment.ErrorMessage.Should().BeNullOrEmpty("Recovery flow should complete without UI error");
+        investment.ShowSuccessModal.Should().BeTrue("Recovery success modal should be shown after successful recovery");
     }
 }

--- a/src/design/App.Test.Integration/InvestAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/InvestAndRecoverTest.cs
@@ -1,0 +1,811 @@
+using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FluentAssertions;
+using Angor.Sdk.Common;
+using App.Composition.Adapters;
+using App.Test.Integration.Helpers;
+using App.UI.Sections.FindProjects;
+using App.UI.Sections.Funders;
+using App.UI.Sections.Funds;
+using App.UI.Sections.MyProjects;
+using App.UI.Sections.MyProjects.Deploy;
+using App.UI.Sections.Portfolio;
+using App.UI.Sections.Settings;
+using App.UI.Shell;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace App.Test.Integration;
+
+public class InvestAndRecoverTest
+{
+    private static readonly TimeSpan FaucetBalanceTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan TransactionTimeout = TimeSpan.FromSeconds(120);
+    private static readonly TimeSpan UiTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan IndexerLagTimeout = TimeSpan.FromMinutes(5);
+
+    [AvaloniaFact]
+    public async Task FullInvestAndRecoverFlow()
+    {
+        using var profileScope = TestProfileScope.For(nameof(InvestAndRecoverTest));
+        Log("========== STARTING FullInvestAndRecoverFlow ==========");
+
+        var runId = Guid.NewGuid().ToString("N")[..12];
+        var projectName = $"Test Invest {runId}";
+        var projectAbout =
+            $"Automated invest-and-recover test run {runId}. Verifies invest creation, founder spend, and investor recovery.";
+        var bannerImageUrl = $"https://picsum.photos/seed/{Guid.NewGuid().ToString("N")[..8]}/320/200";
+        var profileImageUrl = $"https://picsum.photos/seed/{Guid.NewGuid().ToString("N")[..8]}/100/100";
+
+        var targetAmountBtc = "1.0";
+        var investmentAmountBtc = "0.02";
+        var investEndDate = DateTime.UtcNow.AddMonths(3);
+        var installmentCount = 3;
+        var investStartDate = DateTime.UtcNow.AddDays(-40).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        Log($"[STEP 0] Run ID: {runId}");
+        Log($"[STEP 0] Project name: {projectName}");
+        Log($"[STEP 0] Investment amount: {investmentAmountBtc} BTC");
+
+        var window = TestHelpers.CreateShellWindow();
+        var shellVm = window.GetShellViewModel();
+
+        Log("[STEP 1] Wiping existing data...");
+        await WipeExistingData(window);
+
+        Log("[STEP 2] Navigating to Funds section...");
+        window.NavigateToSection("Funds");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var emptyState = await window.WaitForControl<Panel>("EmptyStatePanel", UiTimeout);
+        emptyState.Should().NotBeNull("Funds should show empty state after wipe");
+
+        Log("[STEP 2] Creating wallet via Generate path...");
+        await CreateWalletViaGenerate(window);
+
+        Log("[STEP 3] Waiting for WalletCard to appear...");
+        var walletCardBtn = await window.WaitForWalletCard(TimeSpan.FromSeconds(30));
+        walletCardBtn.Should().NotBeNull("WalletCard should appear after wallet creation");
+
+        Log("[STEP 3] Requesting testnet coins and waiting for balance...");
+        await FundWalletViaFaucet(window);
+
+        var passwordProvider = global::App.App.Services.GetRequiredService<SimplePasswordProvider>();
+        passwordProvider.SetKey("default-key");
+        Log("[STEP 3] Set SimplePasswordProvider key to 'default-key'.");
+
+        Log("[STEP 4] Navigating to My Projects section...");
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var myProjectsVm = GetMyProjectsViewModel(window);
+        myProjectsVm.Should().NotBeNull("MyProjectsViewModel should be available");
+
+        Log("[STEP 4] Opening create wizard...");
+        await OpenCreateWizard(window, myProjectsVm!);
+
+        var wizardVm = myProjectsVm!.CreateProjectVm;
+        wizardVm.Should().NotBeNull("CreateProjectViewModel should exist");
+
+        Log("[STEP 4.1] Selecting 'investment' project type...");
+        wizardVm.DismissWelcome();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        wizardVm.SelectProjectType("investment");
+        Dispatcher.UIThread.RunJobs();
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log("[STEP 4.2] Setting project name and about...");
+        wizardVm.ProjectName = projectName;
+        wizardVm.ProjectAbout = projectAbout;
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log("[STEP 4.3] Setting banner and profile images...");
+        wizardVm.BannerUrl = bannerImageUrl;
+        wizardVm.ProfileUrl = profileImageUrl;
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log("[STEP 4.4] Setting target amount and investment end date...");
+        wizardVm.TargetAmount = targetAmountBtc;
+        wizardVm.InvestEndDate = investEndDate;
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log("[STEP 4.5] Generating three monthly investment stages...");
+        wizardVm.ShowStep5Welcome.Should().BeTrue("Step 5 should start with welcome screen");
+        wizardVm.DismissStep5Welcome();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        wizardVm.DurationValue = "3";
+        wizardVm.DurationUnit = "Months";
+        wizardVm.ReleaseFrequency = "Monthly";
+        wizardVm.StartDate = investStartDate;
+        wizardVm.GenerateInvestmentStages();
+        Dispatcher.UIThread.RunJobs();
+        wizardVm.Stages.Count.Should().Be(installmentCount);
+        wizardVm.Stages.Select(s => s.StageNumber).Should().ContainInOrder(1, 2, 3);
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log("[STEP 4.6] Deploying project...");
+        wizardVm.Deploy();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(1000);
+        Dispatcher.UIThread.RunJobs();
+
+        var deployVm = wizardVm.DeployFlow;
+        deployVm.IsVisible.Should().BeTrue("Deploy overlay should be visible");
+
+        var walletLoadDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTime.UtcNow < walletLoadDeadline && deployVm.Wallets.Count == 0)
+        {
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        deployVm.Wallets.Count.Should().BeGreaterThan(0, "At least one wallet should be loaded");
+        var deployWallet = deployVm.Wallets[0];
+        deployVm.SelectWallet(deployWallet);
+        Dispatcher.UIThread.RunJobs();
+
+        Log("[STEP 4.6] Paying with wallet (SDK deploy pipeline)...");
+        deployVm.PayWithWallet();
+
+        var deployDeadline = DateTime.UtcNow + TransactionTimeout;
+        while (DateTime.UtcNow < deployDeadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (deployVm.CurrentScreen == DeployScreen.Success)
+            {
+                break;
+            }
+
+            if (!deployVm.IsDeploying && deployVm.CurrentScreen != DeployScreen.Success)
+            {
+                if (deployVm.DeployStatusText.Contains("Failed") || deployVm.DeployStatusText.Contains("error"))
+                    break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        deployVm.CurrentScreen.Should().Be(DeployScreen.Success,
+            $"Deploy should reach success. Last status: {deployVm.DeployStatusText}");
+
+        deployVm.GoToMyProjects();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+        if (shellVm.IsModalOpen)
+        {
+            shellVm.HideModal();
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        var project = myProjectsVm.Projects.FirstOrDefault(p => p.Description.Contains(runId));
+        project.Should().NotBeNull($"Project with run ID '{runId}' should appear in My Projects");
+
+        Log("[STEP 4.7] Reloading founder projects from SDK to populate identifiers...");
+        await myProjectsVm.LoadFounderProjectsAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        project = myProjectsVm.Projects.FirstOrDefault(p => p.Description.Contains(runId));
+        project.Should().NotBeNull();
+        project!.ProjectIdentifier.Should().NotBeNullOrEmpty();
+        project.OwnerWalletId.Should().NotBeNullOrEmpty();
+
+        Log("[STEP 5] Navigating to Find Projects...");
+        window.NavigateToSection("Find Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var findProjectsVm = GetFindProjectsViewModel(window);
+        findProjectsVm.Should().NotBeNull("FindProjectsViewModel should be available");
+
+        ProjectItemViewModel? foundProject = null;
+        var findDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < findDeadline)
+        {
+            await findProjectsVm!.LoadProjectsFromSdkAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            foundProject = findProjectsVm.Projects.FirstOrDefault(p =>
+                p.Description.Contains(runId) || p.ShortDescription.Contains(runId));
+            if (foundProject != null)
+                break;
+
+            await Task.Delay(PollInterval);
+        }
+
+        foundProject.Should().NotBeNull($"Should find our project (run ID '{runId}') in Find Projects from SDK");
+        foundProject!.ProjectName.Should().Be(projectName);
+        foundProject.ProjectType.Should().Be("Invest");
+        foundProject.Target.Should().Be("1.00000");
+        foundProject.ProjectId.Should().NotBeNullOrEmpty();
+
+        Log("[STEP 6] Opening project detail...");
+        findProjectsVm!.OpenProjectDetail(foundProject);
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(300);
+
+        Log("[STEP 6] Opening invest page...");
+        findProjectsVm.OpenInvestPage();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var investVm = findProjectsVm.InvestPageViewModel;
+        investVm.Should().NotBeNull("InvestPageViewModel should be created");
+
+        var investWalletDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTime.UtcNow < investWalletDeadline && investVm!.Wallets.Count == 0)
+        {
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        investVm!.Wallets.Count.Should().BeGreaterThan(0);
+        investVm.Stages.Count.Should().Be(installmentCount, "invest project should expose fixed stages");
+        investVm.InvestmentAmount = investmentAmountBtc;
+        Dispatcher.UIThread.RunJobs();
+        investVm.CanSubmit.Should().BeTrue();
+
+        Log("[STEP 6] Submitting invest form...");
+        investVm.Submit();
+        Dispatcher.UIThread.RunJobs();
+        investVm.CurrentScreen.Should().Be(InvestScreen.WalletSelector);
+
+        var investWallet = investVm.Wallets[0];
+        investVm.SelectWallet(investWallet);
+        Dispatcher.UIThread.RunJobs();
+        investVm.SelectedWallet.Should().NotBeNull();
+
+        Log("[STEP 6] Paying with wallet (SDK invest pipeline)...");
+        investVm.PayWithWallet();
+
+        var investDeadline = DateTime.UtcNow + TransactionTimeout;
+        while (DateTime.UtcNow < investDeadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (investVm.CurrentScreen == InvestScreen.Success)
+            {
+                break;
+            }
+
+            if (!investVm.IsProcessing && investVm.CurrentScreen != InvestScreen.Success)
+            {
+                if (investVm.PaymentStatusText.Contains("Failed") || investVm.PaymentStatusText.Contains("Error"))
+                    break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        investVm.CurrentScreen.Should().Be(InvestScreen.Success,
+            $"Invest should reach success. Last status: {investVm.PaymentStatusText}");
+
+        Log("[STEP 7] Adding investment to portfolio...");
+        investVm.AddToPortfolio();
+        Dispatcher.UIThread.RunJobs();
+
+        var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
+        portfolioVm.HasInvestments.Should().BeTrue();
+
+        Log("[STEP 7.1] Verifying no duplicate investments after SDK reload...");
+        await portfolioVm.LoadInvestmentsFromSdkAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var matchingInvestments = portfolioVm.Investments
+            .Where(i => i.ProjectIdentifier == foundProject.ProjectId || i.ProjectName == foundProject.ProjectName)
+            .ToList();
+        matchingInvestments.Count.Should().Be(1,
+            "There should be exactly one investment entry for our project after AddToPortfolio + SDK reload");
+
+        var localInvestment = matchingInvestments[0];
+        localInvestment.ProjectType.Should().Be("invest");
+        localInvestment.TypeLabel.Should().Be("Investment");
+        localInvestment.Step.Should().Be(1, "Invest-type projects should wait for founder approval");
+        localInvestment.StatusText.Should().Be("Awaiting Approval");
+        localInvestment.ApprovalStatus.Should().Be("Pending");
+
+        Log("[STEP 8] Founder approving pending investment request...");
+        findProjectsVm.CloseInvestPage();
+        findProjectsVm.CloseProjectDetail();
+        Dispatcher.UIThread.RunJobs();
+
+        window.NavigateToSection("Funders");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var fundersVm = GetFundersViewModel(window);
+        fundersVm.Should().NotBeNull();
+        fundersVm!.SetFilter("waiting");
+
+        SignatureRequestViewModel? pendingRequest = null;
+        var approvalRequestDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < approvalRequestDeadline)
+        {
+            await fundersVm.LoadInvestmentRequestsAsync();
+            fundersVm.SetFilter("waiting");
+            Dispatcher.UIThread.RunJobs();
+
+            pendingRequest = fundersVm.FilteredSignatures.FirstOrDefault(s =>
+                s.ProjectIdentifier == foundProject.ProjectId || s.ProjectTitle == foundProject.ProjectName);
+            if (pendingRequest != null)
+                break;
+
+            await Task.Delay(PollInterval);
+        }
+
+        pendingRequest.Should().NotBeNull();
+        fundersVm.ApproveSignature(pendingRequest!.Id);
+        Dispatcher.UIThread.RunJobs();
+
+        var approvalCompleteDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        var founderApproved = false;
+        while (DateTime.UtcNow < approvalCompleteDeadline)
+        {
+            await fundersVm.LoadInvestmentRequestsAsync();
+            fundersVm.SetFilter("approved");
+            Dispatcher.UIThread.RunJobs();
+
+            founderApproved = fundersVm.FilteredSignatures.Any(s =>
+                s.ProjectIdentifier == foundProject.ProjectId || s.ProjectTitle == foundProject.ProjectName);
+            if (founderApproved)
+                break;
+
+            await Task.Delay(PollInterval);
+        }
+
+        founderApproved.Should().BeTrue();
+
+        Log("[STEP 9] Reloading funded investments and confirming signed investment...");
+        window.NavigateToSection("Funded");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        InvestmentViewModel? signedInvestment = null;
+        var signedDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < signedDeadline)
+        {
+            await portfolioVm.LoadInvestmentsFromSdkAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            signedInvestment = portfolioVm.Investments.FirstOrDefault(i =>
+                i.ProjectIdentifier == foundProject.ProjectId || i.ProjectName == foundProject.ProjectName);
+
+            if (signedInvestment is { Step: 2 } || signedInvestment?.ApprovalStatus == "Approved")
+                break;
+
+            await Task.Delay(PollInterval);
+        }
+
+        signedInvestment.Should().NotBeNull();
+        signedInvestment!.Step.Should().Be(2);
+        signedInvestment.ProjectType.Should().Be("invest");
+
+        var confirmResult = await portfolioVm.ConfirmInvestmentAsync(signedInvestment);
+        Dispatcher.UIThread.RunJobs();
+        confirmResult.Should().BeTrue();
+        signedInvestment.Step.Should().Be(3);
+        signedInvestment.StatusText.Should().Be("Investment Active");
+        signedInvestment.StatusClass.Should().Be("active");
+
+        Log("[STEP 10] Founder spending stage 1...");
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var founderProjectsVm = GetMyProjectsViewModel(window);
+        founderProjectsVm.Should().NotBeNull();
+        founderProjectsVm!.OpenManageProject(project);
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var manageVm = founderProjectsVm.SelectedManageProject;
+        manageVm.Should().NotBeNull();
+
+        Log("[STEP 10.0] Verifying ManageProject stages before founder spend...");
+        var preSpendDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < preSpendDeadline)
+        {
+            await manageVm!.LoadClaimableTransactionsAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var stage1 = manageVm.Stages.FirstOrDefault(s => s.Number == 1 && s.CanClaim);
+            if (manageVm.Stages.Count == installmentCount && stage1 != null)
+                break;
+
+            await Task.Delay(PollInterval);
+        }
+
+        manageVm!.Stages.Count.Should().Be(installmentCount);
+        manageVm.TotalStages.Should().Be(installmentCount);
+
+        var stage1Pre = manageVm.Stages.First(s => s.Number == 1);
+        var laterStages = manageVm.Stages.Where(s => s.Number > 1).OrderBy(s => s.Number).ToList();
+
+        stage1Pre.Available.Should().BeTrue();
+        stage1Pre.CanClaim.Should().BeTrue("first stage should already be claimable");
+        stage1Pre.AvailableTransactions.Count.Should().BeGreaterThan(0);
+        stage1Pre.SpentTransactionCount.Should().Be(0);
+        stage1Pre.UnspentTransactionCount.Should().BeGreaterThan(0);
+        stage1Pre.UtxoCount.Should().Be(stage1Pre.UnspentTransactionCount,
+            "stage 1 should only have unspent UTXOs before founder claim");
+        stage1Pre.ButtonMode.Should().Be("Claim");
+        stage1Pre.ShowAvailableInDays.Should().BeFalse();
+        stage1Pre.DaysUntilAvailable.Should().BeNull("stage 1 should already be released");
+        stage1Pre.AmountLeft.Should().NotBe("0.00000000");
+        stage1Pre.CompletionDate.Should().NotBeNullOrEmpty();
+
+        laterStages.Should().HaveCount(2);
+        var stage2Pre = laterStages[0];
+        var stage3Pre = laterStages[1];
+
+        laterStages.Should().AllSatisfy(stage =>
+        {
+            stage.Available.Should().BeTrue();
+            stage.CanClaim.Should().BeFalse("later stages should still be locked before recovery");
+            stage.DaysUntilAvailable.Should().NotBeNull();
+            stage.DaysUntilAvailable.Should().BeGreaterThan(0);
+            stage.UnspentTransactionCount.Should().BeGreaterThan(0);
+            stage.UtxoCount.Should().Be(stage.UnspentTransactionCount,
+                $"stage {stage.Number} should only have unspent locked UTXOs before founder claim");
+            stage.SpentTransactionCount.Should().Be(0);
+            stage.ButtonMode.Should().Be("AvailableInDays");
+            stage.ShowAvailableInDays.Should().BeTrue();
+            stage.AmountLeft.Should().NotBe("0.00000000");
+            stage.CompletionDate.Should().NotBeNullOrEmpty();
+        });
+
+        stage2Pre.DaysUntilAvailable.Should().BeInRange(10, 35,
+            "stage 2 should be the next monthly release and still some days away");
+        stage3Pre.DaysUntilAvailable.Should().BeInRange(35, 65,
+            "stage 3 should be farther out than stage 2");
+        stage3Pre.DaysUntilAvailable.Should().BeGreaterThan(stage2Pre.DaysUntilAvailable!.Value,
+            "stage 3 countdown should be greater than stage 2 countdown");
+
+        var claimableDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < claimableDeadline)
+        {
+            await manageVm.LoadClaimableTransactionsAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var claimableStage = manageVm.Stages.FirstOrDefault(s => s.Number == 1 && s.AvailableTransactions.Count > 0);
+            if (claimableStage != null)
+            {
+                var claimResult = await manageVm.ClaimStageFundsAsync(claimableStage.Number, claimableStage.AvailableTransactions.ToList());
+                Dispatcher.UIThread.RunJobs();
+                claimResult.Should().BeTrue();
+                break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        var spentStageDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < spentStageDeadline)
+        {
+            await manageVm.LoadClaimableTransactionsAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            if (manageVm.Stages.Any(s => s.Number == 1 && s.SpentTransactionCount > 0))
+                break;
+
+            await Task.Delay(PollInterval);
+        }
+
+        manageVm.Stages.Any(s => s.Number == 1 && s.SpentTransactionCount > 0).Should().BeTrue();
+
+        Log("[STEP 11] Navigating to Funded section...");
+        window.NavigateToSection("Funded");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var investment = portfolioVm.Investments.FirstOrDefault(i =>
+            i.ProjectName == foundProject.ProjectName || i.ProjectIdentifier == foundProject.ProjectId);
+        investment.Should().NotBeNull();
+
+        await portfolioVm.LoadInvestmentsFromSdkAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var sdkInvestment = portfolioVm.Investments.FirstOrDefault(i =>
+            i.ProjectName == foundProject.ProjectName || i.ProjectIdentifier == foundProject.ProjectId);
+        var targetInvestment = sdkInvestment ?? investment;
+        targetInvestment.Should().NotBeNull();
+
+        Log("[STEP 12] Loading recovery status...");
+        if (string.IsNullOrEmpty(targetInvestment!.InvestmentWalletId))
+            targetInvestment.InvestmentWalletId = investWallet.Id.Value;
+        if (string.IsNullOrEmpty(targetInvestment.ProjectIdentifier))
+            targetInvestment.ProjectIdentifier = foundProject.ProjectId;
+
+        await Task.Delay(TimeSpan.FromSeconds(30));
+
+        var hasRecoveryAction = false;
+        var recoveryDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < recoveryDeadline)
+        {
+            await portfolioVm.LoadRecoveryStatusAsync(targetInvestment);
+            Dispatcher.UIThread.RunJobs();
+
+            if (targetInvestment.RecoveryState.HasAction)
+            {
+                hasRecoveryAction = true;
+                break;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(15));
+        }
+
+        hasRecoveryAction.Should().BeTrue();
+
+        Log("[STEP 12.1] Verifying recovery stage display...");
+        targetInvestment.Stages.Count.Should().Be(installmentCount);
+
+        var recoveryStage1 = targetInvestment.Stages.FirstOrDefault(s => s.StageNumber == 1);
+        recoveryStage1.Should().NotBeNull();
+        recoveryStage1!.Status.Should().Be("Released");
+
+        var recoveryLaterStages = targetInvestment.Stages.Where(s => s.StageNumber > 1).ToList();
+        recoveryLaterStages.Should().HaveCount(2);
+        recoveryLaterStages.Should().AllSatisfy(s =>
+            s.Status.Should().BeOneOf("Pending", "Not Spent"));
+
+        targetInvestment.ProjectType.Should().Be("invest");
+        targetInvestment.ShowRecoverButton.Should().BeTrue();
+        targetInvestment.StagesToRecover.Should().BeGreaterThan(0);
+        double.TryParse(targetInvestment.AmountToRecover, NumberStyles.Float, CultureInfo.InvariantCulture, out var amountToRecover)
+            .Should().BeTrue();
+        amountToRecover.Should().BeGreaterThan(0);
+
+        var actionKey = targetInvestment.RecoveryState.ActionKey;
+        Log($"[STEP 12] Executing recovery action: '{actionKey}' ({targetInvestment.RecoveryState.ButtonLabel})...");
+
+        await EnsureWalletHasFeeFunds(window, targetInvestment.InvestmentWalletId, "before recovery action");
+        var recoveryResult = await ExecuteRecoveryActionWithRetry(portfolioVm, targetInvestment, actionKey);
+
+        Dispatcher.UIThread.RunJobs();
+
+        Log($"[STEP 13] Recovery result: {recoveryResult}");
+        recoveryResult.Should().BeTrue(
+            $"Recovery operation '{actionKey}' should succeed (transaction built and published)");
+
+        window.Close();
+        Log("========== FullInvestAndRecoverFlow PASSED ==========");
+    }
+
+    private async Task WipeExistingData(Window window)
+    {
+        window.NavigateToSettings();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+
+        var settingsView = window.GetVisualDescendants()
+            .OfType<SettingsView>()
+            .FirstOrDefault();
+
+        if (settingsView?.DataContext is SettingsViewModel settingsVm)
+        {
+            settingsVm.ConfirmWipeData();
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    private async Task CreateWalletViaGenerate(Window window)
+    {
+        var addWalletBtn = FindAddWalletButton(window);
+        addWalletBtn.Should().NotBeNull();
+
+        addWalletBtn!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, addWalletBtn));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(300);
+        Dispatcher.UIThread.RunJobs();
+
+        await window.ClickButton("BtnGenerate", UiTimeout);
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+        await window.ClickButton("BtnDownloadSeed", UiTimeout);
+        await Task.Delay(300);
+        Dispatcher.UIThread.RunJobs();
+        await window.ClickButton("BtnContinueBackup", UiTimeout);
+
+        var successPanel = await window.WaitForControl<StackPanel>("CreateWalletSuccessPanel", TimeSpan.FromSeconds(30));
+        successPanel.Should().NotBeNull();
+        await window.ClickButton("BtnCreateWalletDone", UiTimeout);
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private async Task FundWalletViaFaucet(Window window)
+    {
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        var walletId = fundsVm!.SeedGroups.FirstOrDefault()?.Wallets?.FirstOrDefault()?.Id.Value;
+        walletId.Should().NotBeNullOrEmpty();
+
+        var deadline = DateTime.UtcNow + FaucetBalanceTimeout;
+        var faucetRetryInterval = TimeSpan.FromSeconds(30);
+        var lastFaucetAttempt = DateTime.MinValue;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+
+            if (fundsVm.TotalBalance != "0.0000")
+                return;
+
+            if (DateTime.UtcNow - lastFaucetAttempt >= faucetRetryInterval)
+            {
+                lastFaucetAttempt = DateTime.UtcNow;
+                await fundsVm.GetTestCoinsAsync(walletId!);
+                Dispatcher.UIThread.RunJobs();
+            }
+
+            await ClickWalletCardButton(window, "WalletCardBtnRefresh");
+            await Task.Delay(PollInterval);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        fundsVm.TotalBalance.Should().NotBe("0.0000");
+    }
+
+    private async Task OpenCreateWizard(Window window, MyProjectsViewModel myProjectsVm)
+    {
+        myProjectsVm.CreateProjectVm.ResetWizard();
+        myProjectsVm.LaunchCreateWizard();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        myProjectsVm.ShowCreateWizard.Should().BeTrue();
+        myProjectsVm.CreateProjectVm.OnProjectDeployed = () =>
+        {
+            myProjectsVm.OnProjectDeployed(myProjectsVm.CreateProjectVm);
+            myProjectsVm.CloseCreateWizard();
+        };
+    }
+
+    private static Button? FindAddWalletButton(Window window)
+    {
+        var buttons = window.GetVisualDescendants().OfType<Button>().Where(b => b.IsVisible);
+
+        foreach (var btn in buttons)
+        {
+            if (btn.Content is string text && text.Contains("Add Wallet"))
+                return btn;
+
+            if (btn.Content is StackPanel panel)
+            {
+                foreach (var child in panel.Children.OfType<TextBlock>())
+                {
+                    if (child.Text == "Add Wallet")
+                        return btn;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private async Task ClickWalletCardButton(Window window, string automationId)
+    {
+        var button = await window.WaitForControl<Button>(automationId, UiTimeout);
+        button.Should().NotBeNull();
+        button!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, button));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private async Task<bool> ExecuteRecoveryActionWithRetry(
+        PortfolioViewModel portfolioVm,
+        InvestmentViewModel investment,
+        string actionKey)
+    {
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        var attempt = 0;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            attempt++;
+            Log($"[STEP 12] Recovery attempt #{attempt} for action '{actionKey}'...");
+
+            bool result = actionKey switch
+            {
+                "recovery" => await portfolioVm.RecoverFundsAsync(investment),
+                "unfundedRelease" => await portfolioVm.ReleaseFundsAsync(investment),
+                "endOfProject" => await portfolioVm.ClaimEndOfProjectAsync(investment),
+                "penaltyRelease" => await portfolioVm.PenaltyReleaseFundsAsync(investment),
+                _ => false
+            };
+
+            if (result)
+                return true;
+
+            await portfolioVm.LoadRecoveryStatusAsync(investment);
+            Dispatcher.UIThread.RunJobs();
+            Log($"[STEP 12] Retry state: ActionKey={investment.RecoveryState.ActionKey}, " +
+                $"HasUnspent={investment.RecoveryState.HasUnspentItems}, " +
+                $"EndOfProject={investment.RecoveryState.EndOfProject}, " +
+                $"HasReleaseSig={investment.RecoveryState.HasReleaseSignatures}, " +
+                $"InPenalty={investment.RecoveryState.HasSpendableItemsInPenalty}");
+            await Task.Delay(PollInterval);
+        }
+
+        return false;
+    }
+
+    private async Task EnsureWalletHasFeeFunds(Window window, string walletId, string context)
+    {
+        window.NavigateToSection("Funds");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            var refresh = await global::App.App.Services.GetRequiredService<Angor.Sdk.Wallet.Application.IWalletAppService>()
+                .RefreshAndGetAccountBalanceInfo(new WalletId(walletId));
+
+            if (refresh.IsSuccess)
+            {
+                var info = refresh.Value;
+                var available = info.TotalBalance + info.TotalUnconfirmedBalance + info.TotalBalanceReserved;
+                var availableBtc = available / 100_000_000m;
+                Log($"[STEP 12] Wallet balance {context}: {availableBtc:F8} BTC available for fees");
+                if (available > 20_000)
+                    return;
+            }
+
+            Log($"[STEP 12] Wallet needs fee funds {context}. Requesting faucet coins...");
+            await fundsVm!.GetTestCoinsAsync(walletId);
+            await ClickWalletCardButton(window, "WalletCardBtnRefresh");
+            await Task.Delay(PollInterval);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        throw new InvalidOperationException($"Wallet '{walletId}' did not receive enough fee funds {context}.");
+    }
+
+    private static FundsViewModel? GetFundsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FundsView>().FirstOrDefault()?.DataContext as FundsViewModel;
+    }
+
+    private static MyProjectsViewModel? GetMyProjectsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<MyProjectsView>().FirstOrDefault()?.DataContext as MyProjectsViewModel;
+    }
+
+    private static FindProjectsViewModel? GetFindProjectsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FindProjectsView>().FirstOrDefault()?.DataContext as FindProjectsViewModel;
+    }
+
+    private static FundersViewModel? GetFundersViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FundersView>().FirstOrDefault()?.DataContext as FundersViewModel;
+    }
+
+    private static void Log(string message)
+    {
+        Console.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] {message}");
+    }
+}

--- a/src/design/App.Test.Integration/InvestAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/InvestAndRecoverTest.cs
@@ -553,14 +553,22 @@ public class InvestAndRecoverTest
         Log("[STEP 12.1] Verifying recovery stage display...");
         targetInvestment.Stages.Count.Should().Be(installmentCount);
 
+        foreach (var stage in targetInvestment.Stages)
+        {
+            stage.StageNumber.Should().BeGreaterThan(0);
+            stage.Amount.Should().NotBe("0.00000000");
+            stage.Status.Should().BeOneOf("Spent by founder", "Not Spent", "Pending");
+            Log($"[STEP 12.1] Recovery Stage #{stage.StageNumber}: amount={stage.Amount}, status='{stage.Status}'");
+        }
+
         var recoveryStage1 = targetInvestment.Stages.FirstOrDefault(s => s.StageNumber == 1);
         recoveryStage1.Should().NotBeNull();
-        recoveryStage1!.Status.Should().Be("Released");
+        recoveryStage1!.Status.Should().Be("Spent by founder");
 
         var recoveryLaterStages = targetInvestment.Stages.Where(s => s.StageNumber > 1).ToList();
         recoveryLaterStages.Should().HaveCount(2);
         recoveryLaterStages.Should().AllSatisfy(s =>
-            s.Status.Should().BeOneOf("Pending", "Not Spent"));
+            s.Status.Should().Be("Not Spent"));
 
         targetInvestment.ProjectType.Should().Be("invest");
         targetInvestment.ShowRecoverButton.Should().BeTrue();

--- a/src/design/App.Test.Integration/InvestAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/InvestAndRecoverTest.cs
@@ -578,16 +578,16 @@ public class InvestAndRecoverTest
         amountToRecover.Should().BeGreaterThan(0);
 
         var actionKey = targetInvestment.RecoveryState.ActionKey;
-        Log($"[STEP 12] Executing recovery action: '{actionKey}' ({targetInvestment.RecoveryState.ButtonLabel})...");
+        Log($"[STEP 12] Clicking recovery action button: '{actionKey}' ({targetInvestment.RecoveryState.ButtonLabel})...");
 
         await EnsureWalletHasFeeFunds(window, targetInvestment.InvestmentWalletId, "before recovery action");
-        var recoveryResult = await ExecuteRecoveryActionWithRetry(portfolioVm, targetInvestment, actionKey);
+        await window.ClickRecoveryFlowAsync(portfolioVm, targetInvestment, TimeSpan.FromSeconds(30));
 
         Dispatcher.UIThread.RunJobs();
 
-        Log($"[STEP 13] Recovery result: {recoveryResult}");
-        recoveryResult.Should().BeTrue(
-            $"Recovery operation '{actionKey}' should succeed (transaction built and published)");
+        Log("[STEP 13] Recovery flow completed through real UI button path");
+        targetInvestment.ShowSuccessModal.Should().BeTrue(
+            $"Recovery operation '{actionKey}' should succeed and show the success modal");
 
         window.Close();
         Log("========== FullInvestAndRecoverFlow PASSED ==========");
@@ -717,44 +717,6 @@ public class InvestAndRecoverTest
         Dispatcher.UIThread.RunJobs();
         await Task.Delay(200);
         Dispatcher.UIThread.RunJobs();
-    }
-
-    private async Task<bool> ExecuteRecoveryActionWithRetry(
-        PortfolioViewModel portfolioVm,
-        InvestmentViewModel investment,
-        string actionKey)
-    {
-        var deadline = DateTime.UtcNow + IndexerLagTimeout;
-        var attempt = 0;
-
-        while (DateTime.UtcNow < deadline)
-        {
-            attempt++;
-            Log($"[STEP 12] Recovery attempt #{attempt} for action '{actionKey}'...");
-
-            bool result = actionKey switch
-            {
-                "recovery" => await portfolioVm.RecoverFundsAsync(investment),
-                "unfundedRelease" => await portfolioVm.ReleaseFundsAsync(investment),
-                "endOfProject" => await portfolioVm.ClaimEndOfProjectAsync(investment),
-                "penaltyRelease" => await portfolioVm.PenaltyReleaseFundsAsync(investment),
-                _ => false
-            };
-
-            if (result)
-                return true;
-
-            await portfolioVm.LoadRecoveryStatusAsync(investment);
-            Dispatcher.UIThread.RunJobs();
-            Log($"[STEP 12] Retry state: ActionKey={investment.RecoveryState.ActionKey}, " +
-                $"HasUnspent={investment.RecoveryState.HasUnspentItems}, " +
-                $"EndOfProject={investment.RecoveryState.EndOfProject}, " +
-                $"HasReleaseSig={investment.RecoveryState.HasReleaseSignatures}, " +
-                $"InPenalty={investment.RecoveryState.HasSpendableItemsInPenalty}");
-            await Task.Delay(PollInterval);
-        }
-
-        return false;
     }
 
     private async Task EnsureWalletHasFeeFunds(Window window, string walletId, string context)

--- a/src/design/App.Test.Integration/InvestAndRecoverTest.md
+++ b/src/design/App.Test.Integration/InvestAndRecoverTest.md
@@ -1,0 +1,51 @@
+# InvestAndRecoverTest
+
+## Purpose
+
+Full end-to-end integration test that boots the real Avalonia app in headless mode, creates a wallet, funds it via a testnet faucet, creates an **Invest-type** project through the 6-step wizard, submits an investment, has the **founder approve the pending request**, has the **investor confirm the signed investment**, then has the **founder spend stage 1**, and finally has the **investor recover the remaining stages**.
+
+## Scenario
+
+1. Boot the app and wipe profile data.
+2. Create a wallet with the Generate flow.
+3. Faucet-fund the wallet until balance is non-zero.
+4. Create an **Invest** project with:
+   - target amount `1.0 BTC`
+   - investment end date `now + 3 months`
+   - 3 monthly generated stages
+   - start date set in the past so stage 1 is claimable while later stages remain locked
+5. Reload founder projects so `ProjectIdentifier` and `OwnerWalletId` are populated.
+6. Find the project from SDK-backed Find Projects and verify metadata like project type and displayed target amount.
+7. Invest `0.02 BTC`, add the investment to the portfolio, reload from SDK, and verify there is exactly one portfolio entry for the project.
+8. Founder approves the pending investment request in **Funders**.
+9. Investor confirms the signed investment in **Funded** and verifies it becomes active.
+10. Founder opens **Manage Project**, verifies:
+    - stage 1 is claimable now
+    - stages 2 and 3 are locked
+    - locked stages show `AvailableInDays`
+    - stage 3 countdown is greater than stage 2 countdown
+11. Founder spends stage 1.
+12. Investor loads recovery status and verifies:
+    - recovery stages are populated
+    - stage 1 is `Released`
+    - stages 2 and 3 are still unreleased
+13. Investor executes the recovery action exposed by `RecoveryState.ActionKey`.
+
+## Notes
+
+- This is the single-profile companion to the multi-profile invest flow in `src/design/App.Test.Integration/MultiInvestClaimAndRecoverTest.cs`.
+- It intentionally exercises VM assertions in addition to transaction success so duplicate rows, wrong stage states, or missing recovery-stage data fail fast.
+- Invest projects do not use the fund penalty-threshold behavior for approval routing; they still require founder approval in the portfolio flow.
+- The test relies on real Signet, faucet, indexer, and Nostr infrastructure, so indexer lag and mempool propagation are expected.
+
+## Run
+
+```bash
+dotnet test "src/design/App.Test.Integration/App.Test.Integration.csproj" --filter "DisplayName~FullInvestAndRecoverFlow"
+```
+
+Verbose:
+
+```bash
+dotnet test "src/design/App.Test.Integration/App.Test.Integration.csproj" --filter "DisplayName~FullInvestAndRecoverFlow" --logger "console;verbosity=detailed"
+```

--- a/src/design/App.Test.Integration/InvestmentCancellationTest.cs
+++ b/src/design/App.Test.Integration/InvestmentCancellationTest.cs
@@ -246,10 +246,9 @@ public class InvestmentCancellationTest
 
         // ── Step 2: Cancel the pending investment (before founder approval) ──
         Log(profileName, "Cancelling pending investment (before founder approval)...");
-        var cancelResult = await portfolioVm.CancelInvestmentAsync(pendingInvestment);
+        await window.ClickInvestmentDetailActionAsync(portfolioVm, pendingInvestment, "CancelInvestmentStep1Button");
         Dispatcher.UIThread.RunJobs();
 
-        cancelResult.Should().BeTrue("Cancellation should succeed for a pending (Step 1) investment");
         pendingInvestment.StatusText.Should().Be("Cancelled", "Status should be 'Cancelled' after cancellation");
         pendingInvestment.Status.Should().Be("Cancelled", "Status field should be 'Cancelled'");
         Log(profileName, $"Investment cancelled. Status='{pendingInvestment.StatusText}'");
@@ -319,7 +318,7 @@ public class InvestmentCancellationTest
 
         pendingSignature.Should().NotBeNull("above-threshold investment should require founder approval");
         Log(profileName, $"Approving signature request id={pendingSignature!.Id} for project {project.ProjectIdentifier}");
-        fundersVm!.ApproveSignature(pendingSignature.Id);
+        await window.ClickApproveSignatureAsync(fundersVm!, pendingSignature, UiTimeout);
 
         var approvalDeadline = DateTime.UtcNow + IndexerLagTimeout;
         while (DateTime.UtcNow < approvalDeadline)
@@ -375,10 +374,9 @@ public class InvestmentCancellationTest
 
         // Cancel the approved investment
         Log(profileName, "Cancelling approved investment (after founder approval)...");
-        var cancelResult = await portfolioVm.CancelInvestmentAsync(approvedInvestment);
+        await window.ClickInvestmentDetailActionAsync(portfolioVm, approvedInvestment, "CancelInvestmentButton");
         Dispatcher.UIThread.RunJobs();
 
-        cancelResult.Should().BeTrue("Cancellation should succeed for an approved (Step 2) investment");
         approvedInvestment.StatusText.Should().Be("Cancelled", "Status should be 'Cancelled' after cancellation");
         approvedInvestment.Status.Should().Be("Cancelled", "Status field should be 'Cancelled'");
         Log(profileName, $"Investment cancelled after approval. Status='{approvedInvestment.StatusText}'");
@@ -412,8 +410,7 @@ public class InvestmentCancellationTest
 
         Log(profileName, $"Confirming approved investment. Step={investment.Step}, Status={investment.StatusText}");
         investment.ApprovalStatus.Should().Be("Approved");
-        var confirmResult = await portfolioVm.ConfirmInvestmentAsync(investment);
-        confirmResult.Should().BeTrue("founder-approved investment should be confirmable by the investor");
+        await window.ClickInvestmentDetailActionAsync(portfolioVm, investment, "ConfirmInvestmentButton");
 
         // Wait for Step 3 (active)
         var activeDeadline = DateTime.UtcNow + IndexerLagTimeout;

--- a/src/design/App.Test.Integration/MultiFundClaimAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/MultiFundClaimAndRecoverTest.cs
@@ -459,7 +459,7 @@ public class MultiFundClaimAndRecoverTest
 
         pendingSignature.Should().NotBeNull("above-threshold investment should require founder approval");
         Log(profileName, $"Approving signature request id={pendingSignature!.Id} for project {project.ProjectIdentifier}");
-        fundersVm!.ApproveSignature(pendingSignature.Id);
+        await window.ClickApproveSignatureAsync(fundersVm!, pendingSignature, UiTimeout);
 
         var approvalDeadline = DateTime.UtcNow + IndexerLagTimeout;
         while (DateTime.UtcNow < approvalDeadline)
@@ -490,8 +490,7 @@ public class MultiFundClaimAndRecoverTest
 
         Log(profileName, $"Confirming approved investment. Step={investment.Step}, Status={investment.StatusText}");
         investment.ApprovalStatus.Should().Be("Approved");
-        var confirmResult = await portfolioVm.ConfirmInvestmentAsync(investment);
-        confirmResult.Should().BeTrue("founder-approved investment should be confirmable by the investor");
+        await window.ClickInvestmentDetailActionAsync(portfolioVm, investment, "ConfirmInvestmentButton", UiTimeout);
 
         var activeDeadline = DateTime.UtcNow + IndexerLagTimeout;
         while (DateTime.UtcNow < activeDeadline)
@@ -528,17 +527,14 @@ public class MultiFundClaimAndRecoverTest
             string.Equals(p.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
         founderProject.Should().NotBeNull();
 
-        myProjectsVm.OpenManageProject(founderProject!);
-        Dispatcher.UIThread.RunJobs();
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
-
         var manageVm = myProjectsVm.SelectedManageProject;
-        manageVm.Should().NotBeNull();
 
         var deadline = DateTime.UtcNow + IndexerLagTimeout;
         while (DateTime.UtcNow < deadline)
         {
+            await myProjectsVm!.LoadFounderProjectsAsync();
+            myProjectsVm.OpenManageProject(founderProject!);
+            manageVm = myProjectsVm.SelectedManageProject;
             await manageVm!.LoadClaimableTransactionsAsync();
             Dispatcher.UIThread.RunJobs();
 
@@ -552,8 +548,7 @@ public class MultiFundClaimAndRecoverTest
                 stage1.AvailableTransactions.Count.Should().Be(2,
                     "founder should claim stage 1 from both investor UTXOs");
 
-                var claimResult = await manageVm.ClaimStageFundsAsync(stage1.Number, stage1.AvailableTransactions.ToList());
-                claimResult.Should().BeTrue();
+                await window.ClickManageProjectClaimStageAsync(myProjectsVm, founderProject!, stage1.Number, UiTimeout);
                 Log(profileName, "Founder claimed stage 1 using both available UTXOs.");
                 break;
             }

--- a/src/design/App.Test.Integration/MultiInvestClaimAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/MultiInvestClaimAndRecoverTest.cs
@@ -338,6 +338,11 @@ public class MultiInvestClaimAndRecoverTest
     {
         var foundProject = await FindProjectFromSdkAsync(window, profileName, project);
 
+        // Verify target amount was stored correctly as 1 BTC (not 1 satoshi).
+        // Target is formatted as BTC with 5 decimal places by ProjectItemViewModel.FromDto().
+        foundProject.Target.Should().Be("1.00000",
+            "TargetAmount '1.0' means 1 BTC = 100_000_000 sats; the SDK should store sats and display converts back to BTC");
+
         var findProjectsVm = GetFindProjectsViewModel(window);
         findProjectsVm.Should().NotBeNull();
 

--- a/src/design/App.Test.Integration/MultiInvestClaimAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/MultiInvestClaimAndRecoverTest.cs
@@ -461,7 +461,7 @@ public class MultiInvestClaimAndRecoverTest
         {
             Log(profileName,
                 $"Approving signature request id={pendingSignature.Id} for project {project.ProjectIdentifier}");
-            fundersVm!.ApproveSignature(pendingSignature.Id);
+            await window.ClickApproveSignatureAsync(fundersVm!, pendingSignature, UiTimeout);
         }
 
         var approvalDeadline = DateTime.UtcNow + IndexerLagTimeout;
@@ -499,8 +499,7 @@ public class MultiInvestClaimAndRecoverTest
         investment.ApprovalStatus.Should().Be("Approved");
         investment.Step.Should().Be(2, "approved investments should require explicit investor confirmation");
 
-        var confirmResult = await portfolioVm.ConfirmInvestmentAsync(investment);
-        confirmResult.Should().BeTrue("founder-approved investment should be confirmable by the investor");
+        await window.ClickInvestmentDetailActionAsync(portfolioVm, investment, "ConfirmInvestmentButton", UiTimeout);
 
         var activeDeadline = DateTime.UtcNow + IndexerLagTimeout;
         while (DateTime.UtcNow < activeDeadline)
@@ -537,17 +536,14 @@ public class MultiInvestClaimAndRecoverTest
             string.Equals(p.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
         founderProject.Should().NotBeNull();
 
-        myProjectsVm.OpenManageProject(founderProject!);
-        Dispatcher.UIThread.RunJobs();
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
-
         var manageVm = myProjectsVm.SelectedManageProject;
-        manageVm.Should().NotBeNull();
 
         var deadline = DateTime.UtcNow + IndexerLagTimeout;
         while (DateTime.UtcNow < deadline)
         {
+            await myProjectsVm!.LoadFounderProjectsAsync();
+            myProjectsVm.OpenManageProject(founderProject!);
+            manageVm = myProjectsVm.SelectedManageProject;
             await manageVm!.LoadClaimableTransactionsAsync();
             Dispatcher.UIThread.RunJobs();
 
@@ -561,8 +557,7 @@ public class MultiInvestClaimAndRecoverTest
                 stage1.AvailableTransactions.Count.Should().Be(2,
                     "founder should claim stage 1 from both investor UTXOs");
 
-                var claimResult = await manageVm.ClaimStageFundsAsync(stage1.Number, stage1.AvailableTransactions.ToList());
-                claimResult.Should().BeTrue();
+                await window.ClickManageProjectClaimStageAsync(myProjectsVm, founderProject!, stage1.Number, UiTimeout);
                 Log(profileName, "Founder claimed stage 1 using both available UTXOs.");
                 break;
             }
@@ -604,19 +599,16 @@ public class MultiInvestClaimAndRecoverTest
             string.Equals(p.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
         founderProject.Should().NotBeNull();
 
-        myProjectsVm.OpenManageProject(founderProject!);
-        Dispatcher.UIThread.RunJobs();
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
-
-        var manageVm = myProjectsVm.SelectedManageProject;
-        manageVm.Should().NotBeNull();
-
         var deadline = DateTime.UtcNow + IndexerLagTimeout;
         while (DateTime.UtcNow < deadline)
         {
-            var releaseResult = await manageVm!.ReleaseFundsToInvestorsAsync();
-            if (releaseResult)
+            await myProjectsVm!.LoadFounderProjectsAsync();
+            myProjectsVm.OpenManageProject(founderProject!);
+            var manageVm = myProjectsVm.SelectedManageProject;
+            manageVm.Should().NotBeNull();
+
+            var releaseSucceeded = await window.ClickManageProjectReleaseFundsAsync(myProjectsVm, founderProject!, UiTimeout);
+            if (releaseSucceeded)
             {
                 Log(profileName, "Founder released remaining stages to investors.");
                 return;

--- a/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:fp="clr-namespace:App.UI.Sections.FindProjects"
              xmlns:controls="clr-namespace:App.UI.Shared.Controls"
+             xmlns:i="https://github.com/projektanker/icons.avalonia"
              mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="800"
              x:Class="App.UI.Sections.FindProjects.FindProjectsView"
              x:DataType="fp:FindProjectsViewModel">
@@ -37,33 +38,86 @@
         <!-- investor+raised, target, progress bar.                  -->
         <!-- ═══════════════════════════════════════════════════════ -->
         <controls:ScrollableView Name="ProjectListPanel" ContentPadding="24,24,24,24">
-            <ItemsControl ItemsSource="{Binding Projects}">
-                <ItemsControl.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <controls:ResponsiveGrid MinItemWidth="320"
-                                                 ColumnSpacing="16"
-                                                 RowSpacing="16" />
-                    </ItemsPanelTemplate>
-                </ItemsControl.ItemsPanel>
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate x:DataType="fp:ProjectItemViewModel">
-                        <controls:ProjectCard
-                            ProjectName="{Binding ProjectName}"
-                            ShortDescription="{Binding ShortDescription}"
-                            InvestorCount="{Binding InvestorCount}"
-                            InvestorLabel="{Binding InvestorLabel}"
-                            Raised="{Binding Raised}"
-                            Target="{Binding Target}"
-                            TargetLabel="{Binding TargetLabel}"
-                            Progress="{Binding Progress}"
-                            ProjectType="{Binding ProjectType}"
-                            Status="{Binding Status}"
-                            Banner="{Binding BannerUrl}"
-                            Avatar="{Binding AvatarUrl}"
-                            CurrencySymbol="{Binding $parent[UserControl].DataContext.CurrencySymbol}" />
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
+            <StackPanel Spacing="16">
+                <!-- Header with refresh button -->
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock Grid.Column="0"
+                               Text="Discover Projects"
+                               FontSize="20" FontWeight="Bold"
+                               VerticalAlignment="Center" />
+                    <Button Name="RefreshProjectsButton" Grid.Column="1"
+                            Classes="Primary"
+                            Padding="12,8"
+                            VerticalAlignment="Center"
+                            IsEnabled="{Binding !IsLoading}">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <!-- Normal state: refresh icon -->
+                            <i:Icon Value="fa-solid fa-arrows-rotate"
+                                    FontSize="14"
+                                    IsVisible="{Binding !IsLoading}"
+                                    Foreground="{DynamicResource PrimaryButtonForeground}"
+                                    VerticalAlignment="Center" />
+                            <!-- Loading state: spinning icon -->
+                            <i:Icon Value="fa-solid fa-spinner"
+                                    FontSize="14"
+                                    IsVisible="{Binding IsLoading}"
+                                    Foreground="{DynamicResource PrimaryButtonForeground}"
+                                    VerticalAlignment="Center"
+                                    RenderTransformOrigin="50%,50%">
+                                <i:Icon.RenderTransform>
+                                    <RotateTransform />
+                                </i:Icon.RenderTransform>
+                                <i:Icon.Styles>
+                                    <Style Selector="i|Icon[IsVisible=True]">
+                                        <Style.Animations>
+                                            <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                <KeyFrame Cue="0%">
+                                                    <Setter Property="RotateTransform.Angle" Value="0" />
+                                                </KeyFrame>
+                                                <KeyFrame Cue="100%">
+                                                    <Setter Property="RotateTransform.Angle" Value="360" />
+                                                </KeyFrame>
+                                            </Animation>
+                                        </Style.Animations>
+                                    </Style>
+                                </i:Icon.Styles>
+                            </i:Icon>
+                            <TextBlock Text="Refresh"
+                                       VerticalAlignment="Center"
+                                       FontSize="13" FontWeight="SemiBold" />
+                        </StackPanel>
+                    </Button>
+                </Grid>
+
+                <!-- Project cards in responsive grid -->
+                <ItemsControl ItemsSource="{Binding Projects}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <controls:ResponsiveGrid MinItemWidth="320"
+                                                     ColumnSpacing="16"
+                                                     RowSpacing="16" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="fp:ProjectItemViewModel">
+                            <controls:ProjectCard
+                                ProjectName="{Binding ProjectName}"
+                                ShortDescription="{Binding ShortDescription}"
+                                InvestorCount="{Binding InvestorCount}"
+                                InvestorLabel="{Binding InvestorLabel}"
+                                Raised="{Binding Raised}"
+                                Target="{Binding Target}"
+                                TargetLabel="{Binding TargetLabel}"
+                                Progress="{Binding Progress}"
+                                ProjectType="{Binding ProjectType}"
+                                Status="{Binding Status}"
+                                Banner="{Binding BannerUrl}"
+                                Avatar="{Binding AvatarUrl}"
+                                CurrencySymbol="{Binding $parent[UserControl].DataContext.CurrencySymbol}" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
         </controls:ScrollableView>
     </Panel>
 </UserControl>

--- a/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml.cs
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml.cs
@@ -27,6 +27,17 @@ public partial class FindProjectsView : UserControl
         _detailPanel = this.FindControl<Panel>("ProjectDetailPanel");
         _investPanel = this.FindControl<Panel>("InvestPagePanel");
 
+        // Wire refresh button
+        var refreshBtn = this.FindControl<Button>("RefreshProjectsButton");
+        if (refreshBtn != null)
+        {
+            refreshBtn.Click += async (_, _) =>
+            {
+                if (DataContext is FindProjectsViewModel fvm)
+                    await fvm.LoadProjectsFromSdkAsync();
+            };
+        }
+
         // Listen for taps on ProjectCard elements to open project detail
         AddHandler(InputElement.TappedEvent, OnCardTapped, RoutingStrategies.Bubble);
 

--- a/src/design/App/UI/Sections/FindProjects/ProjectDetailView.axaml
+++ b/src/design/App/UI/Sections/FindProjects/ProjectDetailView.axaml
@@ -889,6 +889,24 @@
                                 </DockPanel>
                             </Border>
                         </StackPanel>
+
+                        <!-- View Project JSON -->
+                        <Border Name="ViewProjectJsonBtn"
+                                Background="{DynamicResource SurfaceMedium}"
+                                BorderBrush="{DynamicResource Stroke}"
+                                BorderThickness="1"
+                                CornerRadius="8"
+                                Padding="12,10"
+                                Cursor="Hand">
+                            <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                                <i:Icon Value="fa-solid fa-code"
+                                       FontSize="16"
+                                       Foreground="{DynamicResource TextStrong}" />
+                                <TextBlock Text="View Project Info JSON"
+                                           FontSize="14" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextStrong}" />
+                            </StackPanel>
+                        </Border>
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/src/design/App/UI/Sections/FindProjects/ProjectDetailView.axaml.cs
+++ b/src/design/App/UI/Sections/FindProjects/ProjectDetailView.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.VisualTree;
+using Angor.Sdk.Funding.Projects;
 using Angor.Shared;
 using Angor.Shared.Services;
 using App.UI.Shared.Controls;
@@ -123,6 +124,11 @@ public partial class ProjectDetailView : UserControl
         if (explorerLink != null)
             explorerLink.PointerPressed += OnExplorerLinkPressed;
 
+        // View Project JSON button — show project info as formatted JSON
+        var viewJsonBtn = this.FindControl<Border>("ViewProjectJsonBtn");
+        if (viewJsonBtn != null)
+            viewJsonBtn.PointerPressed += OnViewProjectJsonPressed;
+
         // Set progress bar width after loaded
         Loaded += OnLoaded;
     }
@@ -229,6 +235,21 @@ public partial class ProjectDetailView : UserControl
             var derivation = App.Services.GetRequiredService<IDerivationOperations>();
             var bitcoinAddress = derivation.ConvertAngorKeyToBitcoinAddress(project.ProjectId);
             ExplorerHelper.OpenAddress(networkService, bitcoinAddress);
+        }
+        e.Handled = true;
+    }
+
+    private void OnViewProjectJsonPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is ProjectItemViewModel project && !string.IsNullOrEmpty(project.ProjectId))
+        {
+            var shell = this.FindAncestorOfType<ShellView>();
+            if (shell?.DataContext is ShellViewModel shellVm && !shellVm.IsModalOpen)
+            {
+                var projectAppService = App.Services.GetRequiredService<IProjectAppService>();
+                var modal = new ProjectInfoJsonModal(project.ProjectId, projectAppService);
+                shellVm.ShowModal(modal);
+            }
         }
         e.Handled = true;
     }

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
@@ -588,12 +588,12 @@ public partial class CreateProjectViewModel : ReactiveObject
     /// </summary>
     private CreateProjectDto BuildCreateProjectDto()
     {
-        // Parse target amount to satoshis
-        var targetSats = long.TryParse(TargetAmount, out var tSats) ? tSats
-            : double.TryParse(TargetAmount, System.Globalization.NumberStyles.Float,
+        // Parse target amount as BTC and convert to satoshis.
+        // The UI always accepts BTC values (e.g. "1" = 1 BTC = 100_000_000 sats).
+        var targetSats = decimal.TryParse(TargetAmount, System.Globalization.NumberStyles.Number,
                 System.Globalization.CultureInfo.InvariantCulture, out var tBtc)
-                ? ((decimal)tBtc).ToUnitSatoshi()
-                : 0L;
+            ? tBtc.ToUnitSatoshi()
+            : 0L;
 
         // Map UI project type to SDK ProjectType
         var sdkProjectType = ProjectType switch

--- a/src/design/App/UI/Sections/MyProjects/ManageProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/ManageProjectViewModel.cs
@@ -282,6 +282,21 @@ public partial class ManageProjectViewModel : ReactiveObject
             TransactionSpent = stats.SpentTransactions;
             TransactionAvailable = stats.AvailableTransactions;
 
+            // Populate next stage countdown from SDK statistics
+            if (stats.NextStage != null && stats.NextStage.ReleaseDate > DateTime.UtcNow)
+            {
+                var timeUntil = stats.NextStage.ReleaseDate - DateTime.UtcNow;
+                CountdownDays = (int)timeUntil.TotalDays;
+                CountdownHours = timeUntil.Hours;
+                CountdownMins = timeUntil.Minutes;
+            }
+            else
+            {
+                CountdownDays = 0;
+                CountdownHours = 0;
+                CountdownMins = 0;
+            }
+
             this.RaisePropertyChanged(nameof(TotalInvestment));
             this.RaisePropertyChanged(nameof(AvailableBalance));
             this.RaisePropertyChanged(nameof(Withdrawable));
@@ -289,6 +304,9 @@ public partial class ManageProjectViewModel : ReactiveObject
             this.RaisePropertyChanged(nameof(TransactionTotal));
             this.RaisePropertyChanged(nameof(TransactionSpent));
             this.RaisePropertyChanged(nameof(TransactionAvailable));
+            this.RaisePropertyChanged(nameof(CountdownDays));
+            this.RaisePropertyChanged(nameof(CountdownHours));
+            this.RaisePropertyChanged(nameof(CountdownMins));
         }
         catch (Exception ex)
         {
@@ -330,22 +348,34 @@ public partial class ManageProjectViewModel : ReactiveObject
                 totalAmount += stageAmount;
 
                 var claimable = stageTransactions.Where(t => t.ClaimStatus == Angor.Sdk.Funding.Founder.Dtos.ClaimStatus.Unspent).ToList();
+                var locked = stageTransactions.Where(t => t.ClaimStatus == Angor.Sdk.Funding.Founder.Dtos.ClaimStatus.Locked).ToList();
                 var spent = stageTransactions.Where(t => t.ClaimStatus == Angor.Sdk.Funding.Founder.Dtos.ClaimStatus.SpentByFounder).ToList();
 
+                // AmountLeft includes both claimable (Unspent) and locked transactions
+                var unspentAmount = claimable.Sum(t => t.Amount.Sats.ToUnitBtc()) + locked.Sum(t => t.Amount.Sats.ToUnitBtc());
                 availableAmount += (double)claimable.Sum(t => t.Amount.Sats.ToUnitBtc());
                 availableCount += claimable.Count;
                 spentCount += spent.Count;
 
+                // Calculate days until available from DynamicReleaseDate for locked stages
+                int? daysUntilAvailable = null;
+                var releaseDate = stageTransactions.FirstOrDefault()?.DynamicReleaseDate;
+                if (locked.Count > 0 && releaseDate.HasValue && releaseDate.Value > DateTime.UtcNow)
+                {
+                    daysUntilAvailable = (int)Math.Ceiling((releaseDate.Value - DateTime.UtcNow).TotalDays);
+                }
+
                 var stage = new ManageStageViewModel
                 {
                     Number = group.Key,
-                    AmountLeft = claimable.Sum(t => t.Amount.Sats.ToUnitBtc()).ToString("F8", CultureInfo.InvariantCulture),
+                    AmountLeft = unspentAmount.ToString("F8", CultureInfo.InvariantCulture),
                     UtxoCount = stageTransactions.Count,
-                    CompletionDate = stageTransactions.FirstOrDefault()?.DynamicReleaseDate?.ToString("dd MMMM yyyy") ?? "",
-                    Available = claimable.Count > 0,
+                    CompletionDate = releaseDate?.ToString("dd MMMM yyyy") ?? "",
+                    Available = claimable.Count > 0 || locked.Count > 0,
                     CanClaim = claimable.Count > 0,
+                    DaysUntilAvailable = daysUntilAvailable,
                     SpentTransactionCount = spent.Count,
-                    UnspentTransactionCount = claimable.Count,
+                    UnspentTransactionCount = claimable.Count + locked.Count,
                 };
 
                 foreach (var tx in claimable)

--- a/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
@@ -67,15 +67,15 @@ public class InvestmentStageViewModel
     public string Percentage { get; set; } = "0%";
     public string ReleaseDate { get; set; } = "";
     public string Amount { get; set; } = "0.00000000";
-    public string Status { get; set; } = "Pending"; // Pending, Released, Available, Not Spent
+    public string Status { get; set; } = "Pending";
     /// <summary>Stage label prefix: "Stage" for invest, "Payment" for fund/subscription</summary>
     public string StagePrefix { get; set; } = "Stage";
 
     // Status visibility helpers for per-status badge coloring
     public bool IsStatusPending => Status == "Pending";
-    public bool IsStatusReleased => Status == "Released";
+    public bool IsStatusReleased => Status == "Released" || Status == "Spent by founder";
     public bool IsStatusNotSpent => Status == "Not Spent";
-    public bool IsStatusRecovered => Status == "Recovered";
+    public bool IsStatusRecovered => Status == "Recovered" || Status == "Penalty can be released" || Status.StartsWith("Penalty,");
 }
 
 /// <summary>
@@ -306,14 +306,14 @@ public class InvestmentViewModel : INotifyPropertyChanged
     };
 
     /// <summary>Number of unreleased stages (Vue: stagesToRecover computed)</summary>
-    public int StagesToRecover => Stages.Count(s => s.Status != "Released");
+    public int StagesToRecover => Stages.Count(s => s.Status != "Released" && !s.IsStatusRecovered);
 
     /// <summary>Sum of unreleased stage amounts (Vue: amountToRecover computed)</summary>
     public string AmountToRecover
     {
         get
         {
-            var total = Stages.Where(s => s.Status != "Released")
+            var total = Stages.Where(s => s.Status != "Released" && !s.IsStatusRecovered)
                 .Sum(s => double.TryParse(s.Amount, System.Globalization.NumberStyles.Float,
                     System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0);
             return total.ToString("F5", System.Globalization.CultureInfo.InvariantCulture);
@@ -766,11 +766,18 @@ public partial class PortfolioViewModel : ReactiveObject
             investment.Stages.Clear();
             foreach (var item in recovery.Items)
             {
+                var status = item.Status switch
+                {
+                    "Unspent" => "Not Spent",
+                    var s when !string.IsNullOrEmpty(s) => s,
+                    _ => item.IsSpent ? "Released" : (recovery.HasSpendableItemsInPenalty ? "Pending" : "Not Spent")
+                };
+
                 investment.Stages.Add(new InvestmentStageViewModel
                 {
                     StageNumber = item.StageIndex + 1,
                     Amount = item.Amount.ToUnitBtc().ToString("F8", CultureInfo.InvariantCulture),
-                    Status = item.IsSpent ? "Released" : (recovery.HasSpendableItemsInPenalty ? "Pending" : "Not Spent")
+                    Status = status
                 });
             }
 

--- a/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
@@ -384,6 +384,23 @@ public class InvestmentViewModel : INotifyPropertyChanged
         set { if (_isProcessing == value) return; _isProcessing = value; OnPropertyChanged(); }
     }
 
+    private string? _errorMessage;
+    /// <summary>Error message shown when a recovery operation fails.</summary>
+    public string? ErrorMessage
+    {
+        get => _errorMessage;
+        set
+        {
+            if (_errorMessage == value) return;
+            _errorMessage = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(HasError));
+        }
+    }
+
+    /// <summary>True when there is an error to display.</summary>
+    public bool HasError => !string.IsNullOrEmpty(ErrorMessage);
+
     // ── Recovery data (populated from SDK when available) ──
     public string PenaltyDuration { get; set; } = "";
     public string MinerFee { get; set; } = "";
@@ -762,13 +779,23 @@ public partial class PortfolioViewModel : ReactiveObject
             var daysLeft = (recovery.ExpiryDate - DateTime.UtcNow).Days;
             investment.PenaltyDaysRemaining = Math.Max(0, daysLeft);
 
+            // Penalty-threshold logic only applies to Fund projects.
+            // Invest/Subscribe projects should not take the UI shortcut that maps
+            // `IsAboveThreshold == false` to the end-of-project claim path, because
+            // for non-Fund projects the SDK intentionally reports threshold as not applicable.
+            // Normalize the flag here so non-Fund projects only route to end-of-project
+            // when the project has actually expired.
+            var normalizedIsAboveThreshold = investment.ProjectType == "fund"
+                ? recovery.IsAboveThreshold
+                : true;
+
             // Map all 5 SDK fields to RecoveryState (replaces simplified 3-state string)
             investment.RecoveryState = new RecoveryState(
                 recovery.HasUnspentItems,
                 recovery.HasSpendableItemsInPenalty,
                 recovery.HasReleaseSignatures,
                 recovery.EndOfProject,
-                recovery.IsAboveThreshold);
+                normalizedIsAboveThreshold);
 
             _logger.LogInformation("Recovery status loaded for project {ProjectId}: HasUnspent={HasUnspent}, InPenalty={InPenalty}, HasReleaseSig={HasReleaseSig}, EndOfProject={EndOfProject}, AboveThreshold={AboveThreshold}, ActionKey={ActionKey}",
                 investment.ProjectIdentifier, recovery.HasUnspentItems, recovery.HasSpendableItemsInPenalty,

--- a/src/design/App/UI/Sections/Portfolio/RecoveryModalsView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/RecoveryModalsView.axaml
@@ -210,6 +210,22 @@
                         <!-- Fee rate is selected via the reusable FeeSelectionPopup
                              when the user clicks Confirm -->
 
+                        <!-- Error message (shown when recovery operation fails) -->
+                        <Border CornerRadius="12" Padding="16"
+                                IsVisible="{Binding HasError}"
+                                Background="#331C1C"
+                                BorderBrush="#662222"
+                                BorderThickness="1">
+                            <DockPanel>
+                                <i:Icon Value="fa-solid fa-circle-exclamation" FontSize="18"
+                                        Foreground="#EF4444" VerticalAlignment="Top"
+                                        Margin="0,2,12,0" DockPanel.Dock="Left" />
+                                <TextBlock Text="{Binding ErrorMessage}"
+                                           FontSize="14" TextWrapping="Wrap"
+                                           Foreground="#FCA5A5" />
+                            </DockPanel>
+                        </Border>
+
                         <!-- Confirmation question -->
                         <TextBlock Text="Are you sure you want to recover these funds?"
                                    FontSize="15" FontWeight="SemiBold"
@@ -355,6 +371,22 @@
                         </Grid>
                     </Border>
                 </StackPanel>
+
+                <!-- Error message (shown when claim operation fails) -->
+                <Border CornerRadius="12" Padding="16" Margin="24,0,24,24"
+                        IsVisible="{Binding HasError}"
+                        Background="#331C1C"
+                        BorderBrush="#662222"
+                        BorderThickness="1">
+                    <DockPanel>
+                        <i:Icon Value="fa-solid fa-circle-exclamation" FontSize="18"
+                                Foreground="#EF4444" VerticalAlignment="Top"
+                                Margin="0,2,12,0" DockPanel.Dock="Left" />
+                        <TextBlock Text="{Binding ErrorMessage}"
+                                   FontSize="14" TextWrapping="Wrap"
+                                   Foreground="#FCA5A5" />
+                    </DockPanel>
+                </Border>
             </StackPanel>
         </Border>
 
@@ -512,6 +544,22 @@
 
                         <!-- Fee rate is selected via the reusable FeeSelectionPopup
                              when the user clicks Confirm -->
+
+                        <!-- Error message (shown when release operation fails) -->
+                        <Border CornerRadius="12" Padding="16"
+                                IsVisible="{Binding HasError}"
+                                Background="#331C1C"
+                                BorderBrush="#662222"
+                                BorderThickness="1">
+                            <DockPanel>
+                                <i:Icon Value="fa-solid fa-circle-exclamation" FontSize="18"
+                                        Foreground="#EF4444" VerticalAlignment="Top"
+                                        Margin="0,2,12,0" DockPanel.Dock="Left" />
+                                <TextBlock Text="{Binding ErrorMessage}"
+                                           FontSize="14" TextWrapping="Wrap"
+                                           Foreground="#FCA5A5" />
+                            </DockPanel>
+                        </Border>
 
                     </StackPanel>
                 </ScrollViewer>

--- a/src/design/App/UI/Sections/Portfolio/RecoveryModalsView.axaml.cs
+++ b/src/design/App/UI/Sections/Portfolio/RecoveryModalsView.axaml.cs
@@ -131,6 +131,7 @@ public partial class RecoveryModalsView : UserControl, IBackdropCloseable
     {
         if (Vm == null || Vm.IsProcessing) return;
 
+        Vm.ErrorMessage = null;
         var feeRate = await AskForFeeRateAsync();
         if (feeRate == null) return; // user cancelled
 
@@ -158,6 +159,10 @@ public partial class RecoveryModalsView : UserControl, IBackdropCloseable
                 Vm.ShowRecoveryModal = false;
                 Vm.ShowSuccessModal = true;
             }
+            else
+            {
+                Vm.ErrorMessage = "Recovery transaction failed. The transaction may not be final yet or the network rejected it. Please try again later.";
+            }
         }
         else
         {
@@ -169,6 +174,7 @@ public partial class RecoveryModalsView : UserControl, IBackdropCloseable
     {
         if (Vm == null || Vm.IsProcessing) return;
 
+        Vm.ErrorMessage = null;
         var feeRate = await AskForFeeRateAsync();
         if (feeRate == null) return; // user cancelled
 
@@ -189,6 +195,10 @@ public partial class RecoveryModalsView : UserControl, IBackdropCloseable
                 Vm.ShowClaimModal = false;
                 Vm.ShowSuccessModal = true;
             }
+            else
+            {
+                Vm.ErrorMessage = "Claim transaction failed. The penalty period may not have expired yet. Please try again later.";
+            }
         }
         else
         {
@@ -200,6 +210,7 @@ public partial class RecoveryModalsView : UserControl, IBackdropCloseable
     {
         if (Vm == null || Vm.IsProcessing) return;
 
+        Vm.ErrorMessage = null;
         var feeRate = await AskForFeeRateAsync();
         if (feeRate == null) return; // user cancelled
 
@@ -225,6 +236,10 @@ public partial class RecoveryModalsView : UserControl, IBackdropCloseable
                 Vm.ShowReleaseModal = false;
                 Vm.ShowSuccessModal = true;
             }
+            else
+            {
+                Vm.ErrorMessage = "Release transaction failed. The network may have rejected it. Please try again later.";
+            }
         }
         else
         {
@@ -239,6 +254,7 @@ public partial class RecoveryModalsView : UserControl, IBackdropCloseable
         if (Vm != null)
         {
             Vm.IsProcessing = false;
+            Vm.ErrorMessage = null;
             Vm.ShowRecoveryModal = false;
             Vm.ShowClaimModal = false;
             Vm.ShowReleaseModal = false;

--- a/src/design/App/UI/Shared/Controls/ProjectInfoJsonModal.axaml
+++ b/src/design/App/UI/Shared/Controls/ProjectInfoJsonModal.axaml
@@ -1,0 +1,91 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:i="https://github.com/projektanker/icons.avalonia"
+             mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="600"
+             x:Class="App.UI.Shared.Controls.ProjectInfoJsonModal">
+
+    <UserControl.Styles>
+        <Style Selector="Button.CopyJsonBtn">
+            <Setter Property="Padding" Value="16,8" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
+        </Style>
+        <Style Selector="Button.CopyJsonBtn.CopiedState">
+            <Setter Property="Background" Value="{DynamicResource CopiedBtnBg}" />
+        </Style>
+    </UserControl.Styles>
+
+    <Panel>
+        <Border HorizontalAlignment="Center" VerticalAlignment="Center"
+                MinWidth="500" MaxWidth="700"
+                MaxHeight="600"
+                CornerRadius="16"
+                Background="{DynamicResource ShareModalBg}"
+                BorderBrush="{DynamicResource ShareModalBorder}"
+                BorderThickness="1"
+                BoxShadow="0 8 32 0 #40000000"
+                ClipToBounds="True"
+                Padding="24"
+                RenderTransformOrigin="50%,50%"
+                RenderTransform="scale(1)">
+            <Border.Transitions>
+                <Transitions>
+                    <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.3" />
+                    <DoubleTransition Property="Opacity" Duration="0:0:0.3" />
+                </Transitions>
+            </Border.Transitions>
+
+            <DockPanel>
+                <!-- HEADER -->
+                <Panel DockPanel.Dock="Top" Margin="0,0,0,16">
+                    <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                        <i:Icon Value="fa-solid fa-code" FontSize="20"
+                                Foreground="{DynamicResource TextStrong}" />
+                        <TextBlock Text="Project Info JSON"
+                                   FontSize="20" FontWeight="Bold"
+                                   Foreground="{DynamicResource TextStrong}"
+                                   VerticalAlignment="Center" />
+                    </StackPanel>
+                    <Button Name="CloseButton" Classes="ModalCloseBtnSmall"
+                            HorizontalAlignment="Right" VerticalAlignment="Top" />
+                </Panel>
+
+                <!-- FOOTER: Copy button -->
+                <DockPanel DockPanel.Dock="Bottom" Margin="0,16,0,0">
+                    <Button Name="CopyJsonButton" Classes="CopyJsonBtn"
+                            DockPanel.Dock="Right"
+                            Content="Copy JSON"
+                            Background="{DynamicResource PrimaryGreenBrush}" />
+                    <TextBlock Name="StatusText"
+                               FontSize="13"
+                               Foreground="{DynamicResource TextMuted}"
+                               VerticalAlignment="Center" />
+                </DockPanel>
+
+                <!-- JSON CONTENT -->
+                <Border Background="{DynamicResource SurfaceMedium}"
+                        BorderBrush="{DynamicResource Stroke}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="16">
+                    <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                  VerticalScrollBarVisibility="Auto">
+                        <TextBlock Name="JsonContent"
+                                   Text="Loading..."
+                                   FontSize="13"
+                                   FontFamily="Cascadia Code,Consolas,monospace"
+                                   Foreground="{DynamicResource TextStrong}"
+                                   TextWrapping="Wrap" />
+                    </ScrollViewer>
+                </Border>
+            </DockPanel>
+        </Border>
+    </Panel>
+</UserControl>

--- a/src/design/App/UI/Shared/Controls/ProjectInfoJsonModal.axaml.cs
+++ b/src/design/App/UI/Shared/Controls/ProjectInfoJsonModal.axaml.cs
@@ -1,0 +1,99 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using Angor.Sdk.Funding.Projects;
+using Angor.Sdk.Funding.Shared;
+using App.UI.Shared.Helpers;
+using App.UI.Shell;
+
+namespace App.UI.Shared.Controls;
+
+/// <summary>
+/// Modal that displays the full project info as formatted JSON.
+/// Loaded on demand from the SDK's LiteDB cache via IProjectAppService.
+/// </summary>
+public partial class ProjectInfoJsonModal : UserControl, IBackdropCloseable
+{
+    private string _json = "";
+
+    /// <summary>
+    /// Parameterless constructor for XAML designer/loader.
+    /// </summary>
+    public ProjectInfoJsonModal()
+    {
+        InitializeComponent();
+        WireButtons();
+    }
+
+    public ProjectInfoJsonModal(string projectId, IProjectAppService projectAppService)
+    {
+        InitializeComponent();
+        WireButtons();
+        _ = LoadJsonAsync(projectId, projectAppService);
+    }
+
+    private void WireButtons()
+    {
+        var closeBtn = this.FindControl<Button>("CloseButton");
+        if (closeBtn != null) closeBtn.Click += OnCloseClick;
+
+        var copyBtn = this.FindControl<Button>("CopyJsonButton");
+        if (copyBtn != null) copyBtn.Click += OnCopyClick;
+    }
+
+    private ShellViewModel? ShellVm =>
+        this.FindAncestorOfType<ShellView>()?.DataContext as ShellViewModel;
+
+    public void OnBackdropCloseRequested() { }
+
+    private void OnCloseClick(object? sender, RoutedEventArgs e)
+    {
+        ShellVm?.HideModal();
+    }
+
+    private async void OnCopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrEmpty(_json)) return;
+
+        ClipboardHelper.CopyToClipboard(this, _json);
+
+        var copyBtn = this.FindControl<Button>("CopyJsonButton");
+        if (copyBtn == null) return;
+
+        copyBtn.Content = "Copied!";
+        copyBtn.Classes.Set("CopiedState", true);
+
+        await Task.Delay(2000);
+
+        copyBtn.Content = "Copy JSON";
+        copyBtn.Classes.Set("CopiedState", false);
+    }
+
+    private async Task LoadJsonAsync(string projectId, IProjectAppService projectAppService)
+    {
+        var jsonContent = this.FindControl<TextBlock>("JsonContent");
+        var statusText = this.FindControl<TextBlock>("StatusText");
+
+        try
+        {
+            var result = await projectAppService.GetProjectInfoJson(new ProjectId(projectId));
+
+            if (result.IsSuccess)
+            {
+                _json = result.Value.Json;
+                if (jsonContent != null) jsonContent.Text = _json;
+                if (statusText != null) statusText.Text = $"Project: {projectId}";
+            }
+            else
+            {
+                if (jsonContent != null) jsonContent.Text = $"Failed to load project info: {result.Error}";
+                if (statusText != null) statusText.Text = "Error";
+            }
+        }
+        catch (Exception ex)
+        {
+            if (jsonContent != null) jsonContent.Text = $"Error: {ex.Message}";
+            if (statusText != null) statusText.Text = "Error";
+        }
+    }
+}

--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/GetClaimableTransactionsTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/GetClaimableTransactionsTests.cs
@@ -103,7 +103,7 @@ public class GetClaimableTransactionsTests
         transactions[0].StageNumber.Should().Be(1);
         transactions[0].Amount.Should().Be(new Amount(50_000));
         transactions[0].InvestorAddress.Should().Be("investor-pub-1");
-        transactions[0].DynamicReleaseDate.Should().BeNull();
+        transactions[0].DynamicReleaseDate.Should().Be(stageData.StageDate);
     }
 
     [Fact]
@@ -410,7 +410,7 @@ public class GetClaimableTransactionsTests
     }
 
     [Fact]
-    public async Task Handle_WhenNonDynamicStage_DynamicReleaseDateIsNull()
+    public async Task Handle_WhenNonDynamicStage_SetsStageReleaseDate()
     {
         // Arrange
         var walletId = new WalletId("wallet-1");
@@ -442,7 +442,7 @@ public class GetClaimableTransactionsTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Transactions.First().DynamicReleaseDate.Should().BeNull();
+        result.Value.Transactions.First().DynamicReleaseDate.Should().Be(stageData.StageDate);
     }
 
     [Fact]

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetClaimableTransactions.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetClaimableTransactions.cs
@@ -33,7 +33,7 @@ public static class GetClaimableTransactions
                            StageId = stageData.StageIndex,
                            StageNumber = stageData.StageIndex + 1,
                            Amount = new Amount(item.Amount),
-                           DynamicReleaseDate = stageData.IsDynamic ? stageData.StageDate : null,
+                           DynamicReleaseDate = stageData.StageDate,
                            InvestorAddress = item.InvestorPublicKey,
                            ClaimStatus = DetermineClaimStatus(item, stageData),
                        }));

--- a/src/sdk/Angor.Sdk/Funding/Projects/IProjectAppService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/IProjectAppService.cs
@@ -26,4 +26,5 @@ public interface IProjectAppService
     Task<Result<CreateProjectResponse>> CreateProject(WalletId walletId, long selectedFee, CreateProjectDto project, string projectInfoEventId, ProjectSeedDto projectSeedDto);
     Task<Result<ProjectStatisticsDto>> GetProjectStatistics(ProjectId projectId);
     Task<Result<GetProjectRelays.GetProjectRelaysResponse>> GetRelaysForNpubAsync(string nostrPubKey);
+    Task<Result<GetProjectInfoJson.GetProjectInfoJsonResponse>> GetProjectInfoJson(ProjectId projectId);
 }

--- a/src/sdk/Angor.Sdk/Funding/Projects/Operations/GetProjectInfoJson.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/Operations/GetProjectInfoJson.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using Angor.Sdk.Funding.Services;
+using Angor.Sdk.Funding.Shared;
+using Angor.Shared.Services;
+using CSharpFunctionalExtensions;
+using MediatR;
+
+namespace Angor.Sdk.Funding.Projects.Operations;
+
+public static class GetProjectInfoJson
+{
+    public record GetProjectInfoJsonRequest(ProjectId ProjectId) : IRequest<Result<GetProjectInfoJsonResponse>>;
+
+    public record GetProjectInfoJsonResponse(string Json);
+
+    public class GetProjectInfoJsonHandler(IProjectService projectService)
+        : IRequestHandler<GetProjectInfoJsonRequest, Result<GetProjectInfoJsonResponse>>
+    {
+        private static readonly JsonSerializerOptions IndentedOptions = new()
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new Angor.Shared.Utilities.UnixDateTimeConverter() }
+        };
+
+        public async Task<Result<GetProjectInfoJsonResponse>> Handle(
+            GetProjectInfoJsonRequest request, CancellationToken cancellationToken)
+        {
+            var projectResult = await projectService.GetAsync(request.ProjectId);
+            return projectResult.Map(project =>
+            {
+                var projectInfo = project.ToProjectInfo();
+                var json = JsonSerializer.Serialize(projectInfo, IndentedOptions);
+                return new GetProjectInfoJsonResponse(json);
+            });
+        }
+    }
+}

--- a/src/sdk/Angor.Sdk/Funding/Projects/ProjectAppService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/ProjectAppService.cs
@@ -60,4 +60,9 @@ public class ProjectAppService(
     {
         return mediator.Send(new GetProjectRelays.GetProjectRelaysRequest(nostrPubKey));
     }
+
+    public Task<Result<GetProjectInfoJson.GetProjectInfoJsonResponse>> GetProjectInfoJson(ProjectId projectId)
+    {
+        return mediator.Send(new GetProjectInfoJson.GetProjectInfoJsonRequest(projectId));
+    }
 }


### PR DESCRIPTION
## Summary
- fix design app recovery and portfolio status handling for fund and invest flows
- add project diagnostics and recovery UI improvements, including project info JSON and recovery error feedback
- refactor integration tests to drive key user actions through the UI instead of duplicating business-action routing in test code

## Details
- add Find Projects refresh button and fix project target BTC-to-sats conversion
- preserve meaningful recovery stage text in portfolio flows and fix invest recovery routing so non-fund projects do not take the fund-only below-threshold shortcut
- improve Manage Project stage/UTXO handling and add richer stage assertions in fund and invest recovery tests
- add `InvestAndRecoverTest` and update existing integration tests to use shared UI helpers for approve, confirm, cancel, claim, release, and recovery flows

## Verification
- `dotnet test src/design/App.Test.Integration/App.Test.Integration.csproj --no-build --filter "DisplayName~FullFundAndRecoverFlow"`
- `dotnet test src/design/App.Test.Integration/App.Test.Integration.csproj --no-build --filter "DisplayName~FullInvestAndRecoverFlow"`
- `dotnet test src/design/App.Test.Integration/App.Test.Integration.csproj --no-build --filter "DisplayName~InvestmentCancellation"`
- `dotnet test src/design/App.Test.Integration/App.Test.Integration.csproj --no-build --filter "DisplayName~MultiFundClaimAndRecover"`
- `dotnet test src/design/App.Test.Integration/App.Test.Integration.csproj --no-build --filter "DisplayName~MultiInvestClaimAndRecover"`