### PR TITLE
Add verified navigation and UI-level assertions to integration tests

### DIFF
--- a/src/design/App.Test.Integration/CreateProjectTest.cs
+++ b/src/design/App.Test.Integration/CreateProjectTest.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
@@ -106,6 +107,9 @@ public class CreateProjectTest
         await Task.Delay(500);
         Dispatcher.UIThread.RunJobs();
 
+        var portfolioPanel1 = await window.WaitForControl<Visual>("PortfolioRootPanel", TestHelpers.UiTimeout);
+        portfolioPanel1.Should().NotBeNull("Funded section root panel should appear after navigation");
+
         var portfolioVmAfterWipe = window.GetPortfolioViewModel();
         portfolioVmAfterWipe.Should().NotBeNull("PortfolioViewModel should be available after navigating to Funded");
         portfolioVmAfterWipe!.HasInvestments.Should().BeFalse("wipe data should clear funded investments without needing refresh");
@@ -121,9 +125,7 @@ public class CreateProjectTest
         // STEP 2: Navigate to Funds → create wallet via Generate path
         // ──────────────────────────────────────────────────────────────
         TestHelpers.Log("[STEP 2] Navigating to Funds section...");
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var emptyState = await window.WaitForControl<Panel>("EmptyStatePanel", TestHelpers.UiTimeout);
         TestHelpers.Log($"[STEP 2] EmptyStatePanel found: {emptyState != null}");
@@ -157,9 +159,7 @@ public class CreateProjectTest
             fundsVm!.TotalBalance + " TBTC",
             "header available balance should match the confirmed Funds total balance");
 
-        window.NavigateToSection("Funded");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funded");
 
         var portfolioVmBeforeCreate = window.GetPortfolioViewModel();
         portfolioVmBeforeCreate.Should().NotBeNull("PortfolioViewModel should be available before project creation");
@@ -170,9 +170,7 @@ public class CreateProjectTest
         // STEP 4: Navigate to My Projects → open create wizard
         // ──────────────────────────────────────────────────────────────
         TestHelpers.Log("[STEP 4] Navigating to My Projects section...");
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         // My Projects should show empty state (no projects yet)
         var myProjectsVm = window.GetMyProjectsViewModel();
@@ -206,6 +204,8 @@ public class CreateProjectTest
         wizardVm.GoNext();
         Dispatcher.UIThread.RunJobs();
         wizardVm.CurrentStep.Should().Be(2, "Should advance to step 2 after selecting type");
+        var step2Panel = await window.WaitForControl<Visual>("CreateProjectStep2", TestHelpers.UiTimeout);
+        step2Panel.Should().NotBeNull("Step 2 panel should be visible after advancing to step 2");
 
         // ── Step 2: Project profile — name and about ──
         TestHelpers.Log("[STEP 5.2] Filling project name and about...");
@@ -217,6 +217,8 @@ public class CreateProjectTest
         wizardVm.GoNext();
         Dispatcher.UIThread.RunJobs();
         wizardVm.CurrentStep.Should().Be(3, "Should advance to step 3 after filling profile");
+        var step3Panel = await window.WaitForControl<Visual>("CreateProjectStep3", TestHelpers.UiTimeout);
+        step3Panel.Should().NotBeNull("Step 3 panel should be visible after advancing to step 3");
 
         // ── Step 3: Project images — set random picsum.photos URLs ──
         TestHelpers.Log("[STEP 5.3] Setting banner and profile image URLs...");
@@ -232,6 +234,8 @@ public class CreateProjectTest
         wizardVm.GoNext();
         Dispatcher.UIThread.RunJobs();
         wizardVm.CurrentStep.Should().Be(4, "Should advance to step 4 after setting images");
+        var step4Panel = await window.WaitForControl<Visual>("CreateProjectStep4", TestHelpers.UiTimeout);
+        step4Panel.Should().NotBeNull("Step 4 panel should be visible after advancing to step 4");
 
         // ── Step 4: Funding configuration — target amount + end date + penalty ──
         TestHelpers.Log("[STEP 5.4] Setting target amount, end date, and penalty days...");
@@ -251,6 +255,10 @@ public class CreateProjectTest
         wizardVm.DismissStep5Welcome();
         Dispatcher.UIThread.RunJobs();
         await Task.Delay(200);
+
+        // UI: verify step 5 form is visible after welcome is dismissed (IsStep5Form = CurrentStep==5 && !ShowStep5Welcome)
+        var step5Panel = await window.WaitForControl<Visual>("CreateProjectStep5", TestHelpers.UiTimeout);
+        step5Panel.Should().NotBeNull("Step 5 panel should be visible after dismissing welcome");
 
         TestHelpers.Log("[STEP 5.5] Setting duration to 6 months, frequency to Monthly...");
         wizardVm.DurationValue = durationValue;
@@ -290,6 +298,8 @@ public class CreateProjectTest
         wizardVm.GoNext();
         Dispatcher.UIThread.RunJobs();
         wizardVm.CurrentStep.Should().Be(6, "Should advance to step 6 after generating stages");
+        var step6Panel = await window.WaitForControl<Visual>("CreateProjectStep6", TestHelpers.UiTimeout);
+        step6Panel.Should().NotBeNull("Step 6 panel should be visible after advancing to step 6");
 
         // ──────────────────────────────────────────────────────────────
         // STEP 6: Deploy the project
@@ -362,6 +372,15 @@ public class CreateProjectTest
 
         deployVm.CurrentScreen.Should().Be(DeployScreen.Success,
             $"Deploy should reach success screen. Last status: {deployVm.DeployStatusText}");
+
+        // Verify success panel is visible in the visual tree (not just VM state)
+        var deploySuccessPanel = await window.WaitForControl<Visual>("DeploySuccessPanel", TestHelpers.UiTimeout);
+        deploySuccessPanel.Should().NotBeNull("DeploySuccessPanel should be visible in the UI after successful deploy");
+
+        // Verify the project name is displayed in the success screen
+        var deployProjectNameText = await window.GetText("DeploySuccessProjectName", TestHelpers.UiTimeout);
+        deployProjectNameText.Should().Be(projectName,
+            "Deploy success screen should show the correct project name");
 
         // Click "Go to My Projects" — closes modal, adds project to list
         TestHelpers.Log("[STEP 6] Clicking 'Go to My Projects'...");

--- a/src/design/App.Test.Integration/FundAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/FundAndRecoverTest.cs
@@ -100,9 +100,7 @@ public class FundAndRecoverTest
         // STEP 2: Navigate to Funds → create wallet via Generate path
         // ──────────────────────────────────────────────────────────────
         TestHelpers.Log("[STEP 2] Navigating to Funds section...");
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var emptyState = await window.WaitForControl<Panel>("EmptyStatePanel", TestHelpers.UiTimeout);
         TestHelpers.Log($"[STEP 2] EmptyStatePanel found: {emptyState != null}");
@@ -130,9 +128,7 @@ public class FundAndRecoverTest
         // STEP 4: Create + deploy fund project
         // ──────────────────────────────────────────────────────────────
         TestHelpers.Log("[STEP 4] Navigating to My Projects section...");
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = window.GetMyProjectsViewModel();
         myProjectsVm.Should().NotBeNull("MyProjectsViewModel should be available");
@@ -265,9 +261,7 @@ public class FundAndRecoverTest
         // STEP 5: Navigate to Find Projects → find our project
         // ──────────────────────────────────────────────────────────────
         TestHelpers.Log("[STEP 5] Navigating to Find Projects...");
-        window.NavigateToSection("Find Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Find Projects");
 
         var findProjectsVm = window.GetFindProjectsViewModel();
         findProjectsVm.Should().NotBeNull("FindProjectsViewModel should be available");
@@ -405,6 +399,8 @@ public class FundAndRecoverTest
         // STEP 7: Add investment to portfolio + verify no duplicates
         // ──────────────────────────────────────────────────────────────
         TestHelpers.Log("[STEP 7] Adding investment to portfolio...");
+        // DIRECT DI RESOLVE: PortfolioViewModel is a singleton not reachable from the visual
+        // tree while we're still on the Find Projects invest flow. Mirrors internal DI wiring.
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         var countBefore = portfolioVm.Investments.Count;
 
@@ -473,9 +469,7 @@ public class FundAndRecoverTest
         findProjectsVm.CloseProjectDetail();
         Dispatcher.UIThread.RunJobs();
 
-        window.NavigateToSection("Funders");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funders");
 
         var fundersVm = window.GetFundersViewModel();
         fundersVm.Should().NotBeNull("FundersViewModel should be available for founder approval flow");
@@ -538,9 +532,7 @@ public class FundAndRecoverTest
         // STEP 9: Investor reloads signed investment and confirms it
         // ──────────────────────────────────────────────────────────────
         TestHelpers.Log("[STEP 9] Reloading funded investments and confirming signed investment...");
-        window.NavigateToSection("Funded");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funded");
 
         InvestmentViewModel? signedInvestment = null;
         var signedDeadline = DateTime.UtcNow + TestHelpers.IndexerLagTimeout;
@@ -588,9 +580,7 @@ public class FundAndRecoverTest
         findProjectsVm.CloseProjectDetail();
         Dispatcher.UIThread.RunJobs();
 
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var founderProjectsVm = window.GetMyProjectsViewModel();
         founderProjectsVm.Should().NotBeNull("MyProjectsViewModel should be available for founder manage flow");
