### PR TITLE
fix: wallet creation failing silently in Release due to IL trimming

### DIFF
--- a/src/design/App.Desktop/App.Desktop.csproj
+++ b/src/design/App.Desktop/App.Desktop.csproj
@@ -9,7 +9,18 @@
         <TrimMode>partial</TrimMode>
         <PublishSingleFile>true</PublishSingleFile>
         <PublishReadyToRun>true</PublishReadyToRun>
+        <!-- SDK uses reflection-based System.Text.Json (FileStore, WalletFactory, AesWalletEncryption, etc.) -->
+        <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
     </PropertyGroup>
+
+    <!-- Preserve reflection-heavy assemblies from IL trimming -->
+    <ItemGroup Condition="'$(Configuration)'=='Release'">
+        <TrimmerRootAssembly Include="Angor.Sdk" />
+        <TrimmerRootAssembly Include="Angor.Shared" />
+        <TrimmerRootAssembly Include="Angor.Data.Documents" />
+        <TrimmerRootAssembly Include="Angor.Data.Documents.LiteDb" />
+        <TrimmerRootAssembly Include="LiteDB" />
+    </ItemGroup>
     
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>

--- a/src/design/App/App.csproj
+++ b/src/design/App/App.csproj
@@ -41,6 +41,8 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+        <PackageReference Include="Serilog.Extensions.Logging" />
+        <PackageReference Include="Serilog.Sinks.File" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\sdk\Angor.Data.Documents.LiteDb\Angor.Data.Documents.LiteDb.csproj" />

--- a/src/design/App/Composition/CompositionRoot.cs
+++ b/src/design/App/Composition/CompositionRoot.cs
@@ -52,7 +52,11 @@ public static class CompositionRoot
             _ => BitcoinNetwork.Testnet
         };
 
