### PR TITLE
Add founder release-funds integration tests (Fund + Invest) and fix belowThreshold routing

### DIFF
--- a/docs/UI_TESTING_COMMENTS.md
+++ b/docs/UI_TESTING_COMMENTS.md
@@ -14,7 +14,7 @@ Tracked issues and improvements found during manual testing of the new Avalonia 
 
 ## Funder Tab
 3. ~~**Missing refresh button** — No refresh button on the Funder tab; had to restart the app to see investors to approve.~~ ✅ Fixed
-4. **Verify 'Approve All' button** — The 'Approve All' button needs to be checked if it works correctly. Add coverage in an integration test.
+4. ~~**Verify 'Approve All' button** — The 'Approve All' button needs to be checked if it works correctly. Add coverage in an integration test.~~ ✅ Verified working
 
 ## Funded > Manage Project
 5. ~~**Missing refresh button** — No refresh button on the Manage Project view.~~ ✅ Fixed

--- a/docs/UI_TESTING_COMMENTS.md
+++ b/docs/UI_TESTING_COMMENTS.md
@@ -9,8 +9,8 @@ Tracked issues and improvements found during manual testing of the new Avalonia 
 
 ## Find Projects
 2. ~~**Refresh button should spin / show loading state** — The refresh button should spin while loading. If there are no projects loaded yet, show a large spinner.~~ ✅ Fixed
-20. **Fund project: Missing instalment selector** — When funding a project of type Fund, there is no option to select which instalment pattern to use (e.g. 3-month or 6-month). Should show the available instalments, and once one is selected, show the payout breakdown schedule.
-21. **Fund project: Show penalty threshold status** — Should indicate whether the funding amount is above or below the penalty threshold (i.e. whether it requires founder approval or not).
+20. ~~**Fund project: Missing instalment selector** — When funding a project of type Fund, there is no option to select which instalment pattern to use (e.g. 3-month or 6-month). Should show the available instalments, and once one is selected, show the payout breakdown schedule.~~ ✅ Fixed — Added funding pattern selector card with pattern options, stage count badges, frequency display. Updated patternIndex in payment flow.
+21. ~~**Fund project: Show penalty threshold status** — Should indicate whether the funding amount is above or below the penalty threshold (i.e. whether it requires founder approval or not).~~ ✅ Fixed — Added reactive threshold badge in invest page footer showing "Requires Approval" (orange) or "No Approval Needed" (green).
 
 ## Funder Tab
 3. ~~**Missing refresh button** — No refresh button on the Funder tab; had to restart the app to see investors to approve.~~ ✅ Fixed
@@ -23,7 +23,7 @@ Tracked issues and improvements found during manual testing of the new Avalonia 
 8. ~~**Stages don't refresh after investing** — After investing, stages don't refresh automatically. Have to navigate away and back to the manage page to see changes.~~ ✅ Fixed
 9. ~~**Invest button needs spinner** — The Invest button should spin and be disabled after clicking to prevent double-clicks.~~ ✅ Fixed
 18. ~~**Stage percentage shows 0%** — The stage percentage in the list of stages shows 0%.~~ ✅ Fixed
-23. **Penalty button is a mockup** — The penalty button does not show real pending penalties, it is currently a mockup.
+23. ~~**Penalty button is a mockup** — The penalty button does not show real pending penalties, it is currently a mockup.~~ ✅ Verified — Penalty button is fully wired to SDK (BuildPenaltyReleaseTransaction), shows real penalty amounts and days remaining from recovery status.
 24. ~~**Recover shows penalty popup when below threshold** — Clicking the recover button shows a penalty days popup even when the investment is below the threshold (no penalty applies). Should skip penalty and go straight to recovery.~~ ✅ Fixed
 
 ## My Projects (Founder) > Manage Project
@@ -32,9 +32,9 @@ Tracked issues and improvements found during manual testing of the new Avalonia 
 22. ~~**Claimable stage shows no info** — When funds are claimable, the stage shows nothing. Should show the number of UTXOs available to claim out of total (currently only shows 'available in X days' when not yet claimable).~~ ✅ Fixed
 
 ## Create Project
-11. **Advanced editor not working** — The advanced editor in the create project wizard is not functional.
+11. ~~**Advanced editor not working** — The advanced editor in the create project wizard is not functional.~~ ✅ Fixed — Added advanced editor with per-stage percentage editing, remove stage, and add stage buttons. Toggle button swaps between simple/advanced views.
 12. ~~**Debug prefill should use realistic stage dates** — In debug mode, the prefill button for invest should make stage 1 spendable immediately (today) but stages 2 and 3 should have future release dates to better simulate a real scenario.~~ ✅ Fixed
-19. **Fund type: Selected instalments missing from summary** — When creating a Fund project and selecting two instalment patterns, the review summary doesn't show which instalments were selected.
+19. ~~**Fund type: Selected instalments missing from summary** — When creating a Fund project and selecting two instalment patterns, the review summary doesn't show which instalments were selected.~~ ✅ Fixed — Added Payout Frequency, Installment Options, and Payout Day to the Step 6 review summary.
 
 ## Investor > Manage Project (Recovery)
 13. ~~**Recover/Penalty popup shows wrong stage count** — Shows all 3 stages even when some are already spent by the founder. Should only show the stages actually being recovered. Also doesn't show the penalty days.~~ ✅ Fixed

--- a/docs/UI_TESTING_COMMENTS.md
+++ b/docs/UI_TESTING_COMMENTS.md
@@ -27,7 +27,7 @@ Tracked issues and improvements found during manual testing of the new Avalonia 
 24. ~~**Recover shows penalty popup when below threshold** — Clicking the recover button shows a penalty days popup even when the investment is below the threshold (no penalty applies). Should skip penalty and go straight to recovery.~~ ✅ Fixed
 
 ## My Projects (Founder) > Manage Project
-10. **Missing 'Release Funds to Investor' button** — The release funds button is missing. Need to replicate from the avalonia app implementation (`src/avalonia/`). Also need an integration test for this.
+10. ~~**Missing 'Release Funds to Investor' button** — The release funds button is missing. Need to replicate from the avalonia app implementation (`src/avalonia/`). Also need an integration test for this.~~ ✅ Fixed — Release funds button wired up, duplicate removed, belowThreshold routing fixed. Integration tests added for both Fund and Invest project types (`MultiFundReleaseUnfundedAndClaimTest`, `MultiInvestReleaseUnfundedAndClaimTest`).
 17. ~~**Spend Stage popup disappears before confirmation** — When spending a stage as founder, the popup disappears before the confirmation popup appears, leaving the user unsure what happened.~~ ✅ Fixed
 22. ~~**Claimable stage shows no info** — When funds are claimable, the stage shows nothing. Should show the number of UTXOs available to claim out of total (currently only shows 'available in X days' when not yet claimable).~~ ✅ Fixed
 

--- a/src/design/App.Test.Integration/Helpers/TestHelpers.cs
+++ b/src/design/App.Test.Integration/Helpers/TestHelpers.cs
@@ -434,14 +434,14 @@ public static class TestHelpers
         // ── #1 regression: Continue button should show spinner during wallet creation ──
         Dispatcher.UIThread.RunJobs();
         var continueBtn = window.FindByAutomationId<Button>("BtnContinueBackup");
-        var continueSpinner = window.FindByName<Projektanker.Icons.Avalonia.Icon>("ContinueSpinner");
+        var continueSpinner = window.FindByName<StackPanel>("ContinueBtnSpinner");
         // The spinner should be visible and button disabled while wallet creation is in progress.
         // If the operation completes instantly (test/headless), the success panel will already be
         // shown, so we only assert if the button still exists and is in the processing state.
         if (continueBtn is { IsEnabled: false })
         {
-            continueSpinner.Should().NotBeNull("#1: ContinueSpinner should exist on the Continue button");
-            continueSpinner!.IsVisible.Should().BeTrue("#1: ContinueSpinner should be visible during wallet creation");
+            continueSpinner.Should().NotBeNull("#1: ContinueBtnSpinner should exist on the Continue button");
+            continueSpinner!.IsVisible.Should().BeTrue("#1: ContinueBtnSpinner should be visible during wallet creation");
             Log("  [Generate] ✓ #1 verified: Continue spinner visible and button disabled during creation.");
         }
         else

--- a/src/design/App.Test.Integration/Helpers/TestHelpers.cs
+++ b/src/design/App.Test.Integration/Helpers/TestHelpers.cs
@@ -849,9 +849,17 @@ public static class TestHelpers
 
         var manageVm = myProjectsVm.SelectedManageProject!;
 
-        var manageView = window.GetVisualDescendants().OfType<ManageProjectView>().FirstOrDefault(v => v.IsVisible)
-            ?? throw new InvalidOperationException("Visible ManageProjectView not found");
-        manageView.OpenReleaseFundsModal();
+        // Click the "Release Funds" nav button in the top bar
+        var releaseFundsBtnVisible = await WaitForCondition(
+            () => window.FindByAutomationId<Button>("ReleaseFundsNavButton")?.IsVisible == true,
+            maxWait,
+            TimeSpan.FromMilliseconds(100));
+        if (!releaseFundsBtnVisible)
+            throw new TimeoutException("ReleaseFundsNavButton did not appear in the UI");
+
+        var releaseFundsBtn = window.FindByAutomationId<Button>("ReleaseFundsNavButton")
+            ?? throw new InvalidOperationException("ReleaseFundsNavButton not found");
+        releaseFundsBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, releaseFundsBtn));
         Dispatcher.UIThread.RunJobs();
 
         var releaseButtonVisible = await WaitForCondition(

--- a/src/design/App.Test.Integration/MultiFundClaimAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/MultiFundClaimAndRecoverTest.cs
@@ -88,7 +88,8 @@ public class MultiFundClaimAndRecoverTest
                 BelowThresholdInvestorProfile,
                 project!,
                 belowThresholdInvestmentBtc,
-                expectFounderApproval: false);
+                expectFounderApproval: false,
+                targetPatternStageCount: 6);
         });
 
         await WithProfileWindow(AboveThresholdInvestorProfile, initializedProfiles, async window =>
@@ -99,7 +100,8 @@ public class MultiFundClaimAndRecoverTest
                 AboveThresholdInvestorProfile,
                 project!,
                 aboveThresholdInvestmentBtc,
-                expectFounderApproval: true);
+                expectFounderApproval: true,
+                targetPatternStageCount: 3);
         });
 
         await WithProfileWindow(FounderProfile, initializedProfiles, async window =>
@@ -266,10 +268,12 @@ public class MultiFundClaimAndRecoverTest
         await Task.Delay(200);
         wizardVm.PayoutFrequency = "Weekly";
         wizardVm.ToggleInstallmentCount(3);
+        wizardVm.ToggleInstallmentCount(6);
         wizardVm.WeeklyPayoutDay = payoutDay;
         wizardVm.GeneratePayoutSchedule();
-        wizardVm.Stages.Count.Should().Be(3);
-        wizardVm.Stages.Select(s => s.StageNumber).Should().ContainInOrder(1, 2, 3);
+        wizardVm.Stages.Count.Should().Be(6, "stages preview uses the max selected installment count");
+        wizardVm.Stages.Select(s => s.StageNumber).Should().ContainInOrder(1, 2, 3, 4, 5, 6);
+        wizardVm.SelectedInstallmentCounts.Should().HaveCount(2, "project should have two instalment patterns (3-month and 6-month)");
         wizardVm.GoNext();
         Dispatcher.UIThread.RunJobs();
 
@@ -332,7 +336,8 @@ public class MultiFundClaimAndRecoverTest
         string profileName,
         ProjectHandle project,
         string amountBtc,
-        bool expectFounderApproval)
+        bool expectFounderApproval,
+        int? targetPatternStageCount = null)
     {
         var foundProject = await FindProjectFromSdkAsync(window, profileName, project);
 
@@ -359,9 +364,55 @@ public class MultiFundClaimAndRecoverTest
         }
 
         investVm!.Wallets.Count.Should().BeGreaterThan(0);
+
+        // ── Select funding pattern via UI: find the FundPatternBorder, then invoke code-behind ──
+        if (targetPatternStageCount.HasValue)
+        {
+            Log(profileName, $"Selecting funding pattern with {targetPatternStageCount.Value} stages via UI...");
+
+            investVm.FundingPatterns.Should().HaveCountGreaterThan(1,
+                "project should expose multiple funding patterns");
+
+            // Find the InvestPageView in the visual tree
+            var investPageView = window.GetVisualDescendants()
+                .OfType<InvestPageView>()
+                .FirstOrDefault();
+            investPageView.Should().NotBeNull("InvestPageView should be in the visual tree");
+
+            // Find all FundPatternBorder elements — proves the UI rendered them
+            var patternBorders = investPageView!.GetVisualDescendants()
+                .OfType<Border>()
+                .Where(b => b.Name == "FundPatternBorder")
+                .ToList();
+            patternBorders.Should().HaveCountGreaterThan(1,
+                "invest page should render multiple FundPatternBorder elements");
+
+            // Find the border whose DataContext matches the target stage count
+            var targetBorder = patternBorders.FirstOrDefault(b =>
+                b.DataContext is FundingPatternOption opt && opt.StageCount == targetPatternStageCount.Value);
+            targetBorder.Should().NotBeNull(
+                $"a FundPatternBorder with StageCount={targetPatternStageCount.Value} should exist");
+
+            // Extract the FundingPatternOption and click via the ViewModel
+            // (PointerPressedEventArgs construction is not feasible in headless tests —
+            //  other tests in this suite also use VM calls for Border-based interactions)
+            var targetOption = (FundingPatternOption)targetBorder!.DataContext!;
+            investVm.SelectFundingPattern(targetOption);
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(300);
+            Dispatcher.UIThread.RunJobs();
+
+            investVm.SelectedFundingPattern.Should().NotBeNull();
+            investVm.SelectedFundingPattern!.StageCount.Should().Be(targetPatternStageCount.Value,
+                $"selected funding pattern should have {targetPatternStageCount.Value} stages after selection");
+            Log(profileName, $"Funding pattern with {targetPatternStageCount.Value} stages selected. PatternId={investVm.SelectedFundingPattern.PatternId}");
+        }
+
         investVm.InvestmentAmount = amountBtc;
         investVm.CanSubmit.Should().BeTrue();
-        investVm.Stages.Count.Should().BeGreaterThanOrEqualTo(3, "fund project should expose at least the configured stage outputs to investors");
+        var expectedStageCount = targetPatternStageCount ?? 3;
+        investVm.Stages.Count.Should().BeGreaterThanOrEqualTo(expectedStageCount,
+            $"fund project should expose at least {expectedStageCount} stage outputs for the selected pattern");
         investVm.Stages.Select(s => s.LabelText).Should().Contain(label => label.Contains("Stage 1"));
         investVm.Submit();
         Dispatcher.UIThread.RunJobs();

--- a/src/design/App.Test.Integration/MultiFundClaimAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/MultiFundClaimAndRecoverTest.cs
@@ -20,6 +20,7 @@ using App.UI.Sections.MyProjects;
 using App.UI.Sections.MyProjects.Deploy;
 using App.UI.Sections.Portfolio;
 using App.UI.Sections.Settings;
+using App.UI.Shared.Controls;
 using App.UI.Shell;
 using Microsoft.Extensions.DependencyInjection;
 using System.Globalization;
@@ -654,6 +655,10 @@ public class MultiFundClaimAndRecoverTest
         var postPenaltyState = await WaitForRecoveryActionAsync(portfolioVm, investment, profileName, expectedActionKey: "penaltyRelease");
         postPenaltyState.ActionKey.Should().Be("penaltyRelease");
 
+        // ── Verify PenaltiesModal shows real penalty data via UI button ──
+        Log(profileName, "Verifying PenaltiesModal displays penalty investment...");
+        await VerifyPenaltiesModalAsync(window, portfolioVm, investment, profileName);
+
         Log(profileName, "Recovering from penalty (penalty days = 0)...");
         await EnsureWalletHasFeeFunds(window, profileName, investment.InvestmentWalletId, "before penalty release");
         var penaltyReleaseResult = await ExecuteRecoveryActionWithRetry(
@@ -1081,6 +1086,90 @@ public class MultiFundClaimAndRecoverTest
     {
         var prefix = string.IsNullOrWhiteSpace(profileName) ? "GLOBAL" : profileName;
         Console.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] [{prefix}] {message}");
+    }
+
+    private async Task VerifyPenaltiesModalAsync(
+        Window window,
+        PortfolioViewModel portfolioVm,
+        InvestmentViewModel investment,
+        string profileName)
+    {
+        // The investment reference may be stale (replaced by LoadInvestmentsFromSdkAsync
+        // triggered via WalletsUpdated). Re-fetch from the Investments collection and
+        // reload recovery status on the current reference so PenaltyInvestments is populated.
+        var currentInvestment = portfolioVm.Investments
+            .FirstOrDefault(i => i.ProjectIdentifier == investment.ProjectIdentifier);
+        currentInvestment.Should().NotBeNull("investment should still be in the Investments collection");
+
+        if (!currentInvestment!.RecoveryState.HasSpendableItemsInPenalty)
+        {
+            Log(profileName, "Current investment reference lacks penalty state — reloading recovery status...");
+            await portfolioVm.LoadRecoveryStatusAsync(currentInvestment);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        // Verify VM-level data
+        portfolioVm.PenaltyInvestments.Should().NotBeEmpty("there should be at least one penalty investment");
+        portfolioVm.HasPenaltyInvestments.Should().BeTrue();
+        var penaltyItem = portfolioVm.PenaltyInvestments
+            .FirstOrDefault(i => i.ProjectIdentifier == investment.ProjectIdentifier);
+        penaltyItem.Should().NotBeNull("the current investment should appear in PenaltyInvestments");
+
+        // Navigate to the portfolio section so the PenaltiesButton is in the visual tree
+        window.NavigateToSection("Funded");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        // Click the PenaltiesButton in the PortfolioView to open the modal
+        var penaltiesBtn = window.GetVisualDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(b => b.Name == "PenaltiesButton");
+        penaltiesBtn.Should().NotBeNull("PenaltiesButton should exist in the portfolio view");
+        penaltiesBtn!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, penaltiesBtn));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        // Find the PenaltiesModal in the visual tree
+        var modal = window.GetVisualDescendants()
+            .OfType<PenaltiesModal>()
+            .FirstOrDefault();
+        modal.Should().NotBeNull("PenaltiesModal should be visible after clicking PenaltiesButton");
+        modal!.DataContext.Should().Be(portfolioVm, "PenaltiesModal should have PortfolioViewModel as DataContext");
+
+        // Verify the ItemsControl rendered rows with penalty data
+        var itemsControl = modal.GetVisualDescendants()
+            .OfType<ItemsControl>()
+            .FirstOrDefault();
+        itemsControl.Should().NotBeNull("PenaltiesModal should contain an ItemsControl for penalty rows");
+        itemsControl!.ItemCount.Should().BeGreaterThan(0,
+            "ItemsControl should render at least one penalty investment row");
+
+        // Verify a TextBlock shows the project identifier
+        var projectIdTexts = modal.GetVisualDescendants()
+            .OfType<TextBlock>()
+            .Where(tb => !string.IsNullOrEmpty(tb.Text) && tb.Text.Contains(investment.ProjectIdentifier))
+            .ToList();
+        projectIdTexts.Should().NotBeEmpty(
+            $"PenaltiesModal should display the project identifier '{investment.ProjectIdentifier}'");
+
+        Log(profileName, $"PenaltiesModal verified: {itemsControl.ItemCount} penalty row(s) displayed, project ID visible.");
+
+        // Close the modal
+        var closeBtn = modal.GetVisualDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(b => b.Name == "CloseButton");
+        if (closeBtn != null)
+        {
+            closeBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, closeBtn));
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(200);
+            Dispatcher.UIThread.RunJobs();
+        }
+        else
+        {
+            window.HideModal();
+        }
     }
 
     private enum RecoveryAction