@@ -727,9 +717,7 @@ public class FundAndRecoverTest
         // STEP 11: Navigate to Funded → find our investment
         // ──────────────────────────────────────────────────────────────
         TestHelpers.Log("[STEP 11] Navigating to Funded section...");
-        window.NavigateToSection("Funded");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funded");
 
         // Find our investment in the portfolio (it was added locally via AddToPortfolio)
         var investment = portfolioVm.Investments.FirstOrDefault(i =>

--- a/src/design/App.Test.Integration/Helpers/TestHelpers.cs
+++ b/src/design/App.Test.Integration/Helpers/TestHelpers.cs
@@ -200,6 +200,76 @@ public static class TestHelpers
     }
 
     /// <summary>
+    /// Maps section labels to the AutomationId of the root panel in that section's view.
+    /// Used by <see cref="NavigateToSectionAndVerify"/> to confirm the target view appeared.
+    /// </summary>
+    private static readonly Dictionary<string, string[]> SectionRootPanelIds = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Funds"] = ["EmptyStatePanel", "PopulatedPanel"],  // FundsView shows one or the other depending on wallet state
+        ["My Projects"] = ["MyProjectsRootPanel"],
+        ["Find Projects"] = ["FindProjectsRootPanel"],
+        ["Funded"] = ["PortfolioRootPanel"],
+        ["Funders"] = ["FundersRootPanel"],
+    };
+
+    /// <summary>
+    /// Navigates to a section and verifies the target view's root panel appeared in the visual tree.
+    /// Falls back to <see cref="NavigateToSection"/> + delay if no root panel mapping exists.
+    /// </summary>
+    public static async Task NavigateToSectionAndVerify(this Window window, string sectionLabel, TimeSpan? timeout = null)
+    {
+        window.NavigateToSection(sectionLabel);
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        if (SectionRootPanelIds.TryGetValue(sectionLabel, out var rootPanelIds))
+        {
+            var maxWait = timeout ?? UiTimeout;
+            Visual? panel = null;
+            foreach (var id in rootPanelIds)
+            {
+                panel = await window.WaitForControl<Visual>(id, TimeSpan.FromSeconds(2));
+                if (panel != null) break;
+            }
+            panel.Should().NotBeNull(
+                $"Section '{sectionLabel}' should show one of [{string.Join(", ", rootPanelIds)}] after navigation");
+        }
+    }
+
+    /// <summary>
+    /// Navigates to Settings and verifies the SettingsView root panel appeared.
+    /// </summary>
+    public static async Task NavigateToSettingsAndVerify(this Window window, TimeSpan? timeout = null)
+    {
+        window.NavigateToSettings();
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var maxWait = timeout ?? UiTimeout;
+        var panel = await window.WaitForControl<Visual>("SettingsRootPanel", maxWait);
+        panel.Should().NotBeNull("Settings root panel should appear after navigation");
+    }
+
+    /// <summary>
+    /// Reads the total balance text from the FundsView UI control (FundsTotalBalanceText).
+    /// Returns the text content, or null if the control is not found.
+    /// This is preferred over reading fundsVm.TotalBalance because it validates the data binding.
+    /// </summary>
+    public static async Task<string?> GetFundsTotalBalanceFromUi(this Window window, TimeSpan? timeout = null)
+    {
+        return await window.GetText("FundsTotalBalanceText", timeout ?? UiTimeout);
+    }
+
+    /// <summary>
+    /// Reads the WalletCard balance text from the UI control (WalletCardBalanceText).
+    /// Returns the text content, or null if the control is not found.
+    /// </summary>
+    public static async Task<string?> GetWalletCardBalanceFromUi(this Window window, TimeSpan? timeout = null)
+    {
+        return await window.GetText("WalletCardBalanceText", timeout ?? UiTimeout);
+    }
+
+    /// <summary>
     /// Navigates to Settings by calling ShellViewModel.NavigateToSettings().
     /// </summary>
     public static void NavigateToSettings(this Window window)
@@ -486,10 +556,20 @@ public static class TestHelpers
         {
             Dispatcher.UIThread.RunJobs();
 
-            // Check if balance is already non-zero
+            // Check if balance is already non-zero (check both VM and UI to validate binding)
             if (fundsVm.TotalBalance != "0.0000")
             {
-                Log($"  [Faucet] Non-zero balance detected: {fundsVm.TotalBalance} (after {faucetAttempts} faucet attempt(s))");
+                Log($"  [Faucet] Non-zero balance detected (VM): {fundsVm.TotalBalance} (after {faucetAttempts} faucet attempt(s))");
+
+                // Also verify the UI TextBlock reflects the same balance
+                var uiBalance = await window.GetFundsTotalBalanceFromUi(TimeSpan.FromSeconds(5));
+                if (uiBalance != null)
+                {
+                    uiBalance.Should().Be(fundsVm.TotalBalance,
+                        "UI balance TextBlock should match VM TotalBalance (validates data binding)");
+                    Log($"  [Faucet] UI balance confirmed: {uiBalance}");
+                }
+
                 return;
             }
 
@@ -517,6 +597,11 @@ public static class TestHelpers
 
         fundsVm.TotalBalance.Should().NotBe("0.0000",
             $"Balance should become non-zero within {FaucetBalanceTimeout.TotalSeconds}s. Faucet was attempted {faucetAttempts} time(s).");
+
+        // Final UI-level balance verification
+        var finalUiBalance = await window.GetFundsTotalBalanceFromUi(TimeSpan.FromSeconds(5));
+        finalUiBalance.Should().NotBeNull("FundsTotalBalanceText should be visible in the UI after funding");
+        finalUiBalance.Should().NotBe("0.0000", "UI balance should also reflect non-zero after funding");
     }
 
     /// <summary>

--- a/src/design/App.Test.Integration/InvestAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/InvestAndRecoverTest.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
@@ -51,9 +52,7 @@ public class InvestAndRecoverTest
         await window.WipeExistingData();
 
         TestHelpers.Log("[STEP 2] Navigating to Funds section...");
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var emptyState = await window.WaitForControl<Panel>("EmptyStatePanel", TestHelpers.UiTimeout);
         emptyState.Should().NotBeNull("Funds should show empty state after wipe");
@@ -73,9 +72,7 @@ public class InvestAndRecoverTest
         TestHelpers.Log("[STEP 3] Set SimplePasswordProvider key to 'default-key'.");
 
         TestHelpers.Log("[STEP 4] Navigating to My Projects section...");
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = window.GetMyProjectsViewModel();
         myProjectsVm.Should().NotBeNull("MyProjectsViewModel should be available");
@@ -197,9 +194,7 @@ public class InvestAndRecoverTest
         project.OwnerWalletId.Should().NotBeNullOrEmpty();
 
         TestHelpers.Log("[STEP 5] Navigating to Find Projects...");
-        window.NavigateToSection("Find Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Find Projects");
 
         var findProjectsVm = window.GetFindProjectsViewModel();
         findProjectsVm.Should().NotBeNull("FindProjectsViewModel should be available");
@@ -225,8 +220,48 @@ public class InvestAndRecoverTest
         foundProject.Target.Should().Be("1.00000");
         foundProject.ProjectId.Should().NotBeNullOrEmpty();
 
+        // Refresh wallet UTXOs before investing — the deploy tx consumed UTXOs from the same
+        // wallet, and the investment tx must be built against the post-deploy UTXO set to avoid
+        // txn-mempool-conflict when publishing later. We poll until the balance reflects the
+        // deploy fee deduction (i.e., the indexer has processed the deploy tx).
+        TestHelpers.Log("[STEP 5.1] Waiting for wallet UTXOs to reflect deploy tx...");
+        await window.NavigateToSectionAndVerify("Funds");
+        var utxoDeadline = DateTime.UtcNow + TestHelpers.IndexerLagTimeout;
+        while (DateTime.UtcNow < utxoDeadline)
+        {
+            await window.ClickWalletCardButton("WalletCardBtnRefresh");
+            await Task.Delay(3000);
+            Dispatcher.UIThread.RunJobs();
+
+            // After a deploy, balance should be less than the original ~2 BTC faucet amount
+            // (deploy fee was deducted). If the balance changed from the original, the indexer
+            // has processed the deploy tx and UTXOs are current.
+            var fundsVm = window.GetFundsViewModel();
+            if (fundsVm != null)
+            {
+                var balanceText = fundsVm.TotalBalance;
+                TestHelpers.Log($"[STEP 5.1] Current balance: {balanceText}");
+                // Balance should have decreased from original 2.0000 after paying deploy fee
+                if (!string.IsNullOrEmpty(balanceText) && balanceText != "0.0000" &&
+                    decimal.TryParse(balanceText, NumberStyles.Float, CultureInfo.InvariantCulture, out var bal) &&
+                    bal < 2.0m)
+                {
+                    TestHelpers.Log($"[STEP 5.1] Balance reflects deploy fee deduction: {balanceText}");
+                    break;
+                }
+            }
+        }
+        await window.NavigateToSectionAndVerify("Find Projects");
+
         TestHelpers.Log("[STEP 6] Opening project detail...");
-        findProjectsVm!.OpenProjectDetail(foundProject);
+        // Re-load projects since we navigated away
+        await findProjectsVm!.LoadProjectsFromSdkAsync();
+        Dispatcher.UIThread.RunJobs();
+        foundProject = findProjectsVm.Projects.FirstOrDefault(p =>
+            p.Description.Contains(runId) || p.ShortDescription.Contains(runId));
+        foundProject.Should().NotBeNull();
+
+        findProjectsVm.OpenProjectDetail(foundProject!);
         Dispatcher.UIThread.RunJobs();
         await Task.Delay(300);
 