-        // Logging — Microsoft.Extensions.Logging with console output
+        // Logging — Microsoft.Extensions.Logging with console + file output
+        var logFilePath = System.IO.Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Angor", "logs", "angor-.log");
+
         services.AddLogging(builder =>
         {
             builder.ClearProviders();
@@ -61,6 +65,18 @@ public static class CompositionRoot
             {
                 builder.AddConsole();
             }
+
+            // Add Serilog as a provider for file logging
+            var fileLogger = new LoggerConfiguration()
+                .MinimumLevel.Information()
+                .WriteTo.File(
+                    logFilePath,
+                    rollingInterval: Serilog.RollingInterval.Day,
+                    retainedFileCountLimit: 15,
+                    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}")
+                .CreateLogger();
+
+            builder.AddSerilog(fileLogger, dispose: true);
 
             // Suppress noisy per-request HTTP diagnostics (Sending/Received for every call)
             builder.AddFilter("System.Net.Http.HttpClient", LogLevel.Warning);

--- a/src/design/App/UI/Sections/Funds/CreateWalletModal.axaml.cs
+++ b/src/design/App/UI/Sections/Funds/CreateWalletModal.axaml.cs
@@ -48,7 +48,7 @@ public partial class CreateWalletModal : UserControl, IBackdropCloseable
         // No special cleanup needed — let the shell close the modal.
     }
 
-    private void OnButtonClick(object? sender, RoutedEventArgs e)
+    private async void OnButtonClick(object? sender, RoutedEventArgs e)
     {
         if (e.Source is not Button btn) return;
 
@@ -80,7 +80,7 @@ public partial class CreateWalletModal : UserControl, IBackdropCloseable
                 break;
 
             case "BtnSubmitImport":
-                SubmitImport();
+                await SubmitImport();
                 break;
 
             // ── Step 2b: Backup ──
@@ -93,7 +93,15 @@ public partial class CreateWalletModal : UserControl, IBackdropCloseable
                 {
                     _logger.LogInformation("Seed downloaded confirmed, creating wallet via SDK");
                     // Create wallet via SDK
-                    _ = CreateWalletViaSdkAsync(Vm?.DefaultWalletName ?? "My Wallet");
+                    try
+                    {
+                        await CreateWalletViaSdkAsync(Vm?.DefaultWalletName ?? "My Wallet");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Unhandled exception during wallet creation");
+                        ShellVm?.ShowToast($"Wallet creation failed: {ex.Message}");
+                    }
                 }
                 else
                 {
@@ -129,7 +137,7 @@ public partial class CreateWalletModal : UserControl, IBackdropCloseable
     /// Validate seed phrase and import wallet with user-provided seed words.
     /// Vue: submitSeedImport() — validates 12 or 24 words.
     /// </summary>
-    private void SubmitImport()
+    private async Task SubmitImport()
     {
         var input = SeedPhraseInput.Text?.Trim() ?? "";
         var words = input.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
@@ -148,7 +156,15 @@ public partial class CreateWalletModal : UserControl, IBackdropCloseable
         SeedSuccess.IsVisible = true;
 
         // Import wallet with the user's seed words
-        _ = ImportWalletViaSdkAsync(Vm?.DefaultWalletName ?? "My Wallet", string.Join(" ", words));
+        try
+        {
+            await ImportWalletViaSdkAsync(Vm?.DefaultWalletName ?? "My Wallet", string.Join(" ", words));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception during wallet import");
+            ShellVm?.ShowToast($"Wallet import failed: {ex.Message}");
+        }
     }
 
     /// <summary>
@@ -221,41 +237,49 @@ public partial class CreateWalletModal : UserControl, IBackdropCloseable
     /// </summary>
     private async void DownloadSeed()
     {
-        if (string.IsNullOrEmpty(_generatedSeedWords)) return;
-
-        var topLevel = TopLevel.GetTopLevel(this);
-        if (topLevel?.StorageProvider != null)
+        try
         {
-            _logger.LogInformation("Opening file save dialog for seed backup...");
-            var file = await topLevel.StorageProvider.SaveFilePickerAsync(
-                new Avalonia.Platform.Storage.FilePickerSaveOptions
-                {
-                    Title = "Save Seed Phrase",
-                    SuggestedFileName = "seed-backup.txt",
-                    DefaultExtension = "txt"
-                });
+            if (string.IsNullOrEmpty(_generatedSeedWords)) return;
 
-            if (file != null)
+            var topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel?.StorageProvider != null)
             {
-                _logger.LogInformation("Saving seed phrase to file: {FileName}", file.Name);
-                await using var stream = await file.OpenWriteAsync();
-                await using var writer = new System.IO.StreamWriter(stream);
-                await writer.WriteAsync(_generatedSeedWords);
+                _logger.LogInformation("Opening file save dialog for seed backup...");
+                var file = await topLevel.StorageProvider.SaveFilePickerAsync(
+                    new Avalonia.Platform.Storage.FilePickerSaveOptions
+                    {
+                        Title = "Save Seed Phrase",
+                        SuggestedFileName = "seed-backup.txt",
+                        DefaultExtension = "txt"
+                    });
+
+                if (file != null)
+                {
+                    _logger.LogInformation("Saving seed phrase to file: {FileName}", file.Name);
+                    await using var stream = await file.OpenWriteAsync();
+                    await using var writer = new System.IO.StreamWriter(stream);
+                    await writer.WriteAsync(_generatedSeedWords);
+                }
+                else
+                {
+                    _logger.LogInformation("File save dialog cancelled or unavailable (headless mode)");
+                }
             }
             else
             {
-                _logger.LogInformation("File save dialog cancelled or unavailable (headless mode)");
+                _logger.LogInformation("No StorageProvider available — skipping file save dialog");
             }
-        }
-        else
-        {
-            _logger.LogInformation("No StorageProvider available — skipping file save dialog");
-        }
 
-        _seedDownloaded = true;
-        BtnContinueBackup.IsEnabled = true;
-        BtnContinueBackup.BorderBrush = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#4B7C5A"));
-        BtnContinueBackup.Foreground = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#4B7C5A"));
-        _logger.LogInformation("Seed download acknowledged — Continue button enabled");
+            _seedDownloaded = true;
+            BtnContinueBackup.IsEnabled = true;
+            BtnContinueBackup.BorderBrush = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#4B7C5A"));
+            BtnContinueBackup.Foreground = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#4B7C5A"));
+            _logger.LogInformation("Seed download acknowledged — Continue button enabled");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception during seed download");
+            ShellVm?.ShowToast($"Failed to save seed file: {ex.Message}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Wallet creation in the Design app (`src/design/`) was silently failing in Release builds. Clicking "Continue" after downloading the seed did nothing — no error, no logs.

## Root Cause

`App.Desktop.csproj` enables `PublishTrimmed=true` in Release, which disables reflection-based `System.Text.Json` serialization. The SDK's `WalletFactory.CreateWallet` calls `JsonSerializer.Serialize(descriptor.ToDto())` which throws `InvalidOperationException`, but the exception was swallowed by a fire-and-forget `_ =` pattern in `CreateWalletModal`.

## Changes

- **`App.Desktop.csproj`**: Add `JsonSerializerIsReflectionEnabledByDefault=true` and `TrimmerRootAssembly` entries for SDK/Shared/LiteDB assemblies to prevent trimming of reflection-heavy code
- **`CompositionRoot.cs`**: Add Serilog file sink (`%LOCALAPPDATA%/Angor/logs/`) so Release builds produce persistent logs
- **`App.csproj`**: Add `Serilog.Extensions.Logging` and `Serilog.Sinks.File` package references
- **`CreateWalletModal.axaml.cs`**: Replace `_ =` fire-and-forget async calls with `await` + `try/catch` so errors surface as toast notifications and log entries instead of being silently swallowed