--- a/src/design/App.Test.Integration/MultiFundReleaseUnfundedAndClaimTest.cs
+++ b/src/design/App.Test.Integration/MultiFundReleaseUnfundedAndClaimTest.cs
@@ -1,0 +1,1020 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FluentAssertions;
+using Angor.Sdk.Common;
+using Angor.Sdk.Funding.Founder;
+using Angor.Sdk.Funding.Investor;
+using Angor.Sdk.Funding.Investor.Operations;
+using Angor.Sdk.Funding.Projects;
+using Angor.Sdk.Funding.Shared;
+using Angor.Shared.Utilities;
+using App.Composition.Adapters;
+using App.Test.Integration.Helpers;
+using App.UI.Sections.FindProjects;
+using App.UI.Sections.Funders;
+using App.UI.Sections.Funds;
+using App.UI.Sections.MyProjects;
+using App.UI.Sections.MyProjects.Deploy;
+using App.UI.Sections.Portfolio;
+using App.UI.Sections.Settings;
+using App.UI.Shell;
+using Microsoft.Extensions.DependencyInjection;
+using System.Globalization;
+
+namespace App.Test.Integration;
+
+public class MultiFundReleaseUnfundedAndClaimTest
+{
+    private const string TestName = "MultiFundReleaseUnfundedAndClaim";
+    private const string FounderProfile = TestName + "-Founder";
+    private const string BelowThresholdInvestorProfile = TestName + "-Investor1";
+    private const string AboveThresholdInvestorProfile = TestName + "-Investor2";
+
+    private static readonly TimeSpan FaucetBalanceTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan TransactionTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan UiTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan IndexerLagTimeout = TimeSpan.FromMinutes(5);
+
+    private sealed record ProjectHandle(string RunId, string ProjectName, string ProjectIdentifier, string FounderWalletId);
+
+    [AvaloniaFact]
+    public async Task MultiFundReleaseUnfundedAndClaim()
+    {
+        var initializedProfiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var runId = Guid.NewGuid().ToString("N")[..12];
+        var projectName = $"Multi Fund Release {runId}";
+        var projectAbout =
+            $"{TestName} run {runId}. Founder claims stage 1, releases remaining stages, and both investors claim them.";
+        var bannerImageUrl = $"https://picsum.photos/seed/{Guid.NewGuid().ToString("N")[..8]}/320/200";
+        var profileImageUrl = $"https://picsum.photos/seed/{Guid.NewGuid().ToString("N")[..8]}/100/100";
+        var thresholdAmountBtc = "0.01";
+        var belowThresholdInvestmentBtc = "0.001";
+        var aboveThresholdInvestmentBtc = "0.02";
+        var payoutDay = DateTime.UtcNow.DayOfWeek.ToString();
+
+        Log(null, $"========== STARTING {nameof(MultiFundReleaseUnfundedAndClaim)} ==========");
+        Log(null, $"Run ID: {runId}");
+        Log(null, $"Founder profile: {FounderProfile}");
+        Log(null, $"Investor1 profile (below threshold): {BelowThresholdInvestorProfile}");
+        Log(null, $"Investor2 profile (above threshold): {AboveThresholdInvestorProfile}");
+
+        ProjectHandle? project = null;
+
+        await WithProfileWindow(FounderProfile, initializedProfiles, async window =>
+        {
+            await CreateWalletAndFundAsync(window, FounderProfile);
+            project = await CreateFundProjectAsync(
+                window,
+                FounderProfile,
+                projectName,
+                projectAbout,
+                bannerImageUrl,
+                profileImageUrl,
+                thresholdAmountBtc,
+                payoutDay,
+                runId);
+        });
+
+        project.Should().NotBeNull();
+
+        await WithProfileWindow(BelowThresholdInvestorProfile, initializedProfiles, async window =>
+        {
+            await CreateWalletAndFundAsync(window, BelowThresholdInvestorProfile);
+            await InvestInProjectAsync(
+                window,
+                BelowThresholdInvestorProfile,
+                project!,
+                belowThresholdInvestmentBtc,
+                expectFounderApproval: false);
+        });
+
+        await WithProfileWindow(AboveThresholdInvestorProfile, initializedProfiles, async window =>
+        {
+            await CreateWalletAndFundAsync(window, AboveThresholdInvestorProfile);
+            await InvestInProjectAsync(
+                window,
+                AboveThresholdInvestorProfile,
+                project!,
+                aboveThresholdInvestmentBtc,
+                expectFounderApproval: true);
+        });
+
+        await WithProfileWindow(FounderProfile, initializedProfiles, async window =>
+        {
+            await ApprovePendingInvestmentAsync(window, FounderProfile, project!);
+        });
+
+        await WithProfileWindow(AboveThresholdInvestorProfile, initializedProfiles, async window =>
+        {
+            await ConfirmApprovedInvestmentAsync(window, AboveThresholdInvestorProfile, project!);
+        });
+
+        await WithProfileWindow(FounderProfile, initializedProfiles, async window =>
+        {
+            await ClaimStageOneAsync(window, FounderProfile, project!);
+            await ReleaseRemainingStagesToInvestorsAsync(window, FounderProfile, project!);
+        });
+
+        await WithProfileWindow(AboveThresholdInvestorProfile, initializedProfiles, async window =>
+        {
+            await ClaimRemainingStagesAsync(window, AboveThresholdInvestorProfile, project!);
+        });
+
+        await WithProfileWindow(BelowThresholdInvestorProfile, initializedProfiles, async window =>
+        {
+            await ClaimRemainingStagesAsync(window, BelowThresholdInvestorProfile, project!, expectedActionKey: "belowThreshold");
+        });
+
+        Log(null, $"========== {nameof(MultiFundReleaseUnfundedAndClaim)} PASSED ==========");
+    }
+
+    private async Task WithProfileWindow(
+        string profileName,
+        HashSet<string> initializedProfiles,
+        Func<Window, Task> action)
+    {
+        using var profileScope = TestProfileScope.For(profileName);
+        var window = TestHelpers.CreateShellWindow();
+
+        try
+        {
+            ValidateCurrentProfile(profileName);
+
+            if (!initializedProfiles.Contains(profileName))
+            {
+                Log(profileName, "First use for profile. Wiping existing data...");
+                await WipeExistingData(window, profileName);
+                initializedProfiles.Add(profileName);
+            }
+
+            SetPasswordProvider(profileName);
+            await action(window);
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(250);
+        }
+    }
+
+    private static void ValidateCurrentProfile(string expectedProfile)
+    {
+        var profileContext = global::App.App.Services.GetRequiredService<ProfileContext>();
+        var storage = global::App.App.Services.GetRequiredService<IApplicationStorage>();
+        var profileDirectory = storage.GetProfileDirectory(profileContext.AppName, profileContext.ProfileName);
+
+        profileContext.ProfileName.Should().Be(expectedProfile);
+        Log(expectedProfile, $"Using profile directory: {profileDirectory}");
+    }
+
+    private static void SetPasswordProvider(string profileName)
+    {
+        var passwordProvider = global::App.App.Services.GetRequiredService<SimplePasswordProvider>();
+        passwordProvider.SetKey("default-key");
+        Log(profileName, "Set SimplePasswordProvider key to 'default-key'.");
+    }
+
+    private async Task CreateWalletAndFundAsync(Window window, string profileName)
+    {
+        window.NavigateToSection("Funds");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        if (!fundsVm!.SeedGroups.Any() || !fundsVm.SeedGroups.SelectMany(g => g.Wallets).Any())
+        {
+            Log(profileName, "Creating wallet via Generate flow...");
+            await CreateWalletViaGenerate(window, profileName);
+        }
+        else
+        {
+            Log(profileName, "Wallet already exists for this profile.");
+        }
+
+        var walletCardBtn = await window.WaitForWalletCard(TimeSpan.FromSeconds(30));
+        walletCardBtn.Should().NotBeNull();
+
+        Log(profileName, "Funding wallet via faucet...");
+        await FundWalletViaFaucet(window, profileName);
+    }
+
+    private async Task<ProjectHandle> CreateFundProjectAsync(
+        Window window,
+        string profileName,
+        string projectName,
+        string projectAbout,
+        string bannerImageUrl,
+        string profileImageUrl,
+        string thresholdAmountBtc,
+        string payoutDay,
+        string runId)
+    {
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var myProjectsVm = GetMyProjectsViewModel(window);
+        myProjectsVm.Should().NotBeNull();
+
+        await OpenCreateWizard(window, myProjectsVm!, profileName);
+
+        var wizardVm = myProjectsVm.CreateProjectVm;
+        wizardVm.Should().NotBeNull();
+
+        Log(profileName, "Selecting Fund project type...");
+        wizardVm.DismissWelcome();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        wizardVm.SelectProjectType("fund");
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, $"Setting project metadata: {projectName}");
+        wizardVm.ProjectName = projectName;
+        wizardVm.ProjectAbout = projectAbout;
+        wizardVm.ProjectName.Should().Be(projectName);
+        wizardVm.ProjectAbout.Should().Be(projectAbout);
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Setting project images...");
+        wizardVm.BannerUrl = bannerImageUrl;
+        wizardVm.ProfileUrl = profileImageUrl;
+        wizardVm.BannerUrl.Should().Be(bannerImageUrl);
+        wizardVm.ProfileUrl.Should().Be(profileImageUrl);
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Configuring target amount, threshold, and zero penalty days...");
+        wizardVm.TargetAmount = "1.0";
+        wizardVm.ApprovalThreshold = thresholdAmountBtc;
+        wizardVm.PenaltyDays = 0;
+        wizardVm.TargetAmount.Should().Be("1.0");
+        wizardVm.ApprovalThreshold.Should().Be(thresholdAmountBtc);
+        wizardVm.PenaltyDays.Should().Be(0);
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, $"Configuring payout schedule for today ({payoutDay})...");
+        wizardVm.DismissStep5Welcome();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        wizardVm.PayoutFrequency = "Weekly";
+        wizardVm.ToggleInstallmentCount(3);
+        wizardVm.WeeklyPayoutDay = payoutDay;
+        wizardVm.GeneratePayoutSchedule();
+        wizardVm.Stages.Count.Should().Be(3);
+        wizardVm.Stages.Select(s => s.StageNumber).Should().ContainInOrder(1, 2, 3);
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Deploying project...");
+        wizardVm.Deploy();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(1000);
+        Dispatcher.UIThread.RunJobs();
+
+        var deployVm = wizardVm.DeployFlow;
+        var walletLoadDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTime.UtcNow < walletLoadDeadline && deployVm.Wallets.Count == 0)
+        {
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        deployVm.Wallets.Count.Should().BeGreaterThan(0);
+        deployVm.SelectWallet(deployVm.Wallets[0]);
+        Dispatcher.UIThread.RunJobs();
+        deployVm.PayWithWallet();
+
+        var deployDeadline = DateTime.UtcNow + TransactionTimeout;
+        while (DateTime.UtcNow < deployDeadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (deployVm.CurrentScreen == DeployScreen.Success)
+            {
+                break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        deployVm.CurrentScreen.Should().Be(DeployScreen.Success,
+            $"Deploy should reach success. Last status: {deployVm.DeployStatusText}");
+
+        deployVm.GoToMyProjects();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        await myProjectsVm.LoadFounderProjectsAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var project = myProjectsVm.Projects.FirstOrDefault(p => p.Description.Contains(runId, StringComparison.Ordinal));
+        project.Should().NotBeNull();
+        project!.ProjectIdentifier.Should().NotBeNullOrEmpty();
+        project.OwnerWalletId.Should().NotBeNullOrEmpty();
+        project.Name.Should().Be(projectName);
+        project.Description.Should().Contain(runId);
+        project.ProjectType.Should().Be("fund");
+
+        Log(profileName, $"Project deployed. ProjectId={project.ProjectIdentifier}, OwnerWalletId={project.OwnerWalletId}");
+        return new ProjectHandle(runId, projectName, project.ProjectIdentifier!, project.OwnerWalletId!);
+    }
+
+    private async Task InvestInProjectAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project,
+        string amountBtc,
+        bool expectFounderApproval)
+    {
+        var foundProject = await FindProjectFromSdkAsync(window, profileName, project);
+
+        var findProjectsVm = GetFindProjectsViewModel(window);
+        findProjectsVm.Should().NotBeNull();
+
+        findProjectsVm!.OpenProjectDetail(foundProject);
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(300);
+
+        findProjectsVm.OpenInvestPage();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var investVm = findProjectsVm.InvestPageViewModel;
+        investVm.Should().NotBeNull();
+
+        var walletLoadDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTime.UtcNow < walletLoadDeadline && investVm!.Wallets.Count == 0)
+        {
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        investVm!.Wallets.Count.Should().BeGreaterThan(0);
+        investVm.InvestmentAmount = amountBtc;
+        investVm.CanSubmit.Should().BeTrue();
+        investVm.Stages.Count.Should().BeGreaterThanOrEqualTo(3,
+            "fund project should expose at least the configured stage outputs to investors");
+        investVm.Stages.Select(s => s.LabelText).Should().Contain(label => label.Contains("Stage 1"));
+        investVm.Submit();
+        Dispatcher.UIThread.RunJobs();
+        investVm.CurrentScreen.Should().Be(InvestScreen.WalletSelector);
+
+        var investWallet = investVm.Wallets[0];
+        investVm.SelectWallet(investWallet);
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, $"Investing {amountBtc} BTC with wallet {investWallet.Id.Value}...");
+        investVm.PayWithWallet();
+
+        var investDeadline = DateTime.UtcNow + TransactionTimeout;
+        while (DateTime.UtcNow < investDeadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (investVm.CurrentScreen == InvestScreen.Success)
+            {
+                break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        investVm.CurrentScreen.Should().Be(InvestScreen.Success,
+            $"Invest should reach success. Last status: {investVm.PaymentStatusText}");
+        investVm.FormattedAmount.Should().Be(decimal.Parse(amountBtc, CultureInfo.InvariantCulture).ToString("F8", CultureInfo.InvariantCulture));
+
+        Log(profileName, $"[Bug7] IsAutoApproved={investVm.IsAutoApproved}, SuccessTitle='{investVm.SuccessTitle}'");
+        if (expectFounderApproval)
+        {
+            investVm.IsAutoApproved.Should().BeFalse(
+                "above-threshold investment should NOT be auto-approved");
+            investVm.SuccessTitle.Should().Contain("Pending Approval",
+                "above-threshold investment should show 'Pending Approval' in SuccessTitle");
+        }
+        else
+        {
+            investVm.IsAutoApproved.Should().BeTrue(
+                "below-threshold investment should be auto-approved");
+            investVm.SuccessTitle.Should().Contain("Successful",
+                "below-threshold (auto-approved) investment should show 'Successful' in SuccessTitle");
+        }
+
+        var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
+        investVm.AddToPortfolio();
+        Dispatcher.UIThread.RunJobs();
+
+        var addedInvestment = portfolioVm.Investments.FirstOrDefault(i => i.ProjectIdentifier == project.ProjectIdentifier);
+        addedInvestment.Should().NotBeNull();
+        addedInvestment!.ProjectName.Should().Be(project.ProjectName);
+        var actualInvested = decimal.Parse(addedInvestment.TotalInvested, CultureInfo.InvariantCulture);
+        var expectedInvested = decimal.Parse(amountBtc, CultureInfo.InvariantCulture);
+        actualInvested.Should().BeGreaterThan(0, "TotalInvested should be non-zero after AddToPortfolio");
+        actualInvested.Should().BeLessThanOrEqualTo(expectedInvested, "TotalInvested should not exceed requested amount");
+        (expectedInvested - actualInvested).Should().BeLessThan(0.001m,
+            "TotalInvested should be within fee tolerance of requested amount");
+        Log(profileName, $"Investment completed. Founder approval expected: {expectFounderApproval}");
+    }
+
+    private async Task ApprovePendingInvestmentAsync(Window window, string profileName, ProjectHandle project)
+    {
+        window.NavigateToSection("Funders");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var fundersVm = GetFundersViewModel(window);
+        fundersVm.Should().NotBeNull();
+
+        SignatureRequestViewModel? pendingSignature = null;
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await fundersVm!.LoadInvestmentRequestsAsync();
+            Dispatcher.UIThread.RunJobs();
+            fundersVm.SetFilter("waiting");
+            Dispatcher.UIThread.RunJobs();
+
+            Log(profileName, $"Funders waiting count: {fundersVm.WaitingCount}, approved count: {fundersVm.ApprovedCount}");
+
+            pendingSignature = fundersVm.FilteredSignatures.FirstOrDefault(s =>
+                string.Equals(s.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
+            if (pendingSignature != null)
+            {
+                break;
+            }
+
+            Log(profileName, "Waiting for pending founder approval request...");
+            await Task.Delay(PollInterval);
+        }
+
+        pendingSignature.Should().NotBeNull("above-threshold investment should require founder approval");
+        Log(profileName, $"Approving signature request id={pendingSignature!.Id} for project {project.ProjectIdentifier}");
+        await window.ClickApproveSignatureAsync(fundersVm!, pendingSignature, UiTimeout);
+
+        var approvalDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < approvalDeadline)
+        {
+            await fundersVm.LoadInvestmentRequestsAsync();
+            Dispatcher.UIThread.RunJobs();
+            fundersVm.SetFilter("approved");
+            Dispatcher.UIThread.RunJobs();
+
+            var approved = fundersVm.FilteredSignatures.Any(s =>
+                string.Equals(s.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
+            if (approved)
+            {
+                Log(profileName, "Founder approval completed.");
+                return;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Founder approval did not complete in time.");
+    }
+
+    private async Task ConfirmApprovedInvestmentAsync(Window window, string profileName, ProjectHandle project)
+    {
+        var portfolioVm = await WaitForPortfolioInvestmentAsync(window, profileName, project, investment => investment.Step >= 2);
+        var investment = portfolioVm.Investments.First(i => i.ProjectIdentifier == project.ProjectIdentifier);
+
+        Log(profileName, $"Confirming approved investment. Step={investment.Step}, Status={investment.StatusText}");
+        investment.ApprovalStatus.Should().Be("Approved");
+        await window.ClickInvestmentDetailActionAsync(portfolioVm, investment, "ConfirmInvestmentButton", UiTimeout);
+
+        var activeDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < activeDeadline)
+        {
+            await portfolioVm.LoadInvestmentsFromSdkAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var refreshed = portfolioVm.Investments.FirstOrDefault(i => i.ProjectIdentifier == project.ProjectIdentifier);
+            if (refreshed?.Step == 3)
+            {
+                Log(profileName, "Investor confirmation completed and investment is active.");
+                return;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Confirmed investment did not become active in time.");
+    }
+
+    private async Task ClaimStageOneAsync(Window window, string profileName, ProjectHandle project)
+    {
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var myProjectsVm = GetMyProjectsViewModel(window);
+        myProjectsVm.Should().NotBeNull();
+
+        await myProjectsVm!.LoadFounderProjectsAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var founderProject = myProjectsVm.Projects.FirstOrDefault(p =>
+            string.Equals(p.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
+        founderProject.Should().NotBeNull();
+
+        var manageVm = myProjectsVm.SelectedManageProject;
+
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await myProjectsVm.LoadFounderProjectsAsync();
+            myProjectsVm.OpenManageProject(founderProject!);
+            manageVm = myProjectsVm.SelectedManageProject;
+            await manageVm!.LoadClaimableTransactionsAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var stageSnapshot = string.Join(", ", manageVm.Stages.Select(s =>
+                $"#{s.Number}:available={s.Available},canClaim={s.CanClaim},availableTxs={s.AvailableTransactions.Count},spent={s.SpentTransactionCount},date='{s.CompletionDate}'"));
+            Log(profileName, $"Stage snapshot: {stageSnapshot}");
+
+            var stage1 = manageVm.Stages.FirstOrDefault(s => s.Number == 1 && s.AvailableTransactions.Count >= 2);
+            if (stage1 != null)
+            {
+                stage1.AvailableTransactions.Count.Should().Be(2,
+                    "founder should claim stage 1 from both investor UTXOs");
+
+                await window.ClickManageProjectClaimStageAsync(myProjectsVm, founderProject!, stage1.Number, UiTimeout);
+                Log(profileName, "Founder claimed stage 1 using both available UTXOs.");
+                break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        var spentDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < spentDeadline)
+        {
+            await manageVm!.LoadClaimableTransactionsAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            if (manageVm.Stages.Any(s => s.Number == 1 && s.SpentTransactionCount > 0))
+            {
+                Log(profileName, "Founder spend is visible in stage status.");
+                return;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Founder stage 1 spend was not indexed in time.");
+    }
+
+    private async Task ReleaseRemainingStagesToInvestorsAsync(Window window, string profileName, ProjectHandle project)
+    {
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var myProjectsVm = GetMyProjectsViewModel(window);
+        myProjectsVm.Should().NotBeNull();
+
+        await myProjectsVm!.LoadFounderProjectsAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var founderProject = myProjectsVm.Projects.FirstOrDefault(p =>
+            string.Equals(p.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
+        founderProject.Should().NotBeNull();
+
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await myProjectsVm.LoadFounderProjectsAsync();
+            myProjectsVm.OpenManageProject(founderProject!);
+            var manageVm = myProjectsVm.SelectedManageProject;
+            manageVm.Should().NotBeNull();
+
+            var releaseSucceeded = await window.ClickManageProjectReleaseFundsAsync(myProjectsVm, founderProject!, UiTimeout);
+            if (releaseSucceeded)
+            {
+                Log(profileName, "Founder released remaining stages to investors.");
+                return;
+            }
+
+            Log(profileName, "Remaining stage release not ready yet. Retrying...");
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Founder release signatures were not created in time.");
+    }
+
+    private async Task ClaimRemainingStagesAsync(Window window, string profileName, ProjectHandle project, string expectedActionKey = "unfundedRelease")
+    {
+        var portfolioVm = await WaitForPortfolioInvestmentAsync(window, profileName, project, investment => investment.Step == 3);
+        var investment = portfolioVm.Investments.First(i => i.ProjectIdentifier == project.ProjectIdentifier);
+        investment.InvestmentWalletId.Should().NotBeNullOrEmpty();
+        investment.InvestmentTransactionId.Should().NotBeNullOrEmpty();
+
+        var releaseState = await WaitForRecoveryActionAsync(portfolioVm, investment, profileName, expectedActionKey: expectedActionKey);
+        releaseState.ActionKey.Should().Be(expectedActionKey);
+
+        Log(profileName, $"Claiming remaining stages via '{expectedActionKey}' path...");
+        await EnsureWalletHasFeeFunds(window, profileName, investment.InvestmentWalletId, $"before {expectedActionKey}");
+
+        Func<Task<bool>> executeAction = expectedActionKey switch
+        {
+            "unfundedRelease" => () => portfolioVm.ReleaseFundsAsync(investment).ContinueWith(t => t.Result.Success),
+            "belowThreshold" => () => portfolioVm.ClaimEndOfProjectAsync(investment).ContinueWith(t => t.Result.Success),
+            _ => throw new ArgumentException($"Unsupported action key: {expectedActionKey}")
+        };
+
+        var releaseResult = await ExecuteActionWithRetry(
+            profileName,
+            expectedActionKey,
+            executeAction,
+            () => expectedActionKey == "unfundedRelease"
+                ? LogUnfundedReleaseBuildDiagnostics(investment)
+                : Task.CompletedTask);
+        releaseResult.Should().BeTrue();
+
+        Log(profileName, "Verifying stage statuses after unfunded release...");
+        var statusDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < statusDeadline)
+        {
+            await portfolioVm.LoadRecoveryStatusAsync(investment);
+            Dispatcher.UIThread.RunJobs();
+
+            var recoveredStages = investment.Stages
+                .Where(s => s.Status == "Spent by investor" ||
+                            s.Status == "Recovered after penalty" ||
+                            s.Status == "Project Unfunded, Spent back to investor")
+                .ToList();
+
+            if (recoveredStages.Count > 0)
+            {
+                Log(profileName,
+                    $"Found {recoveredStages.Count} stage(s) with recovered status: {string.Join(", ", recoveredStages.Select(s => $"stage {s.StageNumber}='{s.Status}'"))}");
+                foreach (var stage in recoveredStages)
+                {
+                    stage.IsStatusRecovered.Should().BeTrue(
+                        $"stage {stage.StageNumber} with status '{stage.Status}' should be recognized as recovered");
+                }
+                break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        investment.Stages.Any(s => s.Status == "Spent by investor" ||
+                                   s.Status == "Recovered after penalty" ||
+                                   s.Status == "Project Unfunded, Spent back to investor")
+            .Should().BeTrue("at least one stage should show a recovered status after release");
+    }
+
+    private async Task<bool> ExecuteActionWithRetry(
+        string profileName,
+        string actionLabel,
+        Func<Task<bool>> execute,
+        Func<Task> logDiagnostics)
+    {
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        var attempt = 0;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            attempt++;
+            Log(profileName, $"Attempt #{attempt} for action '{actionLabel}'...");
+            var result = await execute();
+            if (result)
+            {
+                Log(profileName, $"Action '{actionLabel}' succeeded on attempt #{attempt}.");
+                return true;
+            }
+
+            await logDiagnostics();
+            await Task.Delay(PollInterval);
+        }
+
+        return false;
+    }
+
+    private static async Task LogUnfundedReleaseBuildDiagnostics(InvestmentViewModel investment)
+    {
+        var investmentAppService = global::App.App.Services.GetRequiredService<IInvestmentAppService>();
+        var walletId = new WalletId(investment.InvestmentWalletId);
+        var projectId = new ProjectId(investment.ProjectIdentifier);
+        var feeRate = new DomainFeerate(20);
+
+        var buildResult = await investmentAppService.BuildUnfundedReleaseTransaction(
+            new BuildUnfundedReleaseTransaction.BuildUnfundedReleaseTransactionRequest(walletId, projectId, feeRate));
+
+        Log(investment.ProjectIdentifier, buildResult.IsSuccess
+            ? $"Diagnostic BuildUnfundedReleaseTransaction succeeded. TxId={buildResult.Value.TransactionDraft.TransactionId}"
+            : $"Diagnostic BuildUnfundedReleaseTransaction failed: {buildResult.Error}");
+    }
+
+    private async Task<RecoveryState> WaitForRecoveryActionAsync(
+        PortfolioViewModel portfolioVm,
+        InvestmentViewModel investment,
+        string profileName,
+        string expectedActionKey)
+    {
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await portfolioVm.LoadRecoveryStatusAsync(investment);
+            Dispatcher.UIThread.RunJobs();
+
+            Log(profileName,
+                $"Recovery state: HasUnspent={investment.RecoveryState.HasUnspentItems}, InPenalty={investment.RecoveryState.HasSpendableItemsInPenalty}, HasReleaseSig={investment.RecoveryState.HasReleaseSignatures}, EndOfProject={investment.RecoveryState.EndOfProject}, AboveThreshold={investment.RecoveryState.IsAboveThreshold}, ActionKey={investment.RecoveryState.ActionKey}");
+
+            if (investment.RecoveryState.ActionKey == expectedActionKey)
+            {
+                return investment.RecoveryState;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException($"Recovery action '{expectedActionKey}' did not appear in time.");
+    }
+
+    private async Task<PortfolioViewModel> WaitForPortfolioInvestmentAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project,
+        Func<InvestmentViewModel, bool> predicate)
+    {
+        window.NavigateToSection("Funded");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            await portfolioVm.LoadInvestmentsFromSdkAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var investment = portfolioVm.Investments.FirstOrDefault(i =>
+                string.Equals(i.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
+
+            if (investment != null)
+            {
+                Log(profileName, $"Portfolio investment found. Step={investment.Step}, Status={investment.StatusText}, Approval={investment.ApprovalStatus}, WalletId={investment.InvestmentWalletId}, InvestmentTxId={investment.InvestmentTransactionId}");
+                if (predicate(investment))
+                {
+                    return portfolioVm;
+                }
+            }
+            else
+            {
+                Log(profileName, "Portfolio investment not found yet.");
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Portfolio investment did not reach the expected state in time.");
+    }
+
+    private async Task EnsureWalletHasFeeFunds(Window window, string profileName, string walletId, string context)
+    {
+        window.NavigateToSection("Funds");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            var refresh = await global::App.App.Services.GetRequiredService<Angor.Sdk.Wallet.Application.IWalletAppService>()
+                .RefreshAndGetAccountBalanceInfo(new WalletId(walletId));
+
+            if (refresh.IsSuccess)
+            {
+                var info = refresh.Value;
+                var available = info.TotalBalance + info.TotalUnconfirmedBalance + info.TotalBalanceReserved;
+                Log(profileName, $"Wallet balance {context}: {available.ToUnitBtc():F8} BTC available for fees");
+                if (available > 20_000)
+                {
+                    return;
+                }
+            }
+
+            Log(profileName, $"Wallet needs fee funds {context}. Requesting faucet coins...");
+            var (success, error) = await fundsVm!.GetTestCoinsAsync(walletId);
+            Log(profileName, success ? "Fee-funding faucet request accepted." : $"Fee-funding faucet request failed: {error}");
+
+            await ClickWalletCardButton(window, "WalletCardBtnRefresh");
+            await Task.Delay(PollInterval);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        throw new InvalidOperationException($"Wallet '{walletId}' did not receive enough fee funds {context}.");
+    }
+
+    private async Task<ProjectItemViewModel> FindProjectFromSdkAsync(Window window, string profileName, ProjectHandle project)
+    {
+        window.NavigateToSection("Find Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var findProjectsVm = GetFindProjectsViewModel(window);
+        findProjectsVm.Should().NotBeNull();
+
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await findProjectsVm!.LoadProjectsFromSdkAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var foundProject = findProjectsVm.Projects.FirstOrDefault(p =>
+                string.Equals(p.ProjectId, project.ProjectIdentifier, StringComparison.Ordinal) ||
+                p.Description.Contains(project.RunId, StringComparison.Ordinal) ||
+                p.ShortDescription.Contains(project.RunId, StringComparison.Ordinal));
+
+            if (foundProject != null)
+            {
+                Log(profileName, $"Found project in SDK list: {foundProject.ProjectId}");
+                return foundProject;
+            }
+
+            Log(profileName, "Project not found in SDK yet. Retrying...");
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Project was not found in the SDK project list in time.");
+    }
+
+    private async Task WipeExistingData(Window window, string profileName)
+    {
+        window.NavigateToSettings();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+
+        var settingsView = window.GetVisualDescendants().OfType<SettingsView>().FirstOrDefault();
+        if (settingsView?.DataContext is SettingsViewModel settingsVm)
+        {
+            settingsVm.ConfirmWipeData();
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+            Log(profileName, "Profile data wiped.");
+        }
+    }
+
+    private async Task CreateWalletViaGenerate(Window window, string profileName)
+    {
+        var addWalletBtn = FindAddWalletButton(window);
+        addWalletBtn.Should().NotBeNull();
+
+        addWalletBtn!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, addWalletBtn));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(300);
+        Dispatcher.UIThread.RunJobs();
+
+        await window.ClickButton("BtnGenerate", UiTimeout);
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+        await window.ClickButton("BtnDownloadSeed", UiTimeout);
+        await Task.Delay(300);
+        Dispatcher.UIThread.RunJobs();
+        await window.ClickButton("BtnContinueBackup", UiTimeout);
+
+        var successPanel = await window.WaitForControl<StackPanel>("CreateWalletSuccessPanel", TimeSpan.FromSeconds(30));
+        successPanel.Should().NotBeNull();
+        await window.ClickButton("BtnCreateWalletDone", UiTimeout);
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Wallet created successfully.");
+    }
+
+    private async Task FundWalletViaFaucet(Window window, string profileName)
+    {
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        var walletId = fundsVm!.SeedGroups.FirstOrDefault()?.Wallets?.FirstOrDefault()?.Id.Value;
+        walletId.Should().NotBeNullOrEmpty();
+
+        var deadline = DateTime.UtcNow + FaucetBalanceTimeout;
+        var faucetRetryInterval = TimeSpan.FromSeconds(30);
+        var lastFaucetAttempt = DateTime.MinValue;
+        var faucetAttempts = 0;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+
+            if (fundsVm.TotalBalance != "0.0000")
+            {
+                Log(profileName, $"Non-zero balance detected: {fundsVm.TotalBalance}");
+                return;
+            }
+
+            if (DateTime.UtcNow - lastFaucetAttempt >= faucetRetryInterval)
+            {
+                faucetAttempts++;
+                lastFaucetAttempt = DateTime.UtcNow;
+                Log(profileName, $"Faucet attempt #{faucetAttempts}...");
+
+                (bool success, string? error) = await fundsVm.GetTestCoinsAsync(walletId!);
+                Dispatcher.UIThread.RunJobs();
+                Log(profileName, success ? "Faucet request accepted." : $"Faucet request failed: {error}");
+            }
+
+            await ClickWalletCardButton(window, "WalletCardBtnRefresh");
+            await Task.Delay(PollInterval);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        throw new InvalidOperationException("Wallet balance did not become non-zero in time.");
+    }
+
+    private async Task OpenCreateWizard(Window window, MyProjectsViewModel myProjectsVm, string profileName)
+    {
+        myProjectsVm.CreateProjectVm.ResetWizard();
+        myProjectsVm.LaunchCreateWizard();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        myProjectsVm.ShowCreateWizard.Should().BeTrue();
+        myProjectsVm.CreateProjectVm.OnProjectDeployed = () =>
+        {
+            myProjectsVm.OnProjectDeployed(myProjectsVm.CreateProjectVm);
+            myProjectsVm.CloseCreateWizard();
+        };
+
+        Log(profileName, "Create wizard opened.");
+    }
+
+    private static Button? FindAddWalletButton(Window window)
+    {
+        var buttons = window.GetVisualDescendants().OfType<Button>().Where(b => b.IsVisible);
+        foreach (var btn in buttons)
+        {
+            if (btn.Content is string text && text.Contains("Add Wallet", StringComparison.Ordinal))
+            {
+                return btn;
+            }
+
+            if (btn.Content is StackPanel panel)
+            {
+                foreach (var child in panel.Children.OfType<TextBlock>())
+                {
+                    if (child.Text == "Add Wallet")
+                    {
+                        return btn;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private async Task ClickWalletCardButton(Window window, string automationId)
+    {
+        var button = await window.WaitForControl<Button>(automationId, UiTimeout);
+        button.Should().NotBeNull();
+        button!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, button));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static FundsViewModel? GetFundsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FundsView>().FirstOrDefault()?.DataContext as FundsViewModel;
+    }
+
+    private static MyProjectsViewModel? GetMyProjectsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<MyProjectsView>().FirstOrDefault()?.DataContext as MyProjectsViewModel;
+    }
+
+    private static FindProjectsViewModel? GetFindProjectsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FindProjectsView>().FirstOrDefault()?.DataContext as FindProjectsViewModel;
+    }
+
+    private static FundersViewModel? GetFundersViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FundersView>().FirstOrDefault()?.DataContext as FundersViewModel;
+    }
+
+    private static void Log(string? profileName, string message)
+    {
+        var prefix = string.IsNullOrWhiteSpace(profileName) ? "GLOBAL" : profileName;
+        Console.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] [{prefix}] {message}");
+    }
+}

--- a/src/design/App.Test.Integration/MultiFundReleaseUnfundedAndClaimTest.md
+++ b/src/design/App.Test.Integration/MultiFundReleaseUnfundedAndClaimTest.md
@@ -1,0 +1,52 @@
+# MultiFundReleaseUnfundedAndClaimTest
+
+## Purpose
+
+Full end-to-end integration test for a **Fund** project with three isolated app profiles: one founder and two investors. It verifies mixed below-threshold and above-threshold investment behavior, founder approval, founder stage-1 claim across both investor UTXOs, founder release of remaining stages, and investor claims of the released stages without penalty.
+
+## Profiles
+
+- Founder profile: `MultiFundReleaseUnfundedAndClaim-Founder`
+- Investor1 profile (below threshold): `MultiFundReleaseUnfundedAndClaim-Investor1`
+- Investor2 profile (above threshold): `MultiFundReleaseUnfundedAndClaim-Investor2`
+
+All profiles are created under:
+
+- `C:\Users\dan\AppData\Local\Angor\Profiles\`
+
+## Scenario
+
+1. Founder profile creates a wallet, funds it, and deploys a **Fund** project.
+2. The project uses:
+   - approval threshold `0.01 BTC`
+   - penalty days `0`
+   - weekly payout day = today
+   - 3 payout stages
+3. Investor 1 invests `0.001 BTC` (below threshold, auto-approved).
+4. Investor 2 invests `0.02 BTC` (above threshold, requires founder approval).
+5. Founder approves the pending above-threshold investment.
+6. Investor 2 confirms the signed investment so it becomes active.
+7. Founder claims stage 1 and spends both stage-1 UTXOs together.
+8. Founder releases the remaining stages back to investors from the Manage Project UI.
+9. Investor 2 claims the remaining stages through the unfunded-release path.
+10. Investor 1 claims the remaining stages through the below-threshold recovery path.
+
+## Notes
+
+- The test reuses the real headless Avalonia app and switches profiles by rebuilding DI per profile.
+- It logs the active profile directory before each phase so profile isolation is explicit.
+- It validates the missing #10 release-funds UI path for a **Fund** project, not just the existing **Invest** path.
+- The regression this test protects is subtle: below-threshold Fund investments must stay auto-approved, but they still need release metadata so the founder can later release remaining stages back to the investor.
+- Investor claims need fee funds in the investor wallet, so the test proactively refreshes and faucet-funds the wallet before each release transaction.
+
+## Run
+
+```bash
+dotnet test "src/design/App.Test.Integration/App.Test.Integration.csproj" --filter "FullyQualifiedName~MultiFundReleaseUnfundedAndClaimTest"
+```
+
+Verbose:
+
+```bash
+dotnet test "src/design/App.Test.Integration/App.Test.Integration.csproj" --filter "FullyQualifiedName~MultiFundReleaseUnfundedAndClaimTest" --logger "console;verbosity=detailed"
+```

--- a/src/design/App.Test.Integration/MultiInvestClaimAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/MultiInvestClaimAndRecoverTest.cs
@@ -19,6 +19,7 @@ using App.UI.Sections.MyProjects;
 using App.UI.Sections.MyProjects.Deploy;
 using App.UI.Sections.Portfolio;
 using App.UI.Sections.Settings;
+using App.UI.Shared.Controls;
 using App.UI.Shell;
 using Microsoft.Extensions.DependencyInjection;
 using System.Globalization;
@@ -672,6 +673,75 @@ public class MultiInvestClaimAndRecoverTest
 
         investment.Stages.Any(s => s.Status == "Spent by investor" || s.Status == "Recovered after penalty" || s.Status == "Project Unfunded, Spent back to investor").Should().BeTrue(
             "at least one stage should show a recovered status after release");
+
+        // ── Verify PenaltiesModal shows empty state (no penalty for unfunded release) ──
+        Log(profileName, "Verifying PenaltiesModal shows empty state (no penalties for unfunded release)...");
+        await VerifyPenaltiesModalEmptyAsync(window, portfolioVm, profileName);
+    }
+
+    private async Task VerifyPenaltiesModalEmptyAsync(
+        Window window,
+        PortfolioViewModel portfolioVm,
+        string profileName)
+    {
+        // VM-level: no penalty investments expected after unfunded release
+        portfolioVm.HasPenaltyInvestments.Should().BeFalse(
+            "unfunded release should not produce penalty investments");
+        portfolioVm.PenaltyInvestments.Should().BeEmpty();
+
+        // Navigate to Funded section so PortfolioView (and PenaltiesButton) is in the visual tree
+        window.NavigateToSection("Funded");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        // Click PenaltiesButton to open the modal
+        var penaltiesBtn = window.GetVisualDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(b => b.Name == "PenaltiesButton");
+        penaltiesBtn.Should().NotBeNull("PenaltiesButton should exist in the portfolio view");
+        penaltiesBtn!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, penaltiesBtn));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        // Find the PenaltiesModal in the visual tree
+        var modal = window.GetVisualDescendants()
+            .OfType<PenaltiesModal>()
+            .FirstOrDefault();
+        modal.Should().NotBeNull("PenaltiesModal should be visible after clicking PenaltiesButton");
+        modal!.DataContext.Should().Be(portfolioVm, "PenaltiesModal should have PortfolioViewModel as DataContext");
+
+        // Verify ItemsControl has zero items (empty state)
+        var itemsControl = modal.GetVisualDescendants()
+            .OfType<ItemsControl>()
+            .FirstOrDefault();
+        itemsControl.Should().NotBeNull("PenaltiesModal should contain an ItemsControl");
+        itemsControl!.ItemCount.Should().Be(0,
+            "ItemsControl should have zero rows when there are no penalty investments");
+
+        // Verify empty state message is visible
+        var emptyText = modal.GetVisualDescendants()
+            .OfType<TextBlock>()
+            .FirstOrDefault(tb => tb.Text != null && tb.Text.Contains("No investments currently in penalty"));
+        emptyText.Should().NotBeNull("empty state message should be displayed when no penalties exist");
+
+        Log(profileName, "PenaltiesModal empty state verified: no penalty rows, empty message visible.");
+
+        // Close the modal
+        var closeBtn = modal.GetVisualDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(b => b.Name == "CloseButton");
+        if (closeBtn != null)
+        {
+            closeBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, closeBtn));
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(200);
+            Dispatcher.UIThread.RunJobs();
+        }
+        else
+        {
+            window.HideModal();
+        }
     }
 
     private async Task<bool> ExecuteActionWithRetry(

--- a/src/design/App.Test.Integration/MultiInvestReleaseUnfundedAndClaimTest.cs
+++ b/src/design/App.Test.Integration/MultiInvestReleaseUnfundedAndClaimTest.cs
@@ -1,0 +1,1026 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FluentAssertions;
+using Angor.Sdk.Common;
+using Angor.Sdk.Funding.Investor;
+using Angor.Sdk.Funding.Investor.Operations;
+using Angor.Sdk.Funding.Projects;
+using Angor.Sdk.Funding.Shared;
+using Angor.Shared.Utilities;
+using App.Composition.Adapters;
+using App.Test.Integration.Helpers;
+using App.UI.Sections.FindProjects;
+using App.UI.Sections.Funders;
+using App.UI.Sections.Funds;
+using App.UI.Sections.MyProjects;
+using App.UI.Sections.MyProjects.Deploy;
+using App.UI.Sections.Portfolio;
+using App.UI.Sections.Settings;
+using App.UI.Shell;
+using Microsoft.Extensions.DependencyInjection;
+using System.Globalization;
+
+namespace App.Test.Integration;
+
+public class MultiInvestReleaseUnfundedAndClaimTest
+{
+    private const string TestName = "MultiInvestReleaseUnfundedAndClaim";
+    private const string FounderProfile = TestName + "-Founder";
+    private const string Investor1Profile = TestName + "-Investor1";
+    private const string Investor2Profile = TestName + "-Investor2";
+
+    private static readonly TimeSpan FaucetBalanceTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan TransactionTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan UiTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan IndexerLagTimeout = TimeSpan.FromMinutes(5);
+
+    private sealed record ProjectHandle(string RunId, string ProjectName, string ProjectIdentifier, string FounderWalletId);
+
+    [AvaloniaFact]
+    public async Task MultiInvestReleaseUnfundedAndClaim()
+    {
+        var initializedProfiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var runId = Guid.NewGuid().ToString("N")[..12];
+        var projectName = $"Multi Invest Release {runId}";
+        var projectAbout =
+            $"{TestName} run {runId}. Founder claims stage 1, releases remaining stages, and both investors claim them.";
+        var bannerImageUrl = $"https://picsum.photos/seed/{Guid.NewGuid().ToString("N")[..8]}/320/200";
+        var profileImageUrl = $"https://picsum.photos/seed/{Guid.NewGuid().ToString("N")[..8]}/100/100";
+        var thresholdAmountBtc = "0.01";
+        var investor1AmountBtc = "0.02";
+        var investor2AmountBtc = "0.03";
+
+        Log(null, $"========== STARTING {nameof(MultiInvestReleaseUnfundedAndClaim)} ==========");
+        Log(null, $"Run ID: {runId}");
+        Log(null, $"Founder profile: {FounderProfile}");
+        Log(null, $"Investor1 profile: {Investor1Profile}");
+        Log(null, $"Investor2 profile: {Investor2Profile}");
+
+        ProjectHandle? project = null;
+
+        await WithProfileWindow(FounderProfile, initializedProfiles, async window =>
+        {
+            await CreateWalletAndFundAsync(window, FounderProfile);
+            project = await CreateInvestProjectAsync(
+                window,
+                FounderProfile,
+                projectName,
+                projectAbout,
+                bannerImageUrl,
+                profileImageUrl,
+                thresholdAmountBtc,
+                runId);
+        });
+
+        project.Should().NotBeNull();
+
+        await WithProfileWindow(Investor1Profile, initializedProfiles, async window =>
+        {
+            await CreateWalletAndFundAsync(window, Investor1Profile);
+            await InvestInProjectAsync(
+                window,
+                Investor1Profile,
+                project!,
+                investor1AmountBtc,
+                expectFounderApproval: true);
+        });
+
+        await WithProfileWindow(Investor2Profile, initializedProfiles, async window =>
+        {
+            await CreateWalletAndFundAsync(window, Investor2Profile);
+            await InvestInProjectAsync(
+                window,
+                Investor2Profile,
+                project!,
+                investor2AmountBtc,
+                expectFounderApproval: true);
+        });
+
+        await WithProfileWindow(FounderProfile, initializedProfiles, async window =>
+        {
+            await ApprovePendingInvestmentsAsync(window, FounderProfile, project!, expectedPendingCount: 2);
+        });
+
+        await WithProfileWindow(Investor1Profile, initializedProfiles, async window =>
+        {
+            await ConfirmApprovedInvestmentAsync(window, Investor1Profile, project!);
+        });
+
+        await WithProfileWindow(Investor2Profile, initializedProfiles, async window =>
+        {
+            await ConfirmApprovedInvestmentAsync(window, Investor2Profile, project!);
+        });
+
+        await WithProfileWindow(FounderProfile, initializedProfiles, async window =>
+        {
+            await ClaimStageOneAsync(window, FounderProfile, project!);
+            await ReleaseRemainingStagesToInvestorsAsync(window, FounderProfile, project!);
+        });
+
+        await WithProfileWindow(Investor1Profile, initializedProfiles, async window =>
+        {
+            await ClaimRemainingStagesAsync(window, Investor1Profile, project!);
+        });
+
+        await WithProfileWindow(Investor2Profile, initializedProfiles, async window =>
+        {
+            await ClaimRemainingStagesAsync(window, Investor2Profile, project!);
+        });
+
+        Log(null, $"========== {nameof(MultiInvestReleaseUnfundedAndClaim)} PASSED ==========");
+    }
+
+    private async Task WithProfileWindow(
+        string profileName,
+        HashSet<string> initializedProfiles,
+        Func<Window, Task> action)
+    {
+        using var profileScope = TestProfileScope.For(profileName);
+        var window = TestHelpers.CreateShellWindow();
+
+        try
+        {
+            ValidateCurrentProfile(profileName);
+
+            if (!initializedProfiles.Contains(profileName))
+            {
+                Log(profileName, "First use for profile. Wiping existing data...");
+                await WipeExistingData(window, profileName);
+                initializedProfiles.Add(profileName);
+            }
+
+            SetPasswordProvider(profileName);
+            await action(window);
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(250);
+        }
+    }
+
+    private static void ValidateCurrentProfile(string expectedProfile)
+    {
+        var profileContext = global::App.App.Services.GetRequiredService<ProfileContext>();
+        var storage = global::App.App.Services.GetRequiredService<IApplicationStorage>();
+        var profileDirectory = storage.GetProfileDirectory(profileContext.AppName, profileContext.ProfileName);
+
+        profileContext.ProfileName.Should().Be(expectedProfile);
+        Log(expectedProfile, $"Using profile directory: {profileDirectory}");
+    }
+
+    private static void SetPasswordProvider(string profileName)
+    {
+        var passwordProvider = global::App.App.Services.GetRequiredService<SimplePasswordProvider>();
+        passwordProvider.SetKey("default-key");
+        Log(profileName, "Set SimplePasswordProvider key to 'default-key'.");
+    }
+
+    private async Task CreateWalletAndFundAsync(Window window, string profileName)
+    {
+        window.NavigateToSection("Funds");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        if (!fundsVm!.SeedGroups.Any() || !fundsVm.SeedGroups.SelectMany(g => g.Wallets).Any())
+        {
+            Log(profileName, "Creating wallet via Generate flow...");
+            await CreateWalletViaGenerate(window, profileName);
+        }
+        else
+        {
+            Log(profileName, "Wallet already exists for this profile.");
+        }
+
+        var walletCardBtn = await window.WaitForWalletCard(TimeSpan.FromSeconds(30));
+        walletCardBtn.Should().NotBeNull();
+
+        Log(profileName, "Funding wallet via faucet...");
+        await FundWalletViaFaucet(window, profileName);
+    }
+
+    private async Task<ProjectHandle> CreateInvestProjectAsync(
+        Window window,
+        string profileName,
+        string projectName,
+        string projectAbout,
+        string bannerImageUrl,
+        string profileImageUrl,
+        string thresholdAmountBtc,
+        string runId)
+    {
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var myProjectsVm = GetMyProjectsViewModel(window);
+        myProjectsVm.Should().NotBeNull();
+
+        await OpenCreateWizard(window, myProjectsVm!, profileName);
+
+        var wizardVm = myProjectsVm.CreateProjectVm;
+        wizardVm.Should().NotBeNull();
+
+        Log(profileName, "Selecting Invest project type...");
+        wizardVm.DismissWelcome();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        wizardVm.SelectProjectType("investment");
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, $"Setting project metadata: {projectName}");
+        wizardVm.ProjectName = projectName;
+        wizardVm.ProjectAbout = projectAbout;
+        wizardVm.ProjectName.Should().Be(projectName);
+        wizardVm.ProjectAbout.Should().Be(projectAbout);
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Setting project images...");
+        wizardVm.BannerUrl = bannerImageUrl;
+        wizardVm.ProfileUrl = profileImageUrl;
+        wizardVm.BannerUrl.Should().Be(bannerImageUrl);
+        wizardVm.ProfileUrl.Should().Be(profileImageUrl);
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Configuring target amount, threshold, and investment end date...");
+        wizardVm.TargetAmount = "1.0";
+        wizardVm.ApprovalThreshold = thresholdAmountBtc;
+        wizardVm.InvestEndDate = DateTime.UtcNow.AddMonths(3);
+        wizardVm.TargetAmount.Should().Be("1.0");
+        wizardVm.ApprovalThreshold.Should().Be(thresholdAmountBtc);
+        wizardVm.InvestEndDate.Should().NotBeNull();
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Generating three monthly investment stages...");
+        wizardVm.DismissStep5Welcome();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        wizardVm.DurationValue = "3";
+        wizardVm.DurationUnit = "Months";
+        wizardVm.ReleaseFrequency = "Monthly";
+        wizardVm.StartDate = DateTime.UtcNow.AddDays(-120).ToString("yyyy-MM-dd");
+        wizardVm.GenerateInvestmentStages();
+        wizardVm.Stages.Count.Should().Be(3);
+        wizardVm.Stages.Select(s => s.StageNumber).Should().ContainInOrder(1, 2, 3);
+        wizardVm.GoNext();
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Deploying project...");
+        wizardVm.Deploy();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(1000);
+        Dispatcher.UIThread.RunJobs();
+
+        var deployVm = wizardVm.DeployFlow;
+        var walletLoadDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTime.UtcNow < walletLoadDeadline && deployVm.Wallets.Count == 0)
+        {
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        deployVm.Wallets.Count.Should().BeGreaterThan(0);
+        deployVm.SelectWallet(deployVm.Wallets[0]);
+        Dispatcher.UIThread.RunJobs();
+        deployVm.PayWithWallet();
+
+        var deployDeadline = DateTime.UtcNow + TransactionTimeout;
+        while (DateTime.UtcNow < deployDeadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (deployVm.CurrentScreen == DeployScreen.Success)
+            {
+                break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        deployVm.CurrentScreen.Should().Be(DeployScreen.Success,
+            $"Deploy should reach success. Last status: {deployVm.DeployStatusText}");
+
+        deployVm.GoToMyProjects();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        await myProjectsVm.LoadFounderProjectsAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var project = myProjectsVm.Projects.FirstOrDefault(p => p.Description.Contains(runId, StringComparison.Ordinal));
+        project.Should().NotBeNull();
+        project!.ProjectIdentifier.Should().NotBeNullOrEmpty();
+        project.OwnerWalletId.Should().NotBeNullOrEmpty();
+        project.Name.Should().Be(projectName);
+        project.Description.Should().Contain(runId);
+        project.ProjectType.Should().Be("investment");
+
+        Log(profileName, $"Project deployed. ProjectId={project.ProjectIdentifier}, OwnerWalletId={project.OwnerWalletId}");
+        return new ProjectHandle(runId, projectName, project.ProjectIdentifier!, project.OwnerWalletId!);
+    }
+
+    private async Task InvestInProjectAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project,
+        string amountBtc,
+        bool expectFounderApproval)
+    {
+        var foundProject = await FindProjectFromSdkAsync(window, profileName, project);
+
+        var findProjectsVm = GetFindProjectsViewModel(window);
+        findProjectsVm.Should().NotBeNull();
+
+        findProjectsVm!.OpenProjectDetail(foundProject);
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(300);
+
+        findProjectsVm.OpenInvestPage();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var investVm = findProjectsVm.InvestPageViewModel;
+        investVm.Should().NotBeNull();
+
+        var walletLoadDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTime.UtcNow < walletLoadDeadline && investVm!.Wallets.Count == 0)
+        {
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        investVm!.Wallets.Count.Should().BeGreaterThan(0);
+        investVm.InvestmentAmount = amountBtc;
+        investVm.CanSubmit.Should().BeTrue();
+        investVm.Stages.Count.Should().Be(3,
+            "investment project should expose the generated fixed stages to investors");
+        investVm.Stages.Select(s => s.LabelText).Should().Contain(label => label.Contains("Stage 1"));
+        investVm.Submit();
+        Dispatcher.UIThread.RunJobs();
+        investVm.CurrentScreen.Should().Be(InvestScreen.WalletSelector);
+
+        var investWallet = investVm.Wallets[0];
+        investVm.SelectWallet(investWallet);
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, $"Investing {amountBtc} BTC with wallet {investWallet.Id.Value}...");
+        investVm.PayWithWallet();
+
+        var investDeadline = DateTime.UtcNow + TransactionTimeout;
+        while (DateTime.UtcNow < investDeadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (investVm.CurrentScreen == InvestScreen.Success)
+            {
+                break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        investVm.CurrentScreen.Should().Be(InvestScreen.Success,
+            $"Invest should reach success. Last status: {investVm.PaymentStatusText}");
+        investVm.FormattedAmount.Should().Be(decimal.Parse(amountBtc, CultureInfo.InvariantCulture).ToString("F8", CultureInfo.InvariantCulture));
+
+        Log(profileName, $"[Invest] IsAutoApproved={investVm.IsAutoApproved}, SuccessTitle='{investVm.SuccessTitle}'");
+        if (expectFounderApproval)
+        {
+            investVm.IsAutoApproved.Should().BeFalse(
+                "above-threshold investment should NOT be auto-approved");
+            investVm.SuccessTitle.Should().Contain("Pending Approval",
+                "above-threshold investment should show 'Pending Approval' in SuccessTitle");
+        }
+        else
+        {
+            investVm.IsAutoApproved.Should().BeTrue(
+                "below-threshold investment should be auto-approved");
+            investVm.SuccessTitle.Should().Contain("Successful",
+                "below-threshold auto-approved investment should show 'Successful' in SuccessTitle");
+        }
+
+        var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
+        investVm.AddToPortfolio();
+        Dispatcher.UIThread.RunJobs();
+
+        var addedInvestment = portfolioVm.Investments.FirstOrDefault(i => i.ProjectIdentifier == project.ProjectIdentifier);
+        addedInvestment.Should().NotBeNull();
+        addedInvestment!.ProjectName.Should().Be(project.ProjectName);
+        var actualInvested = decimal.Parse(addedInvestment.TotalInvested, CultureInfo.InvariantCulture);
+        var expectedInvested = decimal.Parse(amountBtc, CultureInfo.InvariantCulture);
+        actualInvested.Should().BeGreaterThan(0, "TotalInvested should be non-zero after AddToPortfolio");
+        actualInvested.Should().BeLessThanOrEqualTo(expectedInvested, "TotalInvested should not exceed requested amount");
+        (expectedInvested - actualInvested).Should().BeLessThan(0.001m,
+            "TotalInvested should be within fee tolerance of requested amount");
+        Log(profileName, $"Investment completed. Founder approval expected: {expectFounderApproval}");
+    }
+
+    private async Task ApprovePendingInvestmentsAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project,
+        int expectedPendingCount)
+    {
+        window.NavigateToSection("Funders");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var fundersVm = GetFundersViewModel(window);
+        fundersVm.Should().NotBeNull();
+
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        List<SignatureRequestViewModel>? pendingSignatures = null;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            await fundersVm!.LoadInvestmentRequestsAsync();
+            Dispatcher.UIThread.RunJobs();
+            fundersVm.SetFilter("waiting");
+            Dispatcher.UIThread.RunJobs();
+
+            Log(profileName, $"Funders waiting count: {fundersVm.WaitingCount}, approved count: {fundersVm.ApprovedCount}");
+
+            pendingSignatures = fundersVm.FilteredSignatures
+                .Where(s => string.Equals(s.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal))
+                .OrderBy(s => s.AmountSats)
+                .ToList();
+            if (pendingSignatures.Count == expectedPendingCount)
+            {
+                break;
+            }
+
+            Log(profileName, "Waiting for pending founder approval requests...");
+            await Task.Delay(PollInterval);
+        }
+
+        pendingSignatures.Should().NotBeNull();
+        pendingSignatures!.Count.Should().Be(expectedPendingCount,
+            "both above-threshold investments should require founder approval");
+
+        foreach (var pendingSignature in pendingSignatures)
+        {
+            Log(profileName, $"Approving signature request id={pendingSignature.Id} for project {project.ProjectIdentifier}");
+            await window.ClickApproveSignatureAsync(fundersVm!, pendingSignature, UiTimeout);
+        }
+
+        var approvalDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < approvalDeadline)
+        {
+            await fundersVm.LoadInvestmentRequestsAsync();
+            Dispatcher.UIThread.RunJobs();
+            fundersVm.SetFilter("approved");
+            Dispatcher.UIThread.RunJobs();
+
+            var approvedCount = fundersVm.FilteredSignatures.Count(s =>
+                string.Equals(s.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
+            if (approvedCount >= expectedPendingCount)
+            {
+                Log(profileName, $"Founder approved {approvedCount} investment requests.");
+                return;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Founder approvals did not complete in time.");
+    }
+
+    private async Task ConfirmApprovedInvestmentAsync(Window window, string profileName, ProjectHandle project)
+    {
+        var portfolioVm = await WaitForPortfolioInvestmentAsync(window, profileName, project, investment => investment.Step >= 2);
+        var investment = portfolioVm.Investments.First(i => i.ProjectIdentifier == project.ProjectIdentifier);
+
+        Log(profileName, $"Confirming approved investment. Step={investment.Step}, Status={investment.StatusText}");
+        investment.ApprovalStatus.Should().Be("Approved");
+        await window.ClickInvestmentDetailActionAsync(portfolioVm, investment, "ConfirmInvestmentButton", UiTimeout);
+
+        var activeDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < activeDeadline)
+        {
+            await portfolioVm.LoadInvestmentsFromSdkAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var refreshed = portfolioVm.Investments.FirstOrDefault(i => i.ProjectIdentifier == project.ProjectIdentifier);
+            if (refreshed?.Step == 3)
+            {
+                Log(profileName, "Investor confirmation completed and investment is active.");
+                return;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Confirmed investment did not become active in time.");
+    }
+
+    private async Task ClaimStageOneAsync(Window window, string profileName, ProjectHandle project)
+    {
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var myProjectsVm = GetMyProjectsViewModel(window);
+        myProjectsVm.Should().NotBeNull();
+
+        await myProjectsVm!.LoadFounderProjectsAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var founderProject = myProjectsVm.Projects.FirstOrDefault(p =>
+            string.Equals(p.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
+        founderProject.Should().NotBeNull();
+
+        var manageVm = myProjectsVm.SelectedManageProject;
+
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await myProjectsVm.LoadFounderProjectsAsync();
+            myProjectsVm.OpenManageProject(founderProject!);
+            manageVm = myProjectsVm.SelectedManageProject;
+            await manageVm!.LoadClaimableTransactionsAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var stageSnapshot = string.Join(", ", manageVm.Stages.Select(s =>
+                $"#{s.Number}:available={s.Available},canClaim={s.CanClaim},availableTxs={s.AvailableTransactions.Count},spent={s.SpentTransactionCount},date='{s.CompletionDate}'"));
+            Log(profileName, $"Stage snapshot: {stageSnapshot}");
+
+            var stage1 = manageVm.Stages.FirstOrDefault(s => s.Number == 1 && s.AvailableTransactions.Count >= 2);
+            if (stage1 != null)
+            {
+                stage1.AvailableTransactions.Count.Should().Be(2,
+                    "founder should claim stage 1 from both investor UTXOs");
+
+                await window.ClickManageProjectClaimStageAsync(myProjectsVm, founderProject!, stage1.Number, UiTimeout);
+                Log(profileName, "Founder claimed stage 1 using both available UTXOs.");
+                break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        var spentDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < spentDeadline)
+        {
+            await manageVm!.LoadClaimableTransactionsAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            if (manageVm.Stages.Any(s => s.Number == 1 && s.SpentTransactionCount > 0))
+            {
+                Log(profileName, "Founder spend is visible in stage status.");
+                return;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Founder stage 1 spend was not indexed in time.");
+    }
+
+    private async Task ReleaseRemainingStagesToInvestorsAsync(Window window, string profileName, ProjectHandle project)
+    {
+        window.NavigateToSection("My Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var myProjectsVm = GetMyProjectsViewModel(window);
+        myProjectsVm.Should().NotBeNull();
+
+        await myProjectsVm!.LoadFounderProjectsAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var founderProject = myProjectsVm.Projects.FirstOrDefault(p =>
+            string.Equals(p.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
+        founderProject.Should().NotBeNull();
+
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await myProjectsVm.LoadFounderProjectsAsync();
+            myProjectsVm.OpenManageProject(founderProject!);
+            var manageVm = myProjectsVm.SelectedManageProject;
+            manageVm.Should().NotBeNull();
+
+            var releaseSucceeded = await window.ClickManageProjectReleaseFundsAsync(myProjectsVm, founderProject!, UiTimeout);
+            if (releaseSucceeded)
+            {
+                Log(profileName, "Founder released remaining stages to investors.");
+                return;
+            }
+
+            Log(profileName, "Remaining stage release not ready yet. Retrying...");
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Founder release signatures were not created in time.");
+    }
+
+    private async Task ClaimRemainingStagesAsync(Window window, string profileName, ProjectHandle project, string expectedActionKey = "unfundedRelease")
+    {
+        var portfolioVm = await WaitForPortfolioInvestmentAsync(window, profileName, project, investment => investment.Step == 3);
+        var investment = portfolioVm.Investments.First(i => i.ProjectIdentifier == project.ProjectIdentifier);
+        investment.InvestmentWalletId.Should().NotBeNullOrEmpty();
+        investment.InvestmentTransactionId.Should().NotBeNullOrEmpty();
+
+        var releaseState = await WaitForRecoveryActionAsync(portfolioVm, investment, profileName, expectedActionKey: expectedActionKey);
+        releaseState.ActionKey.Should().Be(expectedActionKey);
+
+        Log(profileName, $"Claiming remaining stages via '{expectedActionKey}' path...");
+        await EnsureWalletHasFeeFunds(window, profileName, investment.InvestmentWalletId, $"before {expectedActionKey}");
+
+        var releaseResult = await ExecuteActionWithRetry(
+            profileName,
+            expectedActionKey,
+            () => portfolioVm.ReleaseFundsAsync(investment).ContinueWith(t => t.Result.Success),
+            () => LogUnfundedReleaseBuildDiagnostics(investment));
+        releaseResult.Should().BeTrue();
+
+        Log(profileName, "Verifying stage statuses after unfunded release...");
+        var statusDeadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < statusDeadline)
+        {
+            await portfolioVm.LoadRecoveryStatusAsync(investment);
+            Dispatcher.UIThread.RunJobs();
+
+            var recoveredStages = investment.Stages
+                .Where(s => s.Status == "Spent by investor" ||
+                            s.Status == "Recovered after penalty" ||
+                            s.Status == "Project Unfunded, Spent back to investor")
+                .ToList();
+
+            if (recoveredStages.Count > 0)
+            {
+                Log(profileName,
+                    $"Found {recoveredStages.Count} stage(s) with recovered status: {string.Join(", ", recoveredStages.Select(s => $"stage {s.StageNumber}='{s.Status}'"))}");
+                foreach (var stage in recoveredStages)
+                {
+                    stage.IsStatusRecovered.Should().BeTrue(
+                        $"stage {stage.StageNumber} with status '{stage.Status}' should be recognized as recovered");
+                }
+                break;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        investment.Stages.Any(s => s.Status == "Spent by investor" ||
+                                   s.Status == "Recovered after penalty" ||
+                                   s.Status == "Project Unfunded, Spent back to investor")
+            .Should().BeTrue("at least one stage should show a recovered status after release");
+    }
+
+    private async Task<bool> ExecuteActionWithRetry(
+        string profileName,
+        string actionLabel,
+        Func<Task<bool>> execute,
+        Func<Task> logDiagnostics)
+    {
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        var attempt = 0;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            attempt++;
+            Log(profileName, $"Attempt #{attempt} for action '{actionLabel}'...");
+            var result = await execute();
+            if (result)
+            {
+                Log(profileName, $"Action '{actionLabel}' succeeded on attempt #{attempt}.");
+                return true;
+            }
+
+            await logDiagnostics();
+            await Task.Delay(PollInterval);
+        }
+
+        return false;
+    }
+
+    private static async Task LogUnfundedReleaseBuildDiagnostics(InvestmentViewModel investment)
+    {
+        var investmentAppService = global::App.App.Services.GetRequiredService<IInvestmentAppService>();
+        var walletId = new WalletId(investment.InvestmentWalletId);
+        var projectId = new ProjectId(investment.ProjectIdentifier);
+        var feeRate = new DomainFeerate(20);
+
+        var buildResult = await investmentAppService.BuildUnfundedReleaseTransaction(
+            new BuildUnfundedReleaseTransaction.BuildUnfundedReleaseTransactionRequest(walletId, projectId, feeRate));
+
+        Log(investment.ProjectIdentifier, buildResult.IsSuccess
+            ? $"Diagnostic BuildUnfundedReleaseTransaction succeeded. TxId={buildResult.Value.TransactionDraft.TransactionId}"
+            : $"Diagnostic BuildUnfundedReleaseTransaction failed: {buildResult.Error}");
+    }
+
+    private async Task<RecoveryState> WaitForRecoveryActionAsync(
+        PortfolioViewModel portfolioVm,
+        InvestmentViewModel investment,
+        string profileName,
+        string expectedActionKey)
+    {
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await portfolioVm.LoadRecoveryStatusAsync(investment);
+            Dispatcher.UIThread.RunJobs();
+
+            Log(profileName,
+                $"Recovery state: HasUnspent={investment.RecoveryState.HasUnspentItems}, InPenalty={investment.RecoveryState.HasSpendableItemsInPenalty}, HasReleaseSig={investment.RecoveryState.HasReleaseSignatures}, EndOfProject={investment.RecoveryState.EndOfProject}, AboveThreshold={investment.RecoveryState.IsAboveThreshold}, ActionKey={investment.RecoveryState.ActionKey}");
+
+            if (investment.RecoveryState.ActionKey == expectedActionKey)
+            {
+                return investment.RecoveryState;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException($"Recovery action '{expectedActionKey}' did not appear in time.");
+    }
+
+    private async Task<PortfolioViewModel> WaitForPortfolioInvestmentAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project,
+        Func<InvestmentViewModel, bool> predicate)
+    {
+        window.NavigateToSection("Funded");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            await portfolioVm.LoadInvestmentsFromSdkAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var investment = portfolioVm.Investments.FirstOrDefault(i =>
+                string.Equals(i.ProjectIdentifier, project.ProjectIdentifier, StringComparison.Ordinal));
+
+            if (investment != null)
+            {
+                Log(profileName, $"Portfolio investment found. Step={investment.Step}, Status={investment.StatusText}, Approval={investment.ApprovalStatus}, WalletId={investment.InvestmentWalletId}, InvestmentTxId={investment.InvestmentTransactionId}");
+                if (predicate(investment))
+                {
+                    return portfolioVm;
+                }
+            }
+            else
+            {
+                Log(profileName, "Portfolio investment not found yet.");
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Portfolio investment did not reach the expected state in time.");
+    }
+
+    private async Task EnsureWalletHasFeeFunds(Window window, string profileName, string walletId, string context)
+    {
+        window.NavigateToSection("Funds");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            var refresh = await global::App.App.Services.GetRequiredService<Angor.Sdk.Wallet.Application.IWalletAppService>()
+                .RefreshAndGetAccountBalanceInfo(new WalletId(walletId));
+
+            if (refresh.IsSuccess)
+            {
+                var info = refresh.Value;
+                var available = info.TotalBalance + info.TotalUnconfirmedBalance + info.TotalBalanceReserved;
+                Log(profileName, $"Wallet balance {context}: {available.ToUnitBtc():F8} BTC available for fees");
+                if (available > 20_000)
+                {
+                    return;
+                }
+            }
+
+            Log(profileName, $"Wallet needs fee funds {context}. Requesting faucet coins...");
+            var (success, error) = await fundsVm!.GetTestCoinsAsync(walletId);
+            Log(profileName, success ? "Fee-funding faucet request accepted." : $"Fee-funding faucet request failed: {error}");
+
+            await ClickWalletCardButton(window, "WalletCardBtnRefresh");
+            await Task.Delay(PollInterval);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        throw new InvalidOperationException($"Wallet '{walletId}' did not receive enough fee funds {context}.");
+    }
+
+    private async Task<ProjectItemViewModel> FindProjectFromSdkAsync(Window window, string profileName, ProjectHandle project)
+    {
+        window.NavigateToSection("Find Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var findProjectsVm = GetFindProjectsViewModel(window);
+        findProjectsVm.Should().NotBeNull();
+
+        var deadline = DateTime.UtcNow + IndexerLagTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await findProjectsVm!.LoadProjectsFromSdkAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            var foundProject = findProjectsVm.Projects.FirstOrDefault(p =>
+                string.Equals(p.ProjectId, project.ProjectIdentifier, StringComparison.Ordinal) ||
+                p.Description.Contains(project.RunId, StringComparison.Ordinal) ||
+                p.ShortDescription.Contains(project.RunId, StringComparison.Ordinal));
+
+            if (foundProject != null)
+            {
+                Log(profileName, $"Found project in SDK list: {foundProject.ProjectId}");
+                return foundProject;
+            }
+
+            Log(profileName, "Project not found in SDK yet. Retrying...");
+            await Task.Delay(PollInterval);
+        }
+
+        throw new InvalidOperationException("Project was not found in the SDK project list in time.");
+    }
+
+    private async Task WipeExistingData(Window window, string profileName)
+    {
+        window.NavigateToSettings();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+
+        var settingsView = window.GetVisualDescendants().OfType<SettingsView>().FirstOrDefault();
+        if (settingsView?.DataContext is SettingsViewModel settingsVm)
+        {
+            settingsVm.ConfirmWipeData();
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+            Log(profileName, "Profile data wiped.");
+        }
+    }
+
+    private async Task CreateWalletViaGenerate(Window window, string profileName)
+    {
+        var addWalletBtn = FindAddWalletButton(window);
+        addWalletBtn.Should().NotBeNull();
+
+        addWalletBtn!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, addWalletBtn));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(300);
+        Dispatcher.UIThread.RunJobs();
+
+        await window.ClickButton("BtnGenerate", UiTimeout);
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+        await window.ClickButton("BtnDownloadSeed", UiTimeout);
+        await Task.Delay(300);
+        Dispatcher.UIThread.RunJobs();
+        await window.ClickButton("BtnContinueBackup", UiTimeout);
+
+        var successPanel = await window.WaitForControl<StackPanel>("CreateWalletSuccessPanel", TimeSpan.FromSeconds(30));
+        successPanel.Should().NotBeNull();
+        await window.ClickButton("BtnCreateWalletDone", UiTimeout);
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        Log(profileName, "Wallet created successfully.");
+    }
+
+    private async Task FundWalletViaFaucet(Window window, string profileName)
+    {
+        var fundsVm = GetFundsViewModel(window);
+        fundsVm.Should().NotBeNull();
+
+        var walletId = fundsVm!.SeedGroups.FirstOrDefault()?.Wallets?.FirstOrDefault()?.Id.Value;
+        walletId.Should().NotBeNullOrEmpty();
+
+        var deadline = DateTime.UtcNow + FaucetBalanceTimeout;
+        var faucetRetryInterval = TimeSpan.FromSeconds(30);
+        var lastFaucetAttempt = DateTime.MinValue;
+        var faucetAttempts = 0;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            Dispatcher.UIThread.RunJobs();
+
+            if (fundsVm.TotalBalance != "0.0000")
+            {
+                Log(profileName, $"Non-zero balance detected: {fundsVm.TotalBalance}");
+                return;
+            }
+
+            if (DateTime.UtcNow - lastFaucetAttempt >= faucetRetryInterval)
+            {
+                faucetAttempts++;
+                lastFaucetAttempt = DateTime.UtcNow;
+                Log(profileName, $"Faucet attempt #{faucetAttempts}...");
+
+                (bool success, string? error) = await fundsVm.GetTestCoinsAsync(walletId!);
+                Dispatcher.UIThread.RunJobs();
+                Log(profileName, success ? "Faucet request accepted." : $"Faucet request failed: {error}");
+            }
+
+            await ClickWalletCardButton(window, "WalletCardBtnRefresh");
+            await Task.Delay(PollInterval);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        throw new InvalidOperationException("Wallet balance did not become non-zero in time.");
+    }
+
+    private async Task OpenCreateWizard(Window window, MyProjectsViewModel myProjectsVm, string profileName)
+    {
+        myProjectsVm.CreateProjectVm.ResetWizard();
+        myProjectsVm.LaunchCreateWizard();
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        myProjectsVm.ShowCreateWizard.Should().BeTrue();
+        myProjectsVm.CreateProjectVm.OnProjectDeployed = () =>
+        {
+            myProjectsVm.OnProjectDeployed(myProjectsVm.CreateProjectVm);
+            myProjectsVm.CloseCreateWizard();
+        };
+
+        Log(profileName, "Create wizard opened.");
+    }
+
+    private static Button? FindAddWalletButton(Window window)
+    {
+        var buttons = window.GetVisualDescendants().OfType<Button>().Where(b => b.IsVisible);
+        foreach (var btn in buttons)
+        {
+            if (btn.Content is string text && text.Contains("Add Wallet", StringComparison.Ordinal))
+            {
+                return btn;
+            }
+
+            if (btn.Content is StackPanel panel)
+            {
+                foreach (var child in panel.Children.OfType<TextBlock>())
+                {
+                    if (child.Text == "Add Wallet")
+                    {
+                        return btn;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private async Task ClickWalletCardButton(Window window, string automationId)
+    {
+        var button = await window.WaitForControl<Button>(automationId, UiTimeout);
+        button.Should().NotBeNull();
+        button!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, button));
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static FundsViewModel? GetFundsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FundsView>().FirstOrDefault()?.DataContext as FundsViewModel;
+    }
+
+    private static MyProjectsViewModel? GetMyProjectsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<MyProjectsView>().FirstOrDefault()?.DataContext as MyProjectsViewModel;
+    }
+
+    private static FindProjectsViewModel? GetFindProjectsViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FindProjectsView>().FirstOrDefault()?.DataContext as FindProjectsViewModel;
+    }
+
+    private static FundersViewModel? GetFundersViewModel(Window window)
+    {
+        return window.GetVisualDescendants().OfType<FundersView>().FirstOrDefault()?.DataContext as FundersViewModel;
+    }
+
+    private static void Log(string? profileName, string message)
+    {
+        var prefix = string.IsNullOrWhiteSpace(profileName) ? "GLOBAL" : profileName;
+        Console.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] [{prefix}] {message}");
+    }
+}

--- a/src/design/App.Test.Integration/MultiInvestReleaseUnfundedAndClaimTest.md
+++ b/src/design/App.Test.Integration/MultiInvestReleaseUnfundedAndClaimTest.md
@@ -1,0 +1,52 @@
+# MultiInvestReleaseUnfundedAndClaimTest
+
+## Purpose
+
+Full end-to-end integration test for an **Invest** project with three isolated app profiles: one founder and two investors. It verifies multi-investor investing, pending founder approval, founder approval of both investment requests, investor confirmation, founder stage-1 claim across both investor UTXOs, founder release signatures for the remaining stages, and investor claims of the remaining stages without penalty.
+
+## Profiles
+
+- Founder profile: `MultiInvestReleaseUnfundedAndClaim-Founder`
+- Investor1 profile: `MultiInvestReleaseUnfundedAndClaim-Investor1`
+- Investor2 profile: `MultiInvestReleaseUnfundedAndClaim-Investor2`
+
+All profiles are created under:
+
+- `C:\Users\dan\AppData\Local\Angor\Profiles\`
+
+## Scenario
+
+1. Founder profile creates a wallet, funds it, and deploys an **Invest** project.
+2. The project uses:
+   - target amount `1.0 BTC`
+   - investment end date `now + 3 months`
+   - 3 generated monthly stages
+3. Investor 1 invests `0.02 BTC`.
+4. Investor 2 invests `0.03 BTC`.
+5. Each investor portfolio entry is verified to be pending founder approval after submit.
+6. Founder opens **Funders**, verifies both investment requests are present, and approves both of them.
+7. Each investor returns to **Funded** and confirms the approved investment so it becomes active.
+8. Founder claims stage 1 and spends both stage-1 UTXOs together.
+9. Founder releases the remaining stages back to investors by sending release signatures.
+10. Investor 1 claims the remaining stages with the unfunded-release path.
+11. Investor 2 claims the remaining stages with the unfunded-release path.
+
+## Notes
+
+- The test reuses the real headless Avalonia app and switches profiles by rebuilding DI per profile.
+- It logs the active profile directory before each phase so profile isolation is explicit.
+- It asserts the deployed project type, the generated 3-stage investment schedule, the amount stored in each investor portfolio entry, and the pending -> approved -> active approval lifecycle.
+- Investor claims need fee funds in the investor wallet, so the test proactively refreshes and faucet-funds the wallet before each release transaction.
+- The investor-side claim waits specifically for the recovery action key `unfundedRelease`, which confirms the founder release signatures are visible before claiming.
+
+## Run
+
+```bash
+dotnet test "src/design/App.Test.Integration/App.Test.Integration.csproj" --filter "FullyQualifiedName~MultiInvestReleaseUnfundedAndClaimTest"
+```
+
+Verbose:
+
+```bash
+dotnet test "src/design/App.Test.Integration/App.Test.Integration.csproj" --filter "FullyQualifiedName~MultiInvestReleaseUnfundedAndClaimTest" --logger "console;verbosity=detailed"
+```

--- a/src/design/App/UI/Sections/FindProjects/FindProjectsViewModel.cs
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsViewModel.cs
@@ -6,6 +6,7 @@ using Angor.Sdk.Funding.Projects;
 using Angor.Sdk.Funding.Projects.Dtos;
 using Angor.Sdk.Funding.Projects.Operations;
 using Angor.Sdk.Funding.Shared;
+using Angor.Shared.Models;
 using Avalonia.Media.Imaging;
 using App.UI.Sections.Portfolio;
 using App.UI.Shared;
@@ -103,6 +104,12 @@ public class ProjectItemViewModel : INotifyPropertyChanged
 
     public ObservableCollection<InvestmentStageViewModel> Stages { get; set; } = new();
 
+    /// <summary>
+    /// Dynamic stage patterns from the project (Fund/Subscribe types).
+    /// Investors select which pattern to use when funding.
+    /// </summary>
+    public List<DynamicStagePattern> DynamicStagePatterns { get; set; } = new();
+
     private Shared.ProjectType TypeEnum => ProjectTypeExtensions.FromDisplayString(ProjectType);
     public string OpportunityTitle => ProjectTypeTerminology.OpportunityTitle(TypeEnum);
     public string ActionButtonText => ProjectTypeTerminology.ActionButtonText(TypeEnum);
@@ -196,6 +203,7 @@ public class ProjectItemViewModel : INotifyPropertyChanged
             PenaltyDays = dto.PenaltyDuration.Days.ToString(),
             PenaltyThresholdSats = dto.PenaltyThreshold,
             Stages = stages,
+            DynamicStagePatterns = dto.DynamicStagePatterns ?? new List<DynamicStagePattern>(),
             BannerUrl = dto.Banner?.ToString(),
             AvatarUrl = dto.Avatar?.ToString()
         };

--- a/src/design/App/UI/Sections/FindProjects/InvestPageView.axaml
+++ b/src/design/App/UI/Sections/FindProjects/InvestPageView.axaml
@@ -256,6 +256,26 @@
                     </StackPanel>
                 </StackPanel>
 
+                <!-- Penalty threshold indicator -->
+                <Panel IsVisible="{Binding HasPenaltyThreshold}" VerticalAlignment="Center">
+                    <!-- Above threshold: requires founder approval -->
+                    <Border IsVisible="{Binding IsAbovePenaltyThreshold}"
+                            Padding="8,4" CornerRadius="4"
+                            Background="#30FF8C00">
+                        <TextBlock Text="Requires Approval"
+                                   FontSize="13" FontWeight="SemiBold"
+                                   Foreground="#FF8C00" />
+                    </Border>
+                    <!-- Below threshold: direct publish -->
+                    <Border IsVisible="{Binding !IsAbovePenaltyThreshold}"
+                            Padding="8,4" CornerRadius="4"
+                            Background="#302D5A3D">
+                        <TextBlock Text="No Approval Needed"
+                                   FontSize="13" FontWeight="SemiBold"
+                                   Foreground="#2D5A3D" />
+                    </Border>
+                </Panel>
+
                 <!-- Submit button -->
                 <Border Name="SubmitButton"
                         CornerRadius="8" Padding="32,14"
@@ -310,11 +330,13 @@
                     <!-- ════════════════════════════════════════════ -->
                     <!-- COLUMN 1: Investment Amount Card (invest)    -->
                     <!--           OR Subscription Plan Card (sub)    -->
+                    <!--           + Funding Pattern selector (fund)  -->
                     <!-- ════════════════════════════════════════════ -->
+                    <StackPanel Grid.Column="0" Spacing="24">
 
                     <!-- ── INVESTMENT AMOUNT (shown for invest/fund) ── -->
                     <!-- Vue: linear-gradient(to bottom right, #fff7ed, #fef3c7), border #fed7aa -->
-                    <Border Grid.Column="0"
+                    <Border
                             CornerRadius="16" Padding="24"
                             BorderThickness="1"
                             Background="{DynamicResource StatsDetailCardBackground}"
@@ -399,11 +421,86 @@
                         </StackPanel>
                     </Border>
 
+                    <!-- ── FUNDING PATTERN SELECTOR (shown for fund type with patterns) ── -->
+                    <Border CornerRadius="16" Padding="24"
+                            BorderThickness="1"
+                            Background="{DynamicResource StatsDetailCardBackground}"
+                            BorderBrush="{DynamicResource StatsDetailCardBorder}"
+                            IsVisible="{Binding ShowFundingPatternSelector}">
+                        <StackPanel Spacing="20">
+                            <!-- Header -->
+                            <StackPanel Orientation="Horizontal" Spacing="12">
+                                <Border Width="40" Height="40" CornerRadius="8"
+                                        Background="#F97316">
+                                    <i:Icon Value="fa-solid fa-calendar-days" FontSize="18"
+                                            Foreground="White"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                </Border>
+                                <TextBlock Text="Funding Pattern"
+                                           FontSize="18" FontWeight="Bold"
+                                           Foreground="{DynamicResource StatsDetailLabel}"
+                                           VerticalAlignment="Center" />
+                            </StackPanel>
+
+                            <TextBlock Text="Select which instalment schedule to use:"
+                                       FontSize="13"
+                                       Foreground="{DynamicResource TextMuted}" />
+
+                            <!-- Pattern options -->
+                            <ItemsControl ItemsSource="{Binding FundingPatterns}" Margin="0,4,0,0">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Spacing="12" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="fp:FundingPatternOption">
+                                        <Border Name="FundPatternBorder"
+                                                Classes="SubPlanBtn"
+                                                CornerRadius="12" Padding="16"
+                                                Cursor="Hand"
+                                                BorderThickness="2">
+                                            <StackPanel Spacing="4">
+                                                <Panel>
+                                                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Left"
+                                                                VerticalAlignment="Center">
+                                                        <TextBlock Text="{Binding Name}"
+                                                                   FontSize="16" FontWeight="Bold"
+                                                                   Foreground="{DynamicResource SubPlanLabel}" />
+                                                        <Border CornerRadius="10" Padding="8,2"
+                                                                Background="{DynamicResource AccentBrush}">
+                                                            <TextBlock FontSize="12" FontWeight="SemiBold"
+                                                                       Foreground="White">
+                                                                <TextBlock.Text>
+                                                                    <MultiBinding StringFormat="{}{0} stages">
+                                                                        <Binding Path="StageCount" />
+                                                                    </MultiBinding>
+                                                                </TextBlock.Text>
+                                                            </TextBlock>
+                                                        </Border>
+                                                    </StackPanel>
+                                                    <TextBlock Text="{Binding FrequencyText}"
+                                                               FontSize="14" FontWeight="SemiBold"
+                                                               Foreground="{DynamicResource SubPlanPrice}"
+                                                               HorizontalAlignment="Right"
+                                                               VerticalAlignment="Center" />
+                                                </Panel>
+                                                <TextBlock Text="{Binding Description}"
+                                                           FontSize="13"
+                                                           Foreground="{DynamicResource SubPlanDescription}"
+                                                           TextWrapping="Wrap" />
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+
                     <!-- ── SUBSCRIPTION PLAN (shown for subscription type) ── -->
                     <!-- Vue: .subscription-card { background: linear-gradient(to bottom right, #fff7ed, #fef3c7) } -->
                     <!-- Same warm gradient as investment card but with subscription-specific content -->
-                    <Border Grid.Column="0"
-                            CornerRadius="16" Padding="24"
+                    <Border CornerRadius="16" Padding="24"
                             BorderThickness="1"
                             Background="{DynamicResource StatsDetailCardBackground}"
                             BorderBrush="{DynamicResource StatsDetailCardBorder}"
@@ -471,6 +568,8 @@
                             </ItemsControl>
                         </StackPanel>
                     </Border>
+
+                    </StackPanel> <!-- end Column 0 StackPanel -->
 
                     <!-- ════════════════════════════════════════════ -->
                     <!-- COLUMN 2: Release Schedule / Payment Schedule -->

--- a/src/design/App/UI/Sections/FindProjects/InvestPageView.axaml.cs
+++ b/src/design/App/UI/Sections/FindProjects/InvestPageView.axaml.cs
@@ -19,6 +19,7 @@ public partial class InvestPageView : UserControl
     private IDisposable? _layoutSubscription;
     private Border? _selectedQuickAmountBorder;
     private Border? _selectedSubPlanBorder;
+    private Border? _selectedFundPatternBorder;
 
     // Cached controls for responsive layout
     private DockPanel? _navBar;
@@ -245,6 +246,23 @@ public partial class InvestPageView : UserControl
                     }
                 }, Avalonia.Threading.DispatcherPriority.Loaded);
             }
+
+            // If fund type with patterns, apply initial pattern selection styling after layout.
+            if (vm.ShowFundingPatternSelector)
+            {
+                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                {
+                    foreach (var border in this.GetVisualDescendants().OfType<Border>())
+                    {
+                        if (border.Name == "FundPatternBorder" &&
+                            border.DataContext is FundingPatternOption { IsSelected: true })
+                        {
+                            UpdateFundPatternSelection(border);
+                            break;
+                        }
+                    }
+                }, Avalonia.Threading.DispatcherPriority.Loaded);
+            }
         }
     }
 
@@ -319,6 +337,7 @@ public partial class InvestPageView : UserControl
                 var name = b.Name;
                 if (name == "QuickAmountBorder" || name == "SubmitButton" ||
                     name == "CopyProjectIdButton" || name == "SubPlanBorder" ||
+                    name == "FundPatternBorder" ||
                     name == "MobileSubmitButton")
                 {
                     found = b;
@@ -365,6 +384,15 @@ public partial class InvestPageView : UserControl
                 }
                 break;
 
+            case "FundPatternBorder":
+                if (found.DataContext is FundingPatternOption fundPattern)
+                {
+                    Vm?.SelectFundingPattern(fundPattern);
+                    UpdateFundPatternSelection(found);
+                    e.Handled = true;
+                }
+                break;
+
             case "CopyProjectIdButton":
                 ClipboardHelper.CopyToClipboard(this, Vm?.ProjectId);
                 e.Handled = true;
@@ -402,5 +430,13 @@ public partial class InvestPageView : UserControl
         // Select new
         newSelected.Classes.Set("SubPlanSelected", true);
         _selectedSubPlanBorder = newSelected;
+    }
+
+    /// <summary>Update funding pattern borders via CSS class toggling.</summary>
+    private void UpdateFundPatternSelection(Border newSelected)
+    {
+        _selectedFundPatternBorder?.Classes.Set("SubPlanSelected", false);
+        newSelected.Classes.Set("SubPlanSelected", true);
+        _selectedFundPatternBorder = newSelected;
     }
 }

--- a/src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs
+++ b/src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs
@@ -7,7 +7,9 @@ using Angor.Sdk.Funding.Shared;
 using Angor.Sdk.Wallet.Application;
 using Angor.Sdk.Wallet.Domain;
 using App.UI.Sections.Portfolio;
+using Angor.Shared.Models;
 using App.UI.Shared;
+using ProjectType = App.UI.Shared.ProjectType;
 using App.UI.Shared.Services;
 using Microsoft.Extensions.Logging;
 using MonitorOp = Angor.Sdk.Funding.Investor.Operations.MonitorAddressForFunds;
@@ -66,6 +68,23 @@ public class SubscriptionPlanOption : ReactiveObject
     public long TotalSats { get; set; }
     public string PriceText { get; set; } = "";
     public string Description { get; set; } = "";
+
+    private bool _isSelected;
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => this.RaiseAndSetIfChanged(ref _isSelected, value);
+    }
+}
+
+/// <summary>Funding pattern option for Fund-type projects (e.g. "3-Month Monthly", "6-Month Monthly").</summary>
+public class FundingPatternOption : ReactiveObject
+{
+    public byte PatternId { get; set; }
+    public string Name { get; set; } = "";
+    public string Description { get; set; } = "";
+    public int StageCount { get; set; }
+    public string FrequencyText { get; set; } = "";
 
     private bool _isSelected;
     public bool IsSelected
@@ -142,6 +161,9 @@ public partial class InvestPageViewModel : ReactiveObject
     // ── Subscription State ──
     [Reactive] private string? selectedSubscriptionPattern;
 
+    // ── Fund Pattern State ──
+    [Reactive] private FundingPatternOption? selectedFundingPattern;
+
     // ── Derived visibility ──
     public bool IsInvestForm => CurrentScreen == InvestScreen.InvestForm;
     public bool IsWalletSelector => CurrentScreen == InvestScreen.WalletSelector;
@@ -197,6 +219,11 @@ public partial class InvestPageViewModel : ReactiveObject
     // Vue ref: subscription-patterns — 2 plan buttons
     public ObservableCollection<SubscriptionPlanOption> SubscriptionPlans { get; } = new();
 
+    // ── Funding Patterns (fund type only) ──
+    public ObservableCollection<FundingPatternOption> FundingPatterns { get; } = new();
+    public bool ShowFundingPatternSelector => Project.ProjectType == "Fund" && FundingPatterns.Count > 0;
+    public bool IsFund => Project.ProjectType == "Fund";
+
     // ── Release Schedule / Payment Schedule ──
     public ObservableCollection<InvestStageRow> Stages { get; } = new();
 
@@ -219,6 +246,24 @@ public partial class InvestPageViewModel : ReactiveObject
     public bool CanSubmit => IsSubscription
         ? SelectedSubscriptionPattern != null && ParseAmount() > 0
         : ParseAmount() >= Constants.MinInvestmentAmount;
+
+    // ── Penalty threshold indicator ──
+    /// <summary>Whether the project has a penalty threshold configured.</summary>
+    public bool HasPenaltyThreshold => Project.PenaltyThresholdSats.HasValue
+                                       || TypeEnum is ProjectType.Fund or ProjectType.Subscription;
+
+    /// <summary>Whether the current investment amount exceeds the penalty threshold (requires founder approval).</summary>
+    public bool IsAbovePenaltyThreshold
+    {
+        get
+        {
+            if (!Project.PenaltyThresholdSats.HasValue) return true; // no threshold = always requires approval
+            var amountSats = (long)((decimal)ParseAmount() * 100_000_000m);
+            return amountSats > Project.PenaltyThresholdSats.Value;
+        }
+    }
+
+    public string ThresholdStatusText => IsAbovePenaltyThreshold ? "Requires Approval" : "No Approval Needed";
 
     // Vue ref: footer-summary stages/payments count
     private ProjectType TypeEnum => ProjectTypeExtensions.FromDisplayString(Project.ProjectType);
@@ -391,6 +436,8 @@ public partial class InvestPageViewModel : ReactiveObject
                 this.RaisePropertyChanged(nameof(SuccessDescription));
                 this.RaisePropertyChanged(nameof(StagesSummary));
                 this.RaisePropertyChanged(nameof(TransactionAmountValue));
+                this.RaisePropertyChanged(nameof(IsAbovePenaltyThreshold));
+                this.RaisePropertyChanged(nameof(ThresholdStatusText));
                 RecomputeStages();
             });
 
@@ -408,6 +455,20 @@ public partial class InvestPageViewModel : ReactiveObject
             // Auto-select pattern1
             SelectSubscriptionPlan("pattern1");
         }
+
+        // Initialize funding patterns if fund type
+        if (IsFund)
+        {
+            InitializeFundingPatterns();
+        }
+
+        // Recompute when funding pattern changes
+        this.WhenAnyValue(x => x.SelectedFundingPattern)
+            .Subscribe(_ =>
+            {
+                this.RaisePropertyChanged(nameof(StagesSummary));
+                RecomputeStages();
+            });
 
         // Initialize stages from project
         RecomputeStages();
@@ -463,6 +524,129 @@ public partial class InvestPageViewModel : ReactiveObject
         this.RaisePropertyChanged(nameof(SubscriptionPlans));
     }
 
+    // ── Fund Pattern helpers ──
+
+    private void InitializeFundingPatterns()
+    {
+        foreach (var pattern in Project.DynamicStagePatterns)
+        {
+            FundingPatterns.Add(new FundingPatternOption
+            {
+                PatternId = pattern.PatternId,
+                Name = pattern.Name ?? $"Pattern {pattern.PatternId}",
+                Description = pattern.DisplayDescription,
+                StageCount = pattern.StageCount,
+                FrequencyText = pattern.Frequency.ToString()
+            });
+        }
+
+        if (FundingPatterns.Count > 0)
+        {
+            SelectFundingPattern(FundingPatterns[0]);
+        }
+
+        this.RaisePropertyChanged(nameof(ShowFundingPatternSelector));
+    }
+
+    /// <summary>Select a funding pattern for Fund-type projects.</summary>
+    public void SelectFundingPattern(FundingPatternOption option)
+    {
+        SelectedFundingPattern = option;
+        foreach (var p in FundingPatterns)
+            p.IsSelected = p.PatternId == option.PatternId;
+
+        this.RaisePropertyChanged(nameof(FundingPatterns));
+    }
+
+    /// <summary>
+    /// Generate synthetic stages from a DynamicStagePattern (Fund-type projects).
+    /// Mirrors the Avalonia reference: GenerateStagesFromPattern in InvestViewModel.cs.
+    /// </summary>
+    private List<InvestStageRow> GenerateStagesFromFundingPattern(DynamicStagePattern pattern, double amount)
+    {
+        var stageCount = pattern.StageCount;
+        if (stageCount <= 0)
+            return new List<InvestStageRow>();
+
+        var ratioPerStage = 1.0 / stageCount;
+        var now = DateTimeOffset.UtcNow;
+        var rows = new List<InvestStageRow>(stageCount);
+
+        for (var i = 0; i < stageCount; i++)
+        {
+            var releaseDate = ComputePatternReleaseDate(now, pattern, i + 1);
+            var stageAmount = amount * ratioPerStage;
+            var pctStr = $"{ratioPerStage * 100:F0}%";
+            rows.Add(new InvestStageRow
+            {
+                StageNumber = i + 1,
+                ReleaseDate = releaseDate.ToString("dd MMM yyyy"),
+                Percentage = pctStr,
+                Amount = $"{stageAmount:F8}",
+                LabelText = $"Stage {i + 1}",
+                AmountDisplayText = $"{stageAmount:F8} {_currencyService.Symbol}",
+                IsSubscriptionRow = false
+            });
+        }
+
+        return rows;
+    }
+
+    private static DateTimeOffset ComputePatternReleaseDate(DateTimeOffset startDate, DynamicStagePattern pattern, int stageNumber)
+    {
+        return pattern.PayoutDayType switch
+        {
+            PayoutDayType.FromStartDate => AddFrequencyIntervals(startDate, pattern.Frequency, stageNumber),
+            PayoutDayType.SpecificDayOfMonth => ComputeSpecificDayOfMonth(startDate, pattern, stageNumber),
+            PayoutDayType.SpecificDayOfWeek => ComputeSpecificDayOfWeek(startDate, pattern, stageNumber),
+            _ => AddFrequencyIntervals(startDate, pattern.Frequency, stageNumber)
+        };
+    }
+
+    private static DateTimeOffset AddFrequencyIntervals(DateTimeOffset startDate, StageFrequency frequency, int intervals)
+    {
+        return frequency switch
+        {
+            StageFrequency.Weekly => startDate.AddDays(7 * intervals),
+            StageFrequency.Biweekly => startDate.AddDays(14 * intervals),
+            StageFrequency.Monthly => startDate.AddMonths(intervals),
+            StageFrequency.BiMonthly => startDate.AddMonths(2 * intervals),
+            StageFrequency.Quarterly => startDate.AddMonths(3 * intervals),
+            _ => startDate.AddMonths(intervals)
+        };
+    }
+
+    private static DateTimeOffset ComputeSpecificDayOfMonth(DateTimeOffset startDate, DynamicStagePattern pattern, int stageNumber)
+    {
+        var monthsToAdd = pattern.Frequency switch
+        {
+            StageFrequency.Monthly => stageNumber,
+            StageFrequency.BiMonthly => 2 * stageNumber,
+            StageFrequency.Quarterly => 3 * stageNumber,
+            _ => stageNumber
+        };
+
+        var target = startDate.AddMonths(monthsToAdd);
+        var day = Math.Min(pattern.PayoutDay, DateTime.DaysInMonth(target.Year, target.Month));
+        return new DateTimeOffset(target.Year, target.Month, day, 0, 0, 0, target.Offset);
+    }
+
+    private static DateTimeOffset ComputeSpecificDayOfWeek(DateTimeOffset startDate, DynamicStagePattern pattern, int stageNumber)
+    {
+        var weeksToAdd = pattern.Frequency switch
+        {
+            StageFrequency.Weekly => stageNumber,
+            StageFrequency.Biweekly => 2 * stageNumber,
+            _ => stageNumber
+        };
+
+        var target = startDate.AddDays(7 * weeksToAdd);
+        var currentDay = (int)target.DayOfWeek;
+        var targetDay = pattern.PayoutDay;
+        var diff = targetDay - currentDay;
+        return target.AddDays(diff);
+    }
+
     private double ParseAmount()
     {
         if (double.TryParse(InvestmentAmount, System.Globalization.NumberStyles.Float,
@@ -515,6 +699,19 @@ public partial class InvestPageViewModel : ReactiveObject
         var amount = ParseAmount();
         var prefix = StageRowPrefix;
         var newInvestRows = new List<InvestStageRow>();
+
+        // Fund type with a selected dynamic pattern: generate synthetic stages
+        if (IsFund && SelectedFundingPattern != null)
+        {
+            var pattern = Project.DynamicStagePatterns
+                .FirstOrDefault(p => p.PatternId == SelectedFundingPattern.PatternId);
+            if (pattern != null)
+            {
+                newInvestRows = GenerateStagesFromFundingPattern(pattern, amount);
+                UpdateStagesInPlace(newInvestRows);
+                return;
+            }
+        }
 
         if (Project.Stages.Count > 0)
         {
@@ -680,9 +877,13 @@ public partial class InvestPageViewModel : ReactiveObject
 
             // Determine pattern index for Fund/Subscription projects
             byte? patternIndex = null;
-            if (IsSubscription || Project.ProjectType == "Fund")
+            if (IsSubscription)
             {
                 patternIndex = SelectedSubscriptionPattern == "pattern2" ? (byte)1 : (byte)0;
+            }
+            else if (IsFund && SelectedFundingPattern != null)
+            {
+                patternIndex = SelectedFundingPattern.PatternId;
             }
 
             // Build investment draft
@@ -1181,9 +1382,13 @@ public partial class InvestPageViewModel : ReactiveObject
 
         // Fund/Subscription projects require a pattern index (same logic as PayWithWalletAsync).
         byte? patternIndex = null;
-        if (IsSubscription || Project.ProjectType == "Fund")
+        if (IsSubscription)
         {
             patternIndex = SelectedSubscriptionPattern == "pattern2" ? (byte)1 : (byte)0;
+        }
+        else if (IsFund && SelectedFundingPattern != null)
+        {
+            patternIndex = SelectedFundingPattern.PatternId;
         }
 
         PaymentStatusText = "Building investment transaction...";

--- a/src/design/App/UI/Sections/Funds/CreateWalletModal.axaml.cs
+++ b/src/design/App/UI/Sections/Funds/CreateWalletModal.axaml.cs
@@ -161,14 +161,10 @@ public partial class CreateWalletModal : UserControl, IBackdropCloseable
         var btn = this.FindControl<Button>("BtnContinueBackup");
         if (btn != null) btn.IsEnabled = !isProcessing;
 
-        var spinner = this.FindControl<Projektanker.Icons.Avalonia.Icon>("ContinueSpinner");
-        if (spinner != null)
-        {
-            spinner.IsVisible = isProcessing;
-            spinner.Classes.Set("Spinning", isProcessing);
-        }
+        var spinner = this.FindControl<StackPanel>("ContinueBtnSpinner");
+        if (spinner != null) spinner.IsVisible = isProcessing;
 
-        var text = this.FindControl<TextBlock>("ContinueText");
+        var text = this.FindControl<TextBlock>("ContinueBtnContent");
         if (text != null) text.Text = isProcessing ? "Creating Wallet..." : "Continue";
     }
 

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectView.axaml.cs
@@ -359,6 +359,11 @@ public partial class CreateProjectView : UserControl
             case "GeneratePayoutsButton": Vm?.GeneratePayoutSchedule(); break;
             case "DeleteStagesButton": Vm?.ClearStages(); break;
             case "ToggleEditorButton": Vm?.ToggleAdvancedEditor(); break;
+            case "AddStageButton": Vm?.AddStage(); break;
+            case "RemoveStageButton":
+                if (btn.Tag is ProjectStageViewModel stageToRemove)
+                    Vm?.RemoveStage(stageToRemove);
+                break;
             case "RegenerateStagesButton": Vm?.ShowRegenerateForm(); break;
             case "RegeneratePayoutsButton": Vm?.ShowRegenerateForm(); break;
             // Stepper step buttons

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
@@ -44,6 +44,7 @@ public class ProjectStageViewModel
     /// Fund/Sub: "33% paid on 28th April 2026"
     /// </summary>
     public string DisplayText { get; set; } = "";
+    public double PercentageValue { get; set; }
 }
 
 /// <summary>
@@ -284,6 +285,25 @@ public partial class CreateProjectViewModel : ReactiveObject
     public bool IsFund => ProjectType == "fund";
     public bool IsSubscription => ProjectType == "subscription";
     public bool IsTypeSelected => !string.IsNullOrEmpty(ProjectType);
+
+    // ── Review summary helpers (Step 6) ──
+    /// <summary>Formatted installment options for review, e.g. "3, 6, 9 installments".</summary>
+    public string InstallmentOptionsText =>
+        SelectedInstallmentCounts.Count > 0
+            ? string.Join(", ", SelectedInstallmentCounts.OrderBy(x => x)) + " installments"
+            : "";
+
+    public bool HasInstallmentOptions => SelectedInstallmentCounts.Count > 0;
+
+    /// <summary>Formatted payout day for review, e.g. "Day 15" or "Wednesday".</summary>
+    public string PayoutDayText =>
+        PayoutFrequency == "Monthly" && MonthlyPayoutDate.HasValue
+            ? $"Day {MonthlyPayoutDate.Value}"
+            : PayoutFrequency == "Weekly" && !string.IsNullOrEmpty(WeeklyPayoutDay)
+                ? WeeklyPayoutDay
+                : "";
+
+    public bool HasPayoutDay => !string.IsNullOrEmpty(PayoutDayText);
 
     // ── Validation error visibility helpers (for XAML binding) ──
     public bool HasFormError => !string.IsNullOrEmpty(FormError);
@@ -899,6 +919,40 @@ public partial class CreateProjectViewModel : ReactiveObject
     }
 
     /// <summary>Toggle between simple and advanced editor (Investment).</summary>
+    public bool IsNotAdvancedEditor => !IsAdvancedEditor;
+    public string AdvancedEditorButtonText => IsAdvancedEditor ? "Simple Editor" : "Advanced Editor";
+
+    /// <summary>Add a new stage to the advanced editor with default values.</summary>
+    public void AddStage()
+    {
+        var nextNum = Stages.Count + 1;
+        var stage = new ProjectStageViewModel
+        {
+            StageNumber = nextNum,
+            Percentage = "0%",
+            PercentageValue = 0,
+            ReleaseDate = "",
+            ReleaseDateValue = DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(nextNum)),
+            StageLabel = IsInvestment ? "Stage" : "Payout",
+            DisplayText = ""
+        };
+        stage.ReleaseDate = stage.ReleaseDateValue.ToString("dd MMMM yyyy");
+        Stages.Add(stage);
+        this.RaisePropertyChanged(nameof(HasStages));
+        this.RaisePropertyChanged(nameof(ScheduleSummary));
+    }
+
+    /// <summary>Remove a stage from the advanced editor.</summary>
+    public void RemoveStage(ProjectStageViewModel stage)
+    {
+        Stages.Remove(stage);
+        // Renumber remaining stages
+        for (int i = 0; i < Stages.Count; i++)
+            Stages[i].StageNumber = i + 1;
+        this.RaisePropertyChanged(nameof(HasStages));
+        this.RaisePropertyChanged(nameof(ScheduleSummary));
+    }
+
     public void ToggleAdvancedEditor()
     {
         IsAdvancedEditor = !IsAdvancedEditor;

--- a/src/design/App/UI/Sections/MyProjects/ManageProjectContentView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/ManageProjectContentView.axaml.cs
@@ -187,7 +187,6 @@ public partial class ManageProjectContentView : UserControl
     /// The parent ManageProjectView subscribes to this to open the appropriate modal.
     /// </summary>
     public event System.Action<int, string>? StageButtonClicked;
-
     private void OnStageButtonClick(object? sender, RoutedEventArgs e)
     {
         if (e.Source is not Button btn) return;

--- a/src/design/App/UI/Sections/MyProjects/ManageProjectView.axaml
+++ b/src/design/App/UI/Sections/MyProjects/ManageProjectView.axaml
@@ -52,6 +52,43 @@
             <!-- RIGHT: Private Keys, Refresh, Share (docked first so it hugs the right edge) -->
             <!-- Vue: .nav-right-buttons — gap 12 -->
             <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="12">
+                <!-- Release Funds to Investors button -->
+                <!-- Vue: .release-funds-button-floating — green gradient, h44, hidden after release -->
+                <Border Name="ReleaseFundsNavBorder"
+                        Classes="FloatingBtn"
+                        Background="{DynamicResource FloatingBtnBg}"
+                        BorderBrush="{DynamicResource FloatingBtnBorder}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        BoxShadow="{DynamicResource FloatingBtnShadow}"
+                        Padding="16,0,16,0"
+                        Height="44"
+                        VerticalAlignment="Center"
+                        Cursor="Hand"
+                        IsVisible="{Binding !FundsReleasedToInvestors}"
+                        RenderTransform="translate(0px, 0px)">
+                    <Border.Transitions>
+                        <Transitions>
+                            <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.2" />
+                            <BoxShadowsTransition Property="BoxShadow" Duration="0:0:0.2" />
+                        </Transitions>
+                    </Border.Transitions>
+                    <Button Name="ReleaseFundsNavButton"
+                            Classes="NavBtn"
+                            AutomationProperties.AutomationId="ReleaseFundsNavButton"
+                            VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Cursor="Hand">
+                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                            <i:Icon Value="fa-solid fa-hand-holding-dollar"
+                                   FontSize="16"
+                                   Foreground="#4B7C5A" />
+                            <TextBlock Text="Release Funds"
+                                       FontSize="14" FontWeight="Medium"
+                                       Foreground="#4B7C5A"
+                                       VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                </Border>
+
                 <!-- View Private Keys button -->
                 <!-- Vue: .private-keys-button-floating — color #ea580c, h44 -->
                 <Border Classes="FloatingBtn"

--- a/src/design/App/UI/Sections/MyProjects/ManageProjectView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/ManageProjectView.axaml.cs
@@ -47,6 +47,7 @@ public partial class ManageProjectView : UserControl
                 else if (mode == "Spent")
                     modalsView.OpenSpentModal(stageIndex);
             };
+
         }
 
         // ── Share button ──
@@ -56,6 +57,10 @@ public partial class ManageProjectView : UserControl
         // ── Refresh button ──
         var refreshBtn = this.FindControl<Button>("RefreshButton");
         if (refreshBtn != null) refreshBtn.Click += OnRefreshClick;
+
+        // ── Release Funds to Investors button ──
+        var releaseFundsBtn = this.FindControl<Button>("ReleaseFundsNavButton");
+        if (releaseFundsBtn != null) releaseFundsBtn.Click += (_, _) => OpenReleaseFundsModal();
 
         // ── View Private Keys button (opens shell modal password step) ──
         var viewPKBtn = this.FindControl<Button>("ViewPrivateKeysButton");

--- a/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep5View.axaml
+++ b/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep5View.axaml
@@ -255,7 +255,7 @@
                         BorderBrush="{DynamicResource Stroke}" BorderThickness="1"
                         Padding="16,14" CornerRadius="12"
                         FontSize="14" Foreground="{DynamicResource TextMuted}"
-                        Content="Advanced Editor" />
+                        Content="{Binding AdvancedEditorButtonText}" />
             </StackPanel>
         </Panel>
 
@@ -511,7 +511,7 @@
             </StackPanel>
         </Panel>
 
-        <!-- Generated Stages/Payouts Card (shared by all types) — AngorApp pattern -->
+        <!-- Generated Stages/Payouts Card (shared by all types, read-only mode) — AngorApp pattern -->
         <Border CornerRadius="12" BorderBrush="{DynamicResource Accent}" BorderThickness="1"
                 Background="{DynamicResource BrandWash}" ClipToBounds="True"
                 IsVisible="{Binding HasStages}">

--- a/src/design/App/UI/Sections/Portfolio/PortfolioView.axaml.cs
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioView.axaml.cs
@@ -177,6 +177,7 @@ public partial class PortfolioView : UserControl
     private void OnPenaltiesClick(object? sender, RoutedEventArgs e)
     {
         var shellVm = this.FindAncestorOfType<ShellView>()?.DataContext as ShellViewModel;
-        shellVm?.ShowModal(new PenaltiesModal());
+        var vm = DataContext as PortfolioViewModel;
+        shellVm?.ShowModal(new PenaltiesModal(vm!));
     }
 }

--- a/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
@@ -485,6 +485,13 @@ public partial class PortfolioViewModel : ReactiveObject
     // ── Right panel investments ──
     public ObservableCollection<InvestmentViewModel> Investments { get; } = new();
 
+    /// <summary>Investments currently in penalty (for PenaltiesModal).</summary>
+    public IEnumerable<InvestmentViewModel> PenaltyInvestments =>
+        Investments.Where(i => i.RecoveryState.HasSpendableItemsInPenalty);
+
+    /// <summary>Whether there are any penalty investments (for XAML empty-state binding).</summary>
+    public bool HasPenaltyInvestments => PenaltyInvestments.Any();
+
     /// <summary>Currency symbol from ICurrencyService (e.g. "BTC", "TBTC").</summary>
     public string CurrencySymbol => _currencyService.Symbol;
 
@@ -637,6 +644,19 @@ public partial class PortfolioViewModel : ReactiveObject
                         CurrencySymbol = _currencyService.Symbol
                     };
 
+                    // Carry over recovery state from previous load so that PenaltyInvestments
+                    // is not lost when WalletsUpdated triggers a reload (see #19).
+                    if (existingInvestment != null)
+                    {
+                        vm.RecoveryState = existingInvestment.RecoveryState;
+                        vm.PenaltyDuration = existingInvestment.PenaltyDuration;
+                        vm.PenaltyDaysRemaining = existingInvestment.PenaltyDaysRemaining;
+                        foreach (var stage in existingInvestment.Stages)
+                        {
+                            vm.Stages.Add(stage);
+                        }
+                    }
+
                     Investments.Add(vm);
                 }
             }
@@ -673,6 +693,8 @@ public partial class PortfolioViewModel : ReactiveObject
             this.RaisePropertyChanged(nameof(TotalInvested));
             this.RaisePropertyChanged(nameof(RecoveredToPenalty));
             this.RaisePropertyChanged(nameof(ProjectsInRecovery));
+            this.RaisePropertyChanged(nameof(PenaltyInvestments));
+            this.RaisePropertyChanged(nameof(HasPenaltyInvestments));
             this.RaisePropertyChanged(nameof(TotalAvailable));
         }
         catch (Exception ex)
@@ -812,6 +834,9 @@ public partial class PortfolioViewModel : ReactiveObject
                 investment.ProjectIdentifier, recovery.HasUnspentItems, recovery.HasSpendableItemsInPenalty,
                 recovery.HasReleaseSignatures, recovery.EndOfProject, recovery.IsAboveThreshold,
                 investment.RecoveryState.ActionKey);
+
+            this.RaisePropertyChanged(nameof(PenaltyInvestments));
+            this.RaisePropertyChanged(nameof(HasPenaltyInvestments));
         }
         catch (Exception ex)
         {
@@ -1159,6 +1184,8 @@ public partial class PortfolioViewModel : ReactiveObject
         this.RaisePropertyChanged(nameof(TotalInvested));
         this.RaisePropertyChanged(nameof(RecoveredToPenalty));
         this.RaisePropertyChanged(nameof(ProjectsInRecovery));
+        this.RaisePropertyChanged(nameof(PenaltyInvestments));
+        this.RaisePropertyChanged(nameof(HasPenaltyInvestments));
         this.RaisePropertyChanged(nameof(TotalAvailable));
     }
 

--- a/src/design/App/UI/Sections/Portfolio/RecoveryModalsView.axaml.cs
+++ b/src/design/App/UI/Sections/Portfolio/RecoveryModalsView.axaml.cs
@@ -147,7 +147,7 @@ public partial class RecoveryModalsView : UserControl, IBackdropCloseable
             var (success, error) = Vm.RecoveryActionKey switch
             {
                 "recovery" => await portfolioVm.RecoverFundsAsync(Vm, feeRate.Value),
-                "belowThreshold" => await portfolioVm.RecoverFundsAsync(Vm, feeRate.Value),
+                "belowThreshold" => await portfolioVm.ClaimEndOfProjectAsync(Vm, feeRate.Value),
                 "unfundedRelease" => await portfolioVm.ReleaseFundsAsync(Vm, feeRate.Value),
                 "endOfProject" => await portfolioVm.ClaimEndOfProjectAsync(Vm, feeRate.Value),
                 "penaltyRelease" => await portfolioVm.PenaltyReleaseFundsAsync(Vm, feeRate.Value),

--- a/src/design/App/UI/Shared/Controls/PenaltiesModal.axaml
+++ b/src/design/App/UI/Shared/Controls/PenaltiesModal.axaml
@@ -3,14 +3,16 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:i="https://github.com/projektanker/icons.avalonia"
+             xmlns:portfolio="clr-namespace:App.UI.Sections.Portfolio"
              mc:Ignorable="d" d:DesignWidth="750" d:DesignHeight="500"
-             x:Class="App.UI.Shared.Controls.PenaltiesModal">
+             x:Class="App.UI.Shared.Controls.PenaltiesModal"
+             x:DataType="portfolio:PortfolioViewModel">
 
     <!--
-        Penalties Details Modal — Vue InvestmentDetail.vue lines 563-626
+        Penalties Details Modal - Vue InvestmentDetail.vue lines 563-626
         Shell modal pattern: card content only, no backdrop (shell provides blur + backdrop).
         max-w-2xl (~672px), table with PROJECT ID / AMOUNT IN PENALTY / DAYS REMAINING
-        Showing 2 stubbed penalty rows.
+        Bound to real PenaltyInvestments from PortfolioViewModel.
     -->
 
     <Panel>
@@ -23,38 +25,35 @@
                 BoxShadow="0 25 50 0 #40000000"
                 ClipToBounds="True">
             <DockPanel>
-                <!-- ── Header: lock icon + title + close ── -->
+                <!-- Header: lock icon + title + close -->
                 <Border DockPanel.Dock="Top"
                         Padding="24"
                         BorderBrush="{DynamicResource ModalHeaderBorder}"
                         BorderThickness="0,0,0,1">
                     <Grid ColumnDefinitions="Auto,12,*,Auto">
-                        <!-- Vue: w-6 h-6 text-gray-400/600 lock icon -->
                         <i:Icon Grid.Column="0"
                                 Value="fa-solid fa-lock"
                                 FontSize="20"
                                 Foreground="{DynamicResource TextMuted}"
                                 VerticalAlignment="Center" />
-                        <!-- Vue: text-2xl font-bold -->
                         <TextBlock Grid.Column="2"
                                    Text="Penalties Details"
                                    FontSize="22" FontWeight="Bold"
                                    Foreground="{DynamicResource TextStrong}"
                                    VerticalAlignment="Center" />
-                        <!-- Close button — ModalCloseBtn style with explicit 36x36 sizing -->
                         <Button Name="CloseButton" Classes="ModalCloseBtn" Grid.Column="3"
                                 Width="36" Height="36"
                                 VerticalAlignment="Center" />
                     </Grid>
                 </Border>
 
-                <!-- ── Scrollable body with table ── -->
+                <!-- Scrollable body with table -->
                 <ScrollViewer VerticalScrollBarVisibility="Auto"
                               HorizontalScrollBarVisibility="Disabled"
                               MaxHeight="500">
                     <StackPanel Margin="24">
 
-                        <!-- ── Table ── -->
+                        <!-- Table -->
                         <Border BorderBrush="{DynamicResource RecoveryTableHeaderBorder}"
                                 BorderThickness="1"
                                 CornerRadius="8"
@@ -62,7 +61,6 @@
                             <StackPanel>
 
                                 <!-- Table header row -->
-                                <!-- Vue: border-b-2 border-gray-200, py-3 px-4 font-semibold text-sm -->
                                 <Border BorderBrush="{DynamicResource RecoveryTableHeaderBorder}"
                                         BorderThickness="0,0,0,2"
                                         Padding="0">
@@ -88,77 +86,61 @@
                                     </Grid>
                                 </Border>
 
-                                <!-- Row 1 -->
-                                <Border BorderBrush="{DynamicResource RecoveryTableRowBorder}"
-                                        BorderThickness="0,0,0,1"
-                                        Padding="0">
-                                    <Grid ColumnDefinitions="3*,2*,2*">
-                                        <TextBlock Grid.Column="0"
-                                                   Text="angor1q3pthkftzh3ym4emg0ctcxhmz5u5m7lt5tk69je"
-                                                   FontSize="13"
-                                                   FontFamily="Cascadia Mono, Consolas, monospace"
-                                                   Foreground="{DynamicResource PenaltyTableText}"
-                                                   Padding="16,16"
-                                                   VerticalAlignment="Center"
-                                                   TextTrimming="CharacterEllipsis" />
-                                        <TextBlock Grid.Column="1"
-                                                   Text="0.0099 TBTC"
-                                                   FontSize="13" FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource PenaltyAmountText}"
-                                                   Padding="16,16"
-                                                   VerticalAlignment="Center" />
-                                        <!-- Amber pill: Penalty Release in 31 days -->
-                                        <Border Grid.Column="2"
-                                                Padding="16,16"
-                                                VerticalAlignment="Center">
-                                            <Border Background="{DynamicResource PenaltyPillBg}"
-                                                    BorderBrush="{DynamicResource PenaltyPillBorder}"
-                                                    BorderThickness="1"
-                                                    CornerRadius="12"
-                                                    Padding="12,6"
-                                                    HorizontalAlignment="Left">
-                                                <TextBlock Text="Penalty Release in 31 days"
-                                                           FontSize="12" FontWeight="SemiBold"
-                                                           Foreground="{DynamicResource PenaltyPillText}" />
-                                            </Border>
-                                        </Border>
-                                    </Grid>
+                                <!-- Empty state -->
+                                <Border Padding="24"
+                                        IsVisible="{Binding !HasPenaltyInvestments}">
+                                    <TextBlock Text="No investments currently in penalty."
+                                               FontSize="14"
+                                               Foreground="{DynamicResource TextMuted}"
+                                               HorizontalAlignment="Center" />
                                 </Border>
 
-                                <!-- Row 2 -->
-                                <Border Padding="0">
-                                    <Grid ColumnDefinitions="3*,2*,2*">
-                                        <TextBlock Grid.Column="0"
-                                                   Text="angor1qv8fh2d30mz6kfwjrx0acn4hp2qlfd8spyze5kr"
-                                                   FontSize="13"
-                                                   FontFamily="Cascadia Mono, Consolas, monospace"
-                                                   Foreground="{DynamicResource PenaltyTableText}"
-                                                   Padding="16,16"
-                                                   VerticalAlignment="Center"
-                                                   TextTrimming="CharacterEllipsis" />
-                                        <TextBlock Grid.Column="1"
-                                                   Text="0.0045 TBTC"
-                                                   FontSize="13" FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource PenaltyAmountText}"
-                                                   Padding="16,16"
-                                                   VerticalAlignment="Center" />
-                                        <!-- Amber pill: Penalty Release in 14 days -->
-                                        <Border Grid.Column="2"
-                                                Padding="16,16"
-                                                VerticalAlignment="Center">
-                                            <Border Background="{DynamicResource PenaltyPillBg}"
-                                                    BorderBrush="{DynamicResource PenaltyPillBorder}"
-                                                    BorderThickness="1"
-                                                    CornerRadius="12"
-                                                    Padding="12,6"
-                                                    HorizontalAlignment="Left">
-                                                <TextBlock Text="Penalty Release in 14 days"
-                                                           FontSize="12" FontWeight="SemiBold"
-                                                           Foreground="{DynamicResource PenaltyPillText}" />
+                                <!-- Dynamic rows from real data -->
+                                <ItemsControl ItemsSource="{Binding PenaltyInvestments}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="portfolio:InvestmentViewModel">
+                                            <Border BorderBrush="{DynamicResource RecoveryTableRowBorder}"
+                                                    BorderThickness="0,0,0,1"
+                                                    Padding="0">
+                                                <Grid ColumnDefinitions="3*,2*,2*">
+                                                    <TextBlock Grid.Column="0"
+                                                               Text="{Binding ProjectIdentifier}"
+                                                               FontSize="13"
+                                                               FontFamily="Cascadia Mono, Consolas, monospace"
+                                                               Foreground="{DynamicResource PenaltyTableText}"
+                                                               Padding="16,16"
+                                                               VerticalAlignment="Center"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                    <TextBlock Grid.Column="1"
+                                                               FontSize="13" FontWeight="SemiBold"
+                                                               Foreground="{DynamicResource PenaltyAmountText}"
+                                                               Padding="16,16"
+                                                               VerticalAlignment="Center">
+                                                        <Run Text="{Binding PenaltyAmount, Mode=OneWay}" />
+                                                        <Run Text=" TBTC" />
+                                                    </TextBlock>
+                                                    <Border Grid.Column="2"
+                                                            Padding="16,16"
+                                                            VerticalAlignment="Center">
+                                                        <Border Background="{DynamicResource PenaltyPillBg}"
+                                                                BorderBrush="{DynamicResource PenaltyPillBorder}"
+                                                                BorderThickness="1"
+                                                                CornerRadius="12"
+                                                                Padding="12,6"
+                                                                HorizontalAlignment="Left">
+                                                            <TextBlock FontSize="12" FontWeight="SemiBold"
+                                                                       Foreground="{DynamicResource PenaltyPillText}">
+                                                                <Run Text="Penalty Release in " />
+                                                                <Run Text="{Binding PenaltyDaysRemaining, Mode=OneWay}" />
+                                                                <Run Text=" days" />
+                                                            </TextBlock>
+                                                        </Border>
+                                                    </Border>
+                                                </Grid>
                                             </Border>
-                                        </Border>
-                                    </Grid>
-                                </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
 
                             </StackPanel>
                         </Border>

--- a/src/design/App/UI/Shared/Controls/PenaltiesModal.axaml.cs
+++ b/src/design/App/UI/Shared/Controls/PenaltiesModal.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
+using App.UI.Sections.Portfolio;
 using App.UI.Shell;
 
 namespace App.UI.Shared.Controls;
@@ -18,6 +19,11 @@ public partial class PenaltiesModal : UserControl, IBackdropCloseable
 
         var closeBtn = this.FindControl<Button>("CloseButton");
         if (closeBtn != null) closeBtn.Click += OnCloseClick;
+    }
+
+    public PenaltiesModal(PortfolioViewModel vm) : this()
+    {
+        DataContext = vm;
     }
 
     private ShellViewModel? ShellVm =>


### PR DESCRIPTION
## Summary
- Add `MultiFundReleaseUnfundedAndClaimTest`: full end-to-end integration test for **Fund** projects -- 1 founder + 2 investors (below/above threshold), founder stage-1 claim, founder release, above-threshold investor claims via `unfundedRelease`, below-threshold investor claims via `belowThreshold` (BuildEndOfProjectClaim)
- Add `MultiInvestReleaseUnfundedAndClaimTest`: same release flow for **Invest** projects -- 1 founder + 2 above-threshold investors, both claiming via `unfundedRelease`
- Fix critical bug: `belowThreshold` recovery action in `RecoveryModalsView.axaml.cs` was incorrectly routed to `RecoverFundsAsync` (crashes with NullReferenceException on `RequestEventTime.Value`), now correctly routes to `ClaimEndOfProjectAsync` matching the Avalonia reference implementation

## Other changes
- Remove duplicate `ReleaseFundsButton` from `ManageProjectContentView.axaml` (only nav bar button remains)
- Clean up dead `ReleaseFundsClicked` event wiring in `ManageProjectView`/`ManageProjectContentView`
- Simplify `TestHelpers.ClickManageProjectReleaseFundsAsync` to target only `ReleaseFundsNavButton`

## Test results
- `MultiFundReleaseUnfundedAndClaimTest` -- **passed in ~2m 5s**
- `MultiInvestReleaseUnfundedAndClaimTest` -- **passed in ~2m 27s**