@@ -286,10 +321,20 @@ public class InvestAndRecoverTest
         investVm.CurrentScreen.Should().Be(InvestScreen.Success,
             $"Invest should reach success. Last status: {investVm.PaymentStatusText}");
 
+        // Verify invest success UI elements
+        var investSuccessModal = await window.WaitForControl<Visual>("InvestSuccessModal", TestHelpers.UiTimeout);
+        investSuccessModal.Should().NotBeNull("Invest success modal should be visible in the UI");
+        var investSuccessTitle = await window.GetText("InvestSuccessTitle", TestHelpers.UiTimeout);
+        investSuccessTitle.Should().NotBeNullOrEmpty("Invest success title should be displayed");
+        TestHelpers.Log($"[STEP 6] Invest success title: '{investSuccessTitle}'");
+
         TestHelpers.Log("[STEP 7] Adding investment to portfolio...");
         investVm.AddToPortfolio();
         Dispatcher.UIThread.RunJobs();
 
+        // DIRECT DI RESOLVE: PortfolioViewModel is a singleton that isn't easily reachable
+        // from the visual tree at this point — we just left the Find Projects section.
+        // Resolving from DI mirrors what the navigation framework does internally.
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         portfolioVm.HasInvestments.Should().BeTrue();
 
@@ -315,9 +360,7 @@ public class InvestAndRecoverTest
         findProjectsVm.CloseProjectDetail();
         Dispatcher.UIThread.RunJobs();
 
-        window.NavigateToSection("Funders");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funders");
 
         var fundersVm = window.GetFundersViewModel();
         fundersVm.Should().NotBeNull();
@@ -362,9 +405,7 @@ public class InvestAndRecoverTest
         founderApproved.Should().BeTrue();
 
         TestHelpers.Log("[STEP 9] Reloading funded investments and confirming signed investment...");
-        window.NavigateToSection("Funded");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funded");
 
         InvestmentViewModel? signedInvestment = null;
         var signedDeadline = DateTime.UtcNow + TestHelpers.IndexerLagTimeout;
@@ -387,17 +428,43 @@ public class InvestAndRecoverTest
         signedInvestment!.Step.Should().Be(2);
         signedInvestment.ProjectType.Should().Be("invest");
 
-        var confirmResult = await portfolioVm.ConfirmInvestmentAsync(signedInvestment);
-        Dispatcher.UIThread.RunJobs();
-        confirmResult.Should().BeTrue();
+        // Retry ConfirmInvestmentAsync with backoff — the publish can fail with
+        // txn-mempool-conflict when the indexer hasn't yet reflected the deploy tx's
+        // UTXO changes or when a previous test run left stale transactions in the mempool.
+        var confirmResult = false;
+        var confirmDeadline = DateTime.UtcNow + TimeSpan.FromMinutes(2);
+        var confirmAttempt = 0;
+        while (DateTime.UtcNow < confirmDeadline)
+        {
+            confirmAttempt++;
+            confirmResult = await portfolioVm.ConfirmInvestmentAsync(signedInvestment);
+            Dispatcher.UIThread.RunJobs();
+
+            if (confirmResult)
+            {
+                TestHelpers.Log($"[STEP 9] ConfirmInvestmentAsync succeeded on attempt #{confirmAttempt}");
+                break;
+            }
+
+            TestHelpers.Log($"[STEP 9] ConfirmInvestmentAsync failed on attempt #{confirmAttempt}, retrying after delay...");
+            // Reset step back to 2 so the next attempt doesn't skip due to state
+            signedInvestment.Step = 2;
+            var backoff = Math.Min(15_000, 5_000 * confirmAttempt);
+            await Task.Delay(backoff);
+
+            // Refresh wallet balance to pick up new UTXO state
+            await window.ClickButton("PortfolioRefreshButton");
+            await Task.Delay(500);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        confirmResult.Should().BeTrue("ConfirmInvestmentAsync should eventually succeed after retries");
         signedInvestment.Step.Should().Be(3);
         signedInvestment.StatusText.Should().Be("Investment Active");
         signedInvestment.StatusClass.Should().Be("active");
 
         TestHelpers.Log("[STEP 10] Founder spending stage 1...");
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var founderProjectsVm = window.GetMyProjectsViewModel();
         founderProjectsVm.Should().NotBeNull();
@@ -504,9 +571,7 @@ public class InvestAndRecoverTest
         manageVm.Stages.Any(s => s.Number == 1 && s.SpentTransactionCount > 0).Should().BeTrue();
 
         TestHelpers.Log("[STEP 11] Navigating to Funded section...");
-        window.NavigateToSection("Funded");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funded");
 
         var investment = portfolioVm.Investments.FirstOrDefault(i =>
             i.ProjectName == foundProject.ProjectName || i.ProjectIdentifier == foundProject.ProjectId);
@@ -592,9 +657,7 @@ public class InvestAndRecoverTest
 
     private async Task EnsureWalletHasFeeFunds(Window window, string walletId, string context)
     {
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var fundsVm = window.GetFundsViewModel();
         fundsVm.Should().NotBeNull();
@@ -602,6 +665,9 @@ public class InvestAndRecoverTest
         var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(2);
         while (DateTime.UtcNow < deadline)
         {
+            // DIRECT SDK CALL: FundsViewModel.TotalBalance is a formatted string that doesn't
+            // expose the raw sats breakdown (confirmed + unconfirmed + reserved) we need to
+            // determine whether the wallet has enough for fee-only transactions.
             var refresh = await global::App.App.Services.GetRequiredService<Angor.Sdk.Wallet.Application.IWalletAppService>()
                 .RefreshAndGetAccountBalanceInfo(new WalletId(walletId));
 

--- a/src/design/App.Test.Integration/InvestModalsViewFixesTest.cs
+++ b/src/design/App.Test.Integration/InvestModalsViewFixesTest.cs
@@ -1,5 +1,6 @@
 using App.Test.Integration.Helpers;
 using App.UI.Sections.FindProjects;
+using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -38,9 +39,13 @@ public class InvestModalsViewFixesTest
 
         // ── Navigate to Find Projects and get an open project ──
         Log("[0] Navigating to Find Projects and loading projects...");
-        window.NavigateToSection("Find Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Find Projects");
+
+        // UI assertion: verify the FindProjectsView is in the visual tree
+        var findProjectsView = window.GetVisualDescendants()
+            .OfType<FindProjectsView>()
+            .FirstOrDefault();
+        findProjectsView.Should().NotBeNull("FindProjectsView should be in the visual tree after navigation");
 
         var findVm = window.GetFindProjectsViewModel();
         findVm.Should().NotBeNull("FindProjectsViewModel should be available");
@@ -54,6 +59,12 @@ public class InvestModalsViewFixesTest
         Dispatcher.UIThread.RunJobs();
         findVm.OpenInvestPage();
         Dispatcher.UIThread.RunJobs();
+
+        // UI assertion: verify InvestPageView appeared in the visual tree
+        var investPageView = window.GetVisualDescendants()
+            .OfType<InvestPageView>()
+            .FirstOrDefault();
+        investPageView.Should().NotBeNull("InvestPageView should be in the visual tree after opening invest page");
 
         var vm = findVm.InvestPageViewModel;
         vm.Should().NotBeNull("InvestPageViewModel should be created via factory");

--- a/src/design/App.Test.Integration/InvestmentCancellationTest.cs
+++ b/src/design/App.Test.Integration/InvestmentCancellationTest.cs
@@ -280,9 +280,7 @@ public class InvestmentCancellationTest
         string profileName,
         ProjectHandle project)
     {
-        window.NavigateToSection("Funders");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funders");
 
         var fundersVm = window.GetFundersViewModel();
         fundersVm.Should().NotBeNull();
@@ -439,9 +437,7 @@ public class InvestmentCancellationTest
         string profileName,
         string balanceBeforeCancel)
     {
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         await window.ClickWalletCardButton("WalletCardBtnRefresh");
         await Task.Delay(2000);
@@ -532,6 +528,8 @@ public class InvestmentCancellationTest
             "Above-threshold investment should show 'Pending Approval'");
 
         // Add to portfolio
+        // DIRECT DI RESOLVE: PortfolioViewModel is a singleton not reachable from the visual
+        // tree while we're still on the Find Projects invest flow. Mirrors internal DI wiring.
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         investVm.AddToPortfolio();
         Dispatcher.UIThread.RunJobs();
@@ -567,10 +565,9 @@ public class InvestmentCancellationTest
         ProjectHandle project,
         Func<InvestmentViewModel, bool> predicate)
     {
-        window.NavigateToSection("Funded");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funded");
 
+        // DIRECT DI RESOLVE: Need the singleton PortfolioViewModel to poll SDK reload.
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         var deadline = DateTime.UtcNow + TestHelpers.IndexerLagTimeout;
 
@@ -618,9 +615,7 @@ public class InvestmentCancellationTest
         string payoutDay,
         string runId)
     {
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = window.GetMyProjectsViewModel();
         myProjectsVm.Should().NotBeNull();
@@ -769,9 +764,7 @@ public class InvestmentCancellationTest
 
     private async Task CreateWalletAndFundAsync(Window window, string profileName)
     {
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var fundsVm = window.GetFundsViewModel();
         fundsVm.Should().NotBeNull();
@@ -798,9 +791,7 @@ public class InvestmentCancellationTest
         string profileName,
         ProjectHandle project)
     {
-        window.NavigateToSection("Find Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Find Projects");
 
         var findProjectsVm = window.GetFindProjectsViewModel();
         findProjectsVm.Should().NotBeNull();

--- a/src/design/App.Test.Integration/MultiFundClaimAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/MultiFundClaimAndRecoverTest.cs
@@ -182,9 +182,7 @@ public class MultiFundClaimAndRecoverTest
 
     private async Task CreateWalletAndFundAsync(Window window, string profileName)
     {
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var fundsVm = GetFundsViewModel(window);
         fundsVm.Should().NotBeNull();
@@ -217,9 +215,7 @@ public class MultiFundClaimAndRecoverTest
         string payoutDay,
         string runId)
     {
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = GetMyProjectsViewModel(window);
         myProjectsVm.Should().NotBeNull();
@@ -467,6 +463,8 @@ public class MultiFundClaimAndRecoverTest
                 "below-threshold (auto-approved) investment should show 'Successful' in SuccessTitle");
         }
 
+        // DIRECT DI RESOLVE: PortfolioViewModel is a singleton not reachable from the visual
+        // tree while we're still on the Find Projects invest flow. Mirrors internal DI wiring.
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         investVm.AddToPortfolio();
         Dispatcher.UIThread.RunJobs();
@@ -487,9 +485,7 @@ public class MultiFundClaimAndRecoverTest
 
     private async Task ApprovePendingInvestmentAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("Funders");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funders");
 
         var fundersVm = GetFundersViewModel(window);
         fundersVm.Should().NotBeNull();
@@ -572,9 +568,7 @@ public class MultiFundClaimAndRecoverTest
 
     private async Task ClaimStageOneAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = GetMyProjectsViewModel(window);
         myProjectsVm.Should().NotBeNull();
@@ -818,10 +812,9 @@ public class MultiFundClaimAndRecoverTest
         ProjectHandle project,
         Func<InvestmentViewModel, bool> predicate)
     {
-        window.NavigateToSection("Funded");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funded");
 
+        // DIRECT DI RESOLVE: Need the singleton PortfolioViewModel to poll SDK reload.
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         var deadline = DateTime.UtcNow + IndexerLagTimeout;
 
@@ -854,9 +847,7 @@ public class MultiFundClaimAndRecoverTest
 
     private async Task EnsureWalletHasFeeFunds(Window window, string profileName, string walletId, string context)
     {
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var fundsVm = GetFundsViewModel(window);
         fundsVm.Should().NotBeNull();
@@ -864,6 +855,8 @@ public class MultiFundClaimAndRecoverTest
         var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(2);
         while (DateTime.UtcNow < deadline)
         {
+            // DIRECT SDK CALL: FundsViewModel.TotalBalance doesn't expose the raw sats breakdown
+            // (confirmed + unconfirmed + reserved) needed to check fee-level funding.
             var refresh = await global::App.App.Services.GetRequiredService<Angor.Sdk.Wallet.Application.IWalletAppService>()
                 .RefreshAndGetAccountBalanceInfo(new WalletId(walletId));
 
@@ -892,9 +885,7 @@ public class MultiFundClaimAndRecoverTest
 
     private async Task<ProjectItemViewModel> FindProjectFromSdkAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("Find Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Find Projects");
 
         var findProjectsVm = GetFindProjectsViewModel(window);
         findProjectsVm.Should().NotBeNull();
@@ -925,9 +916,7 @@ public class MultiFundClaimAndRecoverTest
 
     private async Task WipeExistingData(Window window, string profileName)
     {
-        window.NavigateToSettings();
-        Dispatcher.UIThread.RunJobs();
-        await Task.Delay(500);
+        await window.NavigateToSettingsAndVerify();
 
         var settingsView = window.GetVisualDescendants().OfType<SettingsView>().FirstOrDefault();
         if (settingsView?.DataContext is SettingsViewModel settingsVm)
@@ -1116,9 +1105,7 @@ public class MultiFundClaimAndRecoverTest
         penaltyItem.Should().NotBeNull("the current investment should appear in PenaltyInvestments");
 
         // Navigate to the portfolio section so the PenaltiesButton is in the visual tree
-        window.NavigateToSection("Funded");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funded");
 
         // Click the PenaltiesButton in the PortfolioView to open the modal
         var penaltiesBtn = window.GetVisualDescendants()

--- a/src/design/App.Test.Integration/MultiFundReleaseUnfundedAndClaimTest.cs
+++ b/src/design/App.Test.Integration/MultiFundReleaseUnfundedAndClaimTest.cs
@@ -181,9 +181,7 @@ public class MultiFundReleaseUnfundedAndClaimTest
 
     private async Task CreateWalletAndFundAsync(Window window, string profileName)
     {
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var fundsVm = GetFundsViewModel(window);
         fundsVm.Should().NotBeNull();
@@ -216,9 +214,7 @@ public class MultiFundReleaseUnfundedAndClaimTest
         string payoutDay,
         string runId)
     {
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = GetMyProjectsViewModel(window);
         myProjectsVm.Should().NotBeNull();
@@ -409,6 +405,8 @@ public class MultiFundReleaseUnfundedAndClaimTest
                 "below-threshold (auto-approved) investment should show 'Successful' in SuccessTitle");
         }
 
+        // DIRECT DI RESOLVE: PortfolioViewModel is a singleton not reachable from the visual
+        // tree while we're still on the Find Projects invest flow. Mirrors internal DI wiring.
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         investVm.AddToPortfolio();
         Dispatcher.UIThread.RunJobs();
@@ -427,9 +425,7 @@ public class MultiFundReleaseUnfundedAndClaimTest
 
     private async Task ApprovePendingInvestmentAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("Funders");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funders");
 
         var fundersVm = GetFundersViewModel(window);
         fundersVm.Should().NotBeNull();
@@ -512,9 +508,7 @@ public class MultiFundReleaseUnfundedAndClaimTest
 
     private async Task ClaimStageOneAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = GetMyProjectsViewModel(window);
         myProjectsVm.Should().NotBeNull();
@@ -575,9 +569,7 @@ public class MultiFundReleaseUnfundedAndClaimTest
 
     private async Task ReleaseRemainingStagesToInvestorsAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = GetMyProjectsViewModel(window);
         myProjectsVm.Should().NotBeNull();
@@ -748,10 +740,9 @@ public class MultiFundReleaseUnfundedAndClaimTest
         ProjectHandle project,
         Func<InvestmentViewModel, bool> predicate)
     {
-        window.NavigateToSection("Funded");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funded");
 
+        // DIRECT DI RESOLVE: Need the singleton PortfolioViewModel to poll SDK reload.
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         var deadline = DateTime.UtcNow + IndexerLagTimeout;
 
@@ -784,9 +775,7 @@ public class MultiFundReleaseUnfundedAndClaimTest
 
     private async Task EnsureWalletHasFeeFunds(Window window, string profileName, string walletId, string context)
     {
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var fundsVm = GetFundsViewModel(window);
         fundsVm.Should().NotBeNull();
@@ -794,6 +783,8 @@ public class MultiFundReleaseUnfundedAndClaimTest
         var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(2);
         while (DateTime.UtcNow < deadline)
         {
+            // DIRECT SDK CALL: FundsViewModel.TotalBalance doesn't expose the raw sats breakdown
+            // (confirmed + unconfirmed + reserved) needed to check fee-level funding.
             var refresh = await global::App.App.Services.GetRequiredService<Angor.Sdk.Wallet.Application.IWalletAppService>()
                 .RefreshAndGetAccountBalanceInfo(new WalletId(walletId));
 
@@ -822,9 +813,7 @@ public class MultiFundReleaseUnfundedAndClaimTest
 
     private async Task<ProjectItemViewModel> FindProjectFromSdkAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("Find Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Find Projects");
 
         var findProjectsVm = GetFindProjectsViewModel(window);
         findProjectsVm.Should().NotBeNull();
@@ -855,9 +844,7 @@ public class MultiFundReleaseUnfundedAndClaimTest
 
     private async Task WipeExistingData(Window window, string profileName)
     {
-        window.NavigateToSettings();
-        Dispatcher.UIThread.RunJobs();
-        await Task.Delay(500);
+        await window.NavigateToSettingsAndVerify();
 
         var settingsView = window.GetVisualDescendants().OfType<SettingsView>().FirstOrDefault();
         if (settingsView?.DataContext is SettingsViewModel settingsVm)

--- a/src/design/App.Test.Integration/MultiInvestClaimAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/MultiInvestClaimAndRecoverTest.cs
@@ -179,9 +179,7 @@ public class MultiInvestClaimAndRecoverTest
 
     private async Task CreateWalletAndFundAsync(Window window, string profileName)
     {
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var fundsVm = GetFundsViewModel(window);
         fundsVm.Should().NotBeNull();
@@ -212,9 +210,7 @@ public class MultiInvestClaimAndRecoverTest
         string profileImageUrl,
         string runId)
     {
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = GetMyProjectsViewModel(window);
         myProjectsVm.Should().NotBeNull();
@@ -399,6 +395,8 @@ public class MultiInvestClaimAndRecoverTest
         investVm.FormattedAmount.Should().Be(
             decimal.Parse(amountBtc, CultureInfo.InvariantCulture).ToString("F8", CultureInfo.InvariantCulture));
 
+        // DIRECT DI RESOLVE: PortfolioViewModel is a singleton not reachable from the visual
+        // tree while we're still on the Find Projects invest flow. Mirrors internal DI wiring.
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         investVm.AddToPortfolio();
         Dispatcher.UIThread.RunJobs();
@@ -426,9 +424,7 @@ public class MultiInvestClaimAndRecoverTest
         ProjectHandle project,
         int expectedPendingCount)
     {
-        window.NavigateToSection("Funders");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funders");
 
         var fundersVm = GetFundersViewModel(window);
         fundersVm.Should().NotBeNull();
@@ -528,9 +524,7 @@ public class MultiInvestClaimAndRecoverTest
 
     private async Task ClaimStageOneAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = GetMyProjectsViewModel(window);
         myProjectsVm.Should().NotBeNull();
@@ -591,9 +585,7 @@ public class MultiInvestClaimAndRecoverTest
 
     private async Task ReleaseRemainingStagesToInvestorsAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = GetMyProjectsViewModel(window);
         myProjectsVm.Should().NotBeNull();
@@ -690,9 +682,7 @@ public class MultiInvestClaimAndRecoverTest
         portfolioVm.PenaltyInvestments.Should().BeEmpty();
 
         // Navigate to Funded section so PortfolioView (and PenaltiesButton) is in the visual tree
-        window.NavigateToSection("Funded");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funded");
 
         // Click PenaltiesButton to open the modal
         var penaltiesBtn = window.GetVisualDescendants()
@@ -820,10 +810,9 @@ public class MultiInvestClaimAndRecoverTest
         ProjectHandle project,
         Func<InvestmentViewModel, bool> predicate)
     {
-        window.NavigateToSection("Funded");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funded");
 
+        // DIRECT DI RESOLVE: Need the singleton PortfolioViewModel to poll SDK reload.
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         var deadline = DateTime.UtcNow + IndexerLagTimeout;
 
@@ -856,9 +845,7 @@ public class MultiInvestClaimAndRecoverTest
 
     private async Task EnsureWalletHasFeeFunds(Window window, string profileName, string walletId, string context)
     {
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var fundsVm = GetFundsViewModel(window);
         fundsVm.Should().NotBeNull();
@@ -866,6 +853,8 @@ public class MultiInvestClaimAndRecoverTest
         var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(2);
         while (DateTime.UtcNow < deadline)
         {
+            // DIRECT SDK CALL: FundsViewModel.TotalBalance doesn't expose the raw sats breakdown
+            // (confirmed + unconfirmed + reserved) needed to check fee-level funding.
             var refresh = await global::App.App.Services.GetRequiredService<Angor.Sdk.Wallet.Application.IWalletAppService>()
                 .RefreshAndGetAccountBalanceInfo(new WalletId(walletId));
 
@@ -894,9 +883,7 @@ public class MultiInvestClaimAndRecoverTest
 
     private async Task<ProjectItemViewModel> FindProjectFromSdkAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("Find Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Find Projects");
 
         var findProjectsVm = GetFindProjectsViewModel(window);
         findProjectsVm.Should().NotBeNull();
@@ -927,9 +914,7 @@ public class MultiInvestClaimAndRecoverTest
 
     private async Task WipeExistingData(Window window, string profileName)
     {
-        window.NavigateToSettings();
-        Dispatcher.UIThread.RunJobs();
-        await Task.Delay(500);
+        await window.NavigateToSettingsAndVerify();
 
         var settingsView = window.GetVisualDescendants().OfType<SettingsView>().FirstOrDefault();
         if (settingsView?.DataContext is SettingsViewModel settingsVm)

--- a/src/design/App.Test.Integration/MultiInvestReleaseUnfundedAndClaimTest.cs
+++ b/src/design/App.Test.Integration/MultiInvestReleaseUnfundedAndClaimTest.cs
@@ -183,9 +183,7 @@ public class MultiInvestReleaseUnfundedAndClaimTest
 
     private async Task CreateWalletAndFundAsync(Window window, string profileName)
     {
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var fundsVm = GetFundsViewModel(window);
         fundsVm.Should().NotBeNull();
@@ -217,9 +215,7 @@ public class MultiInvestReleaseUnfundedAndClaimTest
         string thresholdAmountBtc,
         string runId)
     {
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = GetMyProjectsViewModel(window);
         myProjectsVm.Should().NotBeNull();
@@ -411,6 +407,8 @@ public class MultiInvestReleaseUnfundedAndClaimTest
                 "below-threshold auto-approved investment should show 'Successful' in SuccessTitle");
         }
 
+        // DIRECT DI RESOLVE: PortfolioViewModel is a singleton not reachable from the visual
+        // tree while we're still on the Find Projects invest flow. Mirrors internal DI wiring.
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         investVm.AddToPortfolio();
         Dispatcher.UIThread.RunJobs();
@@ -433,9 +431,7 @@ public class MultiInvestReleaseUnfundedAndClaimTest
         ProjectHandle project,
         int expectedPendingCount)
     {
-        window.NavigateToSection("Funders");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funders");
 
         var fundersVm = GetFundersViewModel(window);
         fundersVm.Should().NotBeNull();
@@ -527,9 +523,7 @@ public class MultiInvestReleaseUnfundedAndClaimTest
 
     private async Task ClaimStageOneAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = GetMyProjectsViewModel(window);
         myProjectsVm.Should().NotBeNull();
@@ -590,9 +584,7 @@ public class MultiInvestReleaseUnfundedAndClaimTest
 
     private async Task ReleaseRemainingStagesToInvestorsAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = GetMyProjectsViewModel(window);
         myProjectsVm.Should().NotBeNull();
@@ -754,10 +746,9 @@ public class MultiInvestReleaseUnfundedAndClaimTest
         ProjectHandle project,
         Func<InvestmentViewModel, bool> predicate)
     {
-        window.NavigateToSection("Funded");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funded");
 
+        // DIRECT DI RESOLVE: Need the singleton PortfolioViewModel to poll SDK reload.
         var portfolioVm = global::App.App.Services.GetRequiredService<PortfolioViewModel>();
         var deadline = DateTime.UtcNow + IndexerLagTimeout;
 
@@ -790,9 +781,7 @@ public class MultiInvestReleaseUnfundedAndClaimTest
 
     private async Task EnsureWalletHasFeeFunds(Window window, string profileName, string walletId, string context)
     {
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var fundsVm = GetFundsViewModel(window);
         fundsVm.Should().NotBeNull();
@@ -800,6 +789,8 @@ public class MultiInvestReleaseUnfundedAndClaimTest
         var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(2);
         while (DateTime.UtcNow < deadline)
         {
+            // DIRECT SDK CALL: FundsViewModel.TotalBalance doesn't expose the raw sats breakdown
+            // (confirmed + unconfirmed + reserved) needed to check fee-level funding.
             var refresh = await global::App.App.Services.GetRequiredService<Angor.Sdk.Wallet.Application.IWalletAppService>()
                 .RefreshAndGetAccountBalanceInfo(new WalletId(walletId));
 
@@ -828,9 +819,7 @@ public class MultiInvestReleaseUnfundedAndClaimTest
 
     private async Task<ProjectItemViewModel> FindProjectFromSdkAsync(Window window, string profileName, ProjectHandle project)
     {
-        window.NavigateToSection("Find Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Find Projects");
 
         var findProjectsVm = GetFindProjectsViewModel(window);
         findProjectsVm.Should().NotBeNull();
@@ -861,9 +850,7 @@ public class MultiInvestReleaseUnfundedAndClaimTest
 
     private async Task WipeExistingData(Window window, string profileName)
     {
-        window.NavigateToSettings();
-        Dispatcher.UIThread.RunJobs();
-        await Task.Delay(500);
+        await window.NavigateToSettingsAndVerify();
 
         var settingsView = window.GetVisualDescendants().OfType<SettingsView>().FirstOrDefault();
         if (settingsView?.DataContext is SettingsViewModel settingsVm)

--- a/src/design/App.Test.Integration/SendToSelfTest.cs
+++ b/src/design/App.Test.Integration/SendToSelfTest.cs
@@ -71,9 +71,7 @@ public class SendToSelfTest
         // STEP 2: Navigate to Funds — verify empty state
         // ──────────────────────────────────────────────────────────────
         TestHelpers.Log("[STEP 2] Navigating to Funds section...");
-        window.NavigateToSection("Funds");
-        await Task.Delay(500); // let the view load and call LoadWalletsFromSdkAsync
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         var emptyState = await window.WaitForControl<Panel>("EmptyStatePanel", TestHelpers.UiTimeout);
         TestHelpers.Log($"[STEP 2] EmptyStatePanel found: {emptyState != null}");
@@ -171,21 +169,21 @@ public class SendToSelfTest
             await Task.Delay(TestHelpers.PollInterval);
             Dispatcher.UIThread.RunJobs();
 
-            var vm = window.GetFundsViewModel();
+            var uiBalance = await window.GetFundsTotalBalanceFromUi();
             step9Polls++;
-            if (vm != null && vm.TotalBalance != "0.0000")
+            if (uiBalance != null && uiBalance != "0.0000")
             {
-                TestHelpers.Log($"[STEP 9] Final balance: {vm.TotalBalance} (after {step9Polls} polls)");
+                TestHelpers.Log($"[STEP 9] Final balance (from UI): {uiBalance} (after {step9Polls} polls)");
                 break;
             }
 
-            TestHelpers.Log($"[STEP 9] Poll #{step9Polls}: balance is '{vm?.TotalBalance ?? "N/A"}', retrying...");
+            TestHelpers.Log($"[STEP 9] Poll #{step9Polls}: balance is '{uiBalance ?? "N/A"}', retrying...");
         }
 
-        var fundsVm = window.GetFundsViewModel();
-        fundsVm.Should().NotBeNull();
-        TestHelpers.Log($"[STEP 9] Final balance: {fundsVm!.TotalBalance}");
-        fundsVm!.TotalBalance.Should().NotBe("0.0000", "balance should be > 0 after send-to-self (minus fee)");
+        var finalBalance = await window.GetFundsTotalBalanceFromUi();
+        finalBalance.Should().NotBeNull("FundsTotalBalanceText should be visible in the UI");
+        TestHelpers.Log($"[STEP 9] Final balance (from UI): {finalBalance}");
+        finalBalance.Should().NotBe("0.0000", "balance should be > 0 after send-to-self (minus fee)");
 
         // Cleanup: close window
         window.Close();

--- a/src/design/App.Test.Integration/TEST_ANALYSIS.md
+++ b/src/design/App.Test.Integration/TEST_ANALYSIS.md
@@ -1,0 +1,235 @@
+# Integration Test Analysis — Interaction Hierarchy Audit
+
+## Overview
+
+This document summarizes an audit of all integration tests in `App.Test.Integration` against the [Interaction Hierarchy](TESTING_GUIDELINES.md#interaction-hierarchy-ui--viewmodel--sdk) defined in the testing guidelines. The goal is to identify where tests bypass the UI layer and call ViewModels or SDK services directly, find missing validations, and recommend improvements to increase test reliability.
+
+---
+
+## 1. ViewModel-Level Calls (Where Tests Bypass UI)
+
+### Navigation (all tests)
+
+Every test navigates via `window.NavigateToSection("...")` which sets `shellVm.SelectedNavItem` directly (`TestHelpers.cs:194-199`). There is no UI-level click on the sidebar nav items.
+
+**Impact**: If the nav sidebar binding or click handler breaks, no test will catch it.
+
+### Create Project Wizard (CreateProjectTest, InvestAndRecoverTest, FundAndRecoverTest, WalletImportAndProjectScanTest, Multi* tests)
+
+The entire 6-step wizard is driven exclusively through ViewModel calls:
+
+| Call | Files |
+|---|---|
+| `wizardVm.DismissWelcome()` | All wizard tests |
+| `wizardVm.SelectProjectType("investment"/"fund")` | All wizard tests |
+| `wizardVm.GoNext()` | All wizard tests |
+| `wizardVm.ProjectName = ...` | All wizard tests |
+| `wizardVm.TargetAmount = ...` | All wizard tests |
+| `wizardVm.GenerateInvestmentStages()` / `GeneratePayoutSchedule()` | All wizard tests |
+| `wizardVm.Deploy()` | All wizard tests |
+
+**Why**: `TestHelpers.cs:527` explains — the EmptyState button and wizard type cards use `PointerPressed` on `Border` elements, which the headless test harness can't simulate via `RaiseEvent(Button.ClickEvent)`.
+
+### Deploy Flow (all deploy tests)
+
+| Call | Location |
+|---|---|
+| `deployVm.SelectWallet(wallet)` | CreateProjectTest:329, InvestAndRecoverTest:150, FundAndRecoverTest, WalletImportAndProjectScanTest, Multi* |
+| `deployVm.PayWithWallet()` | Same files |
+| `deployVm.GoToMyProjects()` | Same files |
+
+**Why**: Wallet cards use `PointerPressed` on `Border`, same limitation.
+
+### Invest Flow (FindProjectsPanelTests, InvestModalsViewFixesTest, InvestAndRecoverTest, FundAndRecoverTest, Multi*)
+
+| Call | Location |
+|---|---|
+| `investVm.Submit()` | FindProjectsPanelTests:262, InvestAndRecoverTest:256, etc. |
+| `investVm.SelectWallet(wallet)` | FindProjectsPanelTests:366, InvestAndRecoverTest:261, etc. |
+| `investVm.PayWithWallet()` | InvestAndRecoverTest:266, FundAndRecoverTest, Multi* |
+| `investVm.ShowInvoice()` | FindProjectsPanelTests:432, InvestModalsViewFixesTest:75 |
+| `investVm.SelectNetworkTab(...)` | InvestModalsViewFixesTest:107, 138-142 |
+| `investVm.AddToPortfolio()` | InvestAndRecoverTest:290, FundAndRecoverTest, Multi* |
+| `investVm.CloseModal()` | FindProjectsPanelTests:377, 418, 454 |
+| `investVm.BackToWalletSelector()` | FindProjectsPanelTests:440 |
+| `investVm.SelectQuickAmount(0.01)` | FindProjectsPanelTests:233 |
+
+### Funder Approval (InvestAndRecoverTest, Multi*)
+
+| Call | Location |
+|---|---|
+| `fundersVm.SetFilter("waiting"/"approved")` | InvestAndRecoverTest:324, 351 |
+| `fundersVm.ApproveSignature(id)` | InvestAndRecoverTest:343 |
+| `fundersVm.LoadInvestmentRequestsAsync()` | InvestAndRecoverTest:330, 350 |
+
+**Why**: The `ClickApproveSignatureAsync` UI helper exists in `TestHelpers.cs:671` but is only used in Multi* tests. `InvestAndRecoverTest` calls the VM directly.
+
+### Portfolio Operations (InvestAndRecoverTest, FundAndRecoverTest, Multi*)
+
+| Call | Location |
+|---|---|
+| `portfolioVm.ConfirmInvestmentAsync(...)` | InvestAndRecoverTest:390 |
+| `portfolioVm.LoadRecoveryStatusAsync(...)` | InvestAndRecoverTest:536 |
+| `portfolioVm.LoadInvestmentsFromSdkAsync()` | InvestAndRecoverTest:297 |
+
+### Balance Reads (SendToSelfTest, TestHelpers, InvestAndRecoverTest, WalletImportAndProjectScanTest)
+
+`fundsVm.TotalBalance` is read from the ViewModel ~8 times across tests instead of reading from a UI TextBlock. This misses binding regressions.
+
+| Location | What's read |
+|---|---|
+| `TestHelpers.cs:490,518` | `fundsVm.TotalBalance` in FundWalletViaFaucet |
+| `SendToSelfTest:176,188` | `fundsVm.TotalBalance` in final balance check |
+| `WalletImportAndProjectScanTest:302,313` | `fundsVm.TotalBalance` in balance discovery |
+| `CreateProjectTest:157` | `fundsVm.TotalBalance` in header sync check |
+
+---
+
+## 2. SDK/Service-Level Direct Calls
+
+### Justified (have comments)
+
+| Location | Service | Comment |
+|---|---|---|
+| `CreateProjectTest:448-449` | `IProjectAppService`, `IWalletAppService` | "DIRECT SDK CALL: No ViewModel exposes the raw ProjectDto..." |
+| `SendToSelfTest:141` | `IWalletContext` via DI | Step 8b: verify pending balance internal accounting |
+
+### Unjustified (missing comments) — NOW FIXED for InvestAndRecoverTest, pending for Multi*
+
+| Location | Service | Why it's called |
+|---|---|---|
+| `InvestAndRecoverTest:293` | `GetRequiredService<PortfolioViewModel>()` | DI resolve instead of navigating to Funded section |
+| `InvestAndRecoverTest:605` | `IWalletAppService.RefreshAndGetAccountBalanceInfo()` | Raw sats check for fee funding |
+| `MultiFundClaimAndRecoverTest:470,825` | `GetRequiredService<PortfolioViewModel>()` | Same pattern |
+| `MultiFundClaimAndRecoverTest:868` | `IWalletAppService.RefreshAndGetAccountBalanceInfo()` | Same pattern |
+| `MultiInvestClaimAndRecoverTest:402,827` | `GetRequiredService<PortfolioViewModel>()` | Same pattern |
+| `MultiInvestClaimAndRecoverTest:870` | `IWalletAppService.RefreshAndGetAccountBalanceInfo()` | Same pattern |
+| `MultiFundReleaseUnfundedAndClaimTest:412,755` | `GetRequiredService<PortfolioViewModel>()` | Same pattern |
+| `MultiFundReleaseUnfundedAndClaimTest:798` | `IWalletAppService.RefreshAndGetAccountBalanceInfo()` | Same pattern |
+| `MultiInvestReleaseUnfundedAndClaimTest:414,761` | `GetRequiredService<PortfolioViewModel>()` | Same pattern |
+| `MultiInvestReleaseUnfundedAndClaimTest:804` | `IWalletAppService.RefreshAndGetAccountBalanceInfo()` | Same pattern |
+| `FundAndRecoverTest:408` | `GetRequiredService<PortfolioViewModel>()` | Same pattern |
+| `InvestmentCancellationTest:535,574` | `GetRequiredService<PortfolioViewModel>()` | Same pattern |
+| `OneClickInvestLightningTest:211` | `GetRequiredService<PortfolioViewModel>()` | Same pattern |
+
+### Acceptable Infrastructure Calls
+
+| Location | Service | Purpose |
+|---|---|---|
+| All tests | `GetRequiredService<SimplePasswordProvider>()` | Test setup — set decryption key |
+| `WalletImportAndProjectScanTest:508` | `GetRequiredService<ProfileContext>()` | Test infrastructure — verify profile isolation |
+
+---
+
+## 3. UI-Level Assertions Already Present (Good Examples)
+
+| Test | What's checked at UI level |
+|---|---|
+| `SendToSelfTest` | `ReceiveAddressText` TextBlock, `SendFormPanel`, `SendSuccessPanel`, `SummaryTxid`, `AmountError`, `FeeConfirmButton` |
+| `TestHelpers.CreateWalletViaGenerate()` | `ChoicePanel`, `BackupPanel`, `CreateWalletSuccessPanel`, `ContinueBtnSpinner` visibility, modal closed state |
+| `FindProjectsPanelTests` | `ProjectListPanel`/`ProjectDetailPanel`/`InvestPagePanel` visibility, `ProjectCard` properties, `InvestButton` border visibility, `ProjectDetailView` DataContext |
+| `TestHelpers.ClickRecoveryFlowAsync()` | `InvestmentDetailView` visibility, `RecoverFundsButton`, `ConfirmRecoveryModal`, `FeeConfirmButton`, success modal state |
+| `TestHelpers.ClickManageProjectClaimStageAsync()` | `StageClaimBtn` by class+tag, `ClaimSelectedBtn`, `FeeConfirmButton` |
+| `WalletImportAndProjectScanTest` | `SeedPhraseDisplay` TextBlock, `ImportPanel`, `SeedPhraseInput`, `CreateWalletSuccessPanel` |
+
+---
+
+## 4. Missing Validations — Specific Improvement Opportunities
+
+### A. Navigation never verified at UI level
+
+**Every** `NavigateToSection("X")` call (40+ occurrences) never asserts the target view appeared in the visual tree.
+
+**Suggestion**: After navigation, `WaitForControl<FundsView/MyProjectsView/etc.>` and assert it's visible. Catches broken navigation bindings.
+
+### B. Balance reads use VM instead of UI TextBlock
+
+No balance TextBlock has an `AutomationId` or `x:Name` currently. Tests read `fundsVm.TotalBalance` instead.
+
+**Suggestion**: Add `AutomationId="TotalBalanceText"` to the FundsView total balance TextBlock, `AutomationId="HeaderAvailableBalance"` to ShellView header. Then read via `window.GetText("TotalBalanceText")`.
+
+### C. Wizard step transitions not verified visually
+
+When `wizardVm.GoNext()` advances to step N, the test checks `wizardVm.CurrentStep.Should().Be(N)` but never verifies the step N panel is visible.
+
+**Suggestion**: Add `AutomationId="WizardStep1Panel"` through `"WizardStep6Panel"` to the wizard view, then assert visibility after each `GoNext()`.
+
+### D. Deploy/invest success screens not verified visually
+
+Tests check `deployVm.CurrentScreen == DeployScreen.Success` (VM) but never find the success panel in the visual tree.
+
+**Suggestion**: `DeployFlowOverlay.axaml` has no AutomationIds at all. Add `AutomationId="DeploySuccessPanel"`, `AutomationId="DeployStatusText"`. The invest flow already has `InvestSuccessModal` — use it.
+
+### E. InvestModalsViewFixesTest has zero UI assertions
+
+This 180-line test checks only VM properties (`vm.HasError`, `vm.CurrentScreen`, `vm.PaymentStatusText`, `vm.InvoiceFieldLabel`, etc.) and never finds any control in the visual tree.
+
+**Suggestion**: After `ShowInvoice()`, verify the Invoice panel is visible via `WaitForControl`. Check that error banner TextBlock shows expected text. Verify tab icon controls change.
+
+### F. Funder approval flow missing UI checks (InvestAndRecoverTest)
+
+After navigating to Funders section (line 318), never verifies `FundersView` appeared. Calls `fundersVm.ApproveSignature()` directly instead of using the existing `TestHelpers.ClickApproveSignatureAsync()` helper.
+
+**Suggestion**: Use the UI helper that already exists.
+
+### G. Portfolio section never verified visually
+
+After navigating to "Funded" (InvestAndRecoverTest:365), never checks that `PortfolioView` appeared or that investment cards rendered. All assertions are on VM properties.
+
+**Suggestion**: Wait for `PortfolioView`, then find investment items in the visual tree and verify count + text.
+
+### H. Project list count not validated at UI level
+
+After deploy, `myProjectsVm.HasProjects` is checked but the actual number of rendered project cards is never verified.
+
+**Suggestion**: Count `MyProjectCard` (or equivalent) controls in the visual tree.
+
+### I. Missing text content assertions on success screens
+
+| Where | What's missing |
+|---|---|
+| After wallet creation | Wallet name/label text on WalletCard never verified |
+| After send-to-self | Transaction amount in success panel never verified |
+| After deploy | Project name in success screen never verified |
+| After invest | Investment amount in success screen never verified |
+| After recovery | Recovery amount in success modal never verified |
+
+### J. No error state assertions on happy-path tests
+
+Happy-path tests never assert that error controls are **not** visible. If an error banner accidentally shows alongside a success, no test catches it.
+
+**Suggestion**: After success states, assert `ErrorMessage` is null AND the error banner control is not visible.
+
+---
+
+## 5. AutomationId Gaps (Need Adding to AXAML)
+
+These views currently lack AutomationIds needed by tests:
+
+| View | What needs AutomationId |
+|---|---|
+| `FundsView.axaml` | Total balance TextBlock |
+| `ShellView.axaml` | Header available/invested balance TextBlocks, nav items |
+| `CreateProjectView.axaml` (wizard) | Step panels (1-6) |
+| `DeployFlowOverlay.axaml` | All panels: WalletSelector, Deploying, Success. Status text, project name in success |
+| `MyProjectsView.axaml` | Project list container, empty state |
+| `PortfolioView.axaml` | Investment list container, empty state, investment cards |
+| `FundersView.axaml` | Signature request list, filter buttons |
+| `WalletCard` | Balance text display |
+| `ManageProjectContentView.axaml` | Stage list, available balance |
+
+---
+
+## 6. Summary of Priorities
+
+| Priority | Improvement | Impact |
+|---|---|---|
+| **High** | Add AutomationIds to balance TextBlocks, wizard steps, deploy/invest success, section root panels | Enables all other UI assertions |
+| **High** | Add UI panel visibility checks after navigation | Catches broken nav/binding |
+| **High** | Read balance from UI TextBlock instead of VM property | Catches binding regressions |
+| **High** | Add text content assertions to success screens | Catches display regressions |
+| **Medium** | Add justifying comments to unjustified SDK calls | Guideline compliance |
+| **Medium** | Convert InvestModalsViewFixesTest to include UI assertions | Currently VM-only |
+| **Medium** | Use existing `ClickApproveSignatureAsync` helper in InvestAndRecoverTest | Consistency |
+| **Low** | Replace `NavigateToSection` VM call with UI sidebar click | Requires nav AutomationIds |
+| **Low** | Extract duplicated wizard/deploy/invest code from Multi* tests into TestHelpers | Code dedup |

--- a/src/design/App.Test.Integration/WalletImportAndProjectScanTest.cs
+++ b/src/design/App.Test.Integration/WalletImportAndProjectScanTest.cs
@@ -124,9 +124,7 @@ public class WalletImportAndProjectScanTest
         string runId)
     {
         // ── Step 1: Create wallet and capture seed words ──
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         Log(profileName, "Creating wallet via Generate flow and capturing seed words...");
         var seedWords = await CreateWalletAndCaptureSeed(window, profileName);
@@ -151,9 +149,7 @@ public class WalletImportAndProjectScanTest
         SetPasswordProvider(profileName);
 
         // ── Step 4: Create and deploy a project ──
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = window.GetMyProjectsViewModel();
         myProjectsVm.Should().NotBeNull();
@@ -270,9 +266,7 @@ public class WalletImportAndProjectScanTest
         CreatorState creatorState)
     {
         // ── Step 1: Import wallet from seed words ──
-        window.NavigateToSection("Funds");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("Funds");
 
         Log(profileName, "Importing wallet from creator's seed words...");
         await ImportWalletViaSeedWords(window, profileName, creatorState.SeedWords);
@@ -314,9 +308,7 @@ public class WalletImportAndProjectScanTest
             "Imported wallet should discover on-chain UTXOs and show non-zero balance");
 
         // ── Step 4: Navigate to My Projects — should be empty before scan ──
-        window.NavigateToSection("My Projects");
-        await Task.Delay(500);
-        Dispatcher.UIThread.RunJobs();
+        await window.NavigateToSectionAndVerify("My Projects");
 
         var myProjectsVm = window.GetMyProjectsViewModel();
         myProjectsVm.Should().NotBeNull();

--- a/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml
@@ -12,7 +12,7 @@
         <fp:FindProjectsViewModel />
     </Design.DataContext>
 
-    <Panel>
+    <Panel AutomationProperties.AutomationId="FindProjectsRootPanel">
         <!-- ═══════════════════════════════════════════════════════ -->
         <!-- INVEST PAGE: shown when InvestPageViewModel != null     -->
         <!-- Third drill-down: grid → detail → invest                -->

--- a/src/design/App/UI/Sections/Funders/FundersView.axaml
+++ b/src/design/App/UI/Sections/Funders/FundersView.axaml
@@ -43,7 +43,7 @@
         </Style>
     </UserControl.Styles>
 
-    <Panel>
+    <Panel AutomationProperties.AutomationId="FundersRootPanel">
         <!-- ═══════════════════════════════════════════════════════ -->
         <!-- EMPTY STATE: shown when HasFunders = false              -->
         <!-- Vue: Users icon, "No Funders Yet", description          -->

--- a/src/design/App/UI/Sections/Funds/FundsView.axaml
+++ b/src/design/App/UI/Sections/Funds/FundsView.axaml
@@ -106,6 +106,7 @@
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal" Spacing="4">
                                             <TextBlock Text="{Binding TotalBalance}"
+                                                       AutomationProperties.AutomationId="FundsTotalBalanceText"
                                                        FontSize="20" FontWeight="Bold"
                                                        Foreground="{DynamicResource StatsDetailValue}" />
                                             <TextBlock Text="{Binding CurrencySymbol}"

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectView.axaml
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectView.axaml
@@ -543,22 +543,28 @@
                         </Border>
 
                         <!-- Step 1: Project Type Selection -->
-                        <steps:CreateProjectStep1View Name="Step1View" IsVisible="{Binding IsStep1}" />
+                        <steps:CreateProjectStep1View Name="Step1View" IsVisible="{Binding IsStep1}"
+                                                      AutomationProperties.AutomationId="CreateProjectStep1" />
 
                         <!-- Step 2: Project Profile -->
-                        <steps:CreateProjectStep2View Name="Step2View" IsVisible="{Binding IsStep2}" />
+                        <steps:CreateProjectStep2View Name="Step2View" IsVisible="{Binding IsStep2}"
+                                                      AutomationProperties.AutomationId="CreateProjectStep2" />
 
                         <!-- Step 3: Project Images -->
-                        <steps:CreateProjectStep3View Name="Step3View" IsVisible="{Binding IsStep3}" />
+                        <steps:CreateProjectStep3View Name="Step3View" IsVisible="{Binding IsStep3}"
+                                                      AutomationProperties.AutomationId="CreateProjectStep3" />
 
                         <!-- Step 4: Funding Configuration -->
-                        <steps:CreateProjectStep4View Name="Step4View" IsVisible="{Binding IsStep4}" />
+                        <steps:CreateProjectStep4View Name="Step4View" IsVisible="{Binding IsStep4}"
+                                                      AutomationProperties.AutomationId="CreateProjectStep4" />
 
                         <!-- Step 5: Stages / Payouts -->
-                        <steps:CreateProjectStep5View Name="Step5View" IsVisible="{Binding IsStep5Form}" />
+                        <steps:CreateProjectStep5View Name="Step5View" IsVisible="{Binding IsStep5Form}"
+                                                      AutomationProperties.AutomationId="CreateProjectStep5" />
 
                         <!-- Step 6: Review & Deploy -->
-                        <steps:CreateProjectStep6View Name="Step6View" IsVisible="{Binding IsStep6}" />
+                        <steps:CreateProjectStep6View Name="Step6View" IsVisible="{Binding IsStep6}"
+                                                      AutomationProperties.AutomationId="CreateProjectStep6" />
 
                     </StackPanel>
                     </ScrollViewer>

--- a/src/design/App/UI/Sections/MyProjects/Deploy/DeployFlowOverlay.axaml
+++ b/src/design/App/UI/Sections/MyProjects/Deploy/DeployFlowOverlay.axaml
@@ -45,6 +45,7 @@
         <!-- rounded-2xl shadow-2xl max-w-md -->
         <!-- ════════════════════════════════════════════════════════════ -->
         <Border IsVisible="{Binding IsWalletSelector}"
+                AutomationProperties.AutomationId="DeployWalletSelectorPanel"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="448" MaxWidth="480"
                 CornerRadius="16"
@@ -251,6 +252,7 @@
         <!-- rounded-2xl shadow-2xl max-w-md, p-6                       -->
         <!-- ════════════════════════════════════════════════════════════ -->
         <Border IsVisible="{Binding IsPayFee}"
+                AutomationProperties.AutomationId="DeployPayFeePanel"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="448" MaxWidth="480"
                 CornerRadius="16"
@@ -414,6 +416,7 @@
         <!-- rounded-2xl shadow-2xl max-w-md p-8                        -->
         <!-- ════════════════════════════════════════════════════════════ -->
         <Border IsVisible="{Binding IsSuccess}"
+                AutomationProperties.AutomationId="DeploySuccessPanel"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="448" MaxWidth="480"
                 CornerRadius="16"
@@ -443,6 +446,7 @@
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center"
                             Spacing="8" Margin="0,0,0,12">
                     <TextBlock Text="{Binding ProjectName}"
+                               AutomationProperties.AutomationId="DeploySuccessProjectName"
                                FontSize="28" FontWeight="Bold"
                                Foreground="{DynamicResource TextStrong}" />
                     <TextBlock Text="Deployed!"

--- a/src/design/App/UI/Sections/MyProjects/MyProjectsView.axaml
+++ b/src/design/App/UI/Sections/MyProjects/MyProjectsView.axaml
@@ -12,7 +12,7 @@
         <mp:MyProjectsViewModel />
     </Design.DataContext>
 
-    <Panel>
+    <Panel AutomationProperties.AutomationId="MyProjectsRootPanel">
         <!-- ═══ EMPTY STATE (no projects, wizard not open) ═══ -->
         <!--
             Vue: Centered layout with Angor logo, "WELCOME TO ANGOR FOUNDER HUB",

--- a/src/design/App/UI/Sections/Portfolio/PortfolioView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioView.axaml
@@ -20,7 +20,7 @@
         </Style>
     </UserControl.Styles>
 
-    <Panel>
+    <Panel AutomationProperties.AutomationId="PortfolioRootPanel">
         <!-- ═══════════════════════════════════════════════════════ -->
         <!-- EMPTY STATE: shown when HasInvestments = false          -->
         <!-- Vue: "FUNDED" title, "You haven't funded any projects   -->

--- a/src/design/App/UI/Sections/Settings/SettingsView.axaml
+++ b/src/design/App/UI/Sections/Settings/SettingsView.axaml
@@ -52,7 +52,7 @@
         </Style>
     </UserControl.Styles>
 
-    <Panel>
+    <Panel AutomationProperties.AutomationId="SettingsRootPanel">
         <controls:ScrollableView ContentPadding="24,24,24,24">
             <StackPanel Spacing="24">
 

--- a/src/design/App/UI/Shared/Controls/WalletCard.axaml
+++ b/src/design/App/UI/Shared/Controls/WalletCard.axaml
@@ -65,6 +65,7 @@
                                            TextTrimming="CharacterEllipsis" />
                                 <TextBlock Grid.Column="1"
                                            Text="{TemplateBinding Balance}"
+                                           AutomationProperties.AutomationId="WalletCardBalanceText"
                                            FontSize="15"
                                            FontWeight="SemiBold"
                                            Foreground="{DynamicResource TextStrong}"

--- a/src/design/App/UI/Shell/ShellView.axaml
+++ b/src/design/App/UI/Shell/ShellView.axaml
@@ -84,13 +84,15 @@
                     <TextBlock Text="{Binding ProfileName}" FontSize="12" Foreground="White" />
                 </Border>
                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Right" Spacing="16" Orientation="Horizontal">
-                    <TextBlock VerticalAlignment="Center">
+                    <TextBlock VerticalAlignment="Center"
+                             AutomationProperties.AutomationId="ShellInvestedBalanceText">
                         <TextBlock.Inlines>
                             <Run Classes="Thin">Invested:</Run>
                             <Run Classes="Label" Text="{Binding InvestedBalanceDisplay}" />
                         </TextBlock.Inlines>
                     </TextBlock>
-                    <TextBlock VerticalAlignment="Center">
+                    <TextBlock VerticalAlignment="Center"
+                             AutomationProperties.AutomationId="ShellAvailableBalanceText">
                         <TextBlock.Inlines>
                             <Run Classes="Thin">Available:</Run>
                             <Run Classes="Label" Text="{Binding AvailableBalanceDisplay}" />


### PR DESCRIPTION
## Summary
- Replace ~55 raw `NavigateToSection` calls with `NavigateToSectionAndVerify` across 8 test files, ensuring the target section's root panel appears after every navigation
- Add 19 AutomationIds to 10 AXAML files (balance TextBlocks, section root panels, wizard steps, deploy flow panels)
- Add UI assertions for `FindProjectsView` and `InvestPageView` in `InvestModalsViewFixesTest`
- Add justifying comments to all direct SDK/DI resolve calls across 7 test files
- Add `TEST_ANALYSIS.md` documenting the full audit with findings and recommendations

## Files changed

### Test files (navigation verification + comments)
- `MultiFundClaimAndRecoverTest.cs` - 9 navigations verified
- `MultiInvestClaimAndRecoverTest.cs` - 10 navigations verified
- `MultiFundReleaseUnfundedAndClaimTest.cs` - 9 navigations verified
- `MultiInvestReleaseUnfundedAndClaimTest.cs` - 9 navigations verified
- `FundAndRecoverTest.cs` - 7 navigations verified
- `WalletImportAndProjectScanTest.cs` - 4 navigations verified
- `InvestmentCancellationTest.cs` - 6 navigations verified
- `InvestModalsViewFixesTest.cs` - 1 navigation + 2 UI assertions
- `SendToSelfTest.cs` - previously updated
- `CreateProjectTest.cs` - previously updated
- `InvestAndRecoverTest.cs` - previously updated

### Test helpers
- `TestHelpers.cs` - `NavigateToSectionAndVerify`, `NavigateToSettingsAndVerify`, `GetFundsTotalBalanceFromUi`, `GetWalletCardBalanceFromUi`

### AXAML files with AutomationIds
- `FundsView.axaml`, `ShellView.axaml`, `CreateProjectView.axaml`, `DeployFlowOverlay.axaml`, `MyProjectsView.axaml`, `PortfolioView.axaml`, `FundersView.axaml`, `FindProjectsView.axaml`, `SettingsView.axaml`, `WalletCard.axaml`

## Build
0 errors, only pre-existing warnings (CS8603 nullable, NU1507 package source).
