### PR TITLE
Fix InvestModalsViewFixesTest timing: accept any valid progress text

### DIFF
--- a/src/design/App.Test.Integration/InvestModalsViewFixesTest.cs
+++ b/src/design/App.Test.Integration/InvestModalsViewFixesTest.cs
@@ -87,7 +87,11 @@ public class InvestModalsViewFixesTest
         vm.CurrentScreen.Should().Be(InvestScreen.Invoice, "ShowInvoice advances to the Invoice screen");
         vm.SelectedNetworkTab.Should().Be(NetworkTab.OnChain, "On-Chain is the default tab");
         vm.IsProcessing.Should().BeTrue("ShowInvoice flips IsProcessing synchronously so the spinner shows immediately");
-        vm.PaymentStatusText.Should().Be("Generating invoice address...",
+        // ShowInvoice sets "Generating invoice address..." but the reactive command fires immediately
+        // and may overwrite it synchronously (e.g. "Creating wallet..." when no wallet exists).
+        // Assert that there IS progress feedback, not a specific exact string.
+        var validOnChainProgress = new[] { "Generating invoice address...", "Creating wallet...", "Refreshing wallet..." };
+        vm.PaymentStatusText.Should().BeOneOf(validOnChainProgress,
             "synchronous status text gives the user immediate feedback instead of a frozen placeholder");
         vm.InvoiceString.Should().Be(vm.PaymentStatusText,
             "InvoiceString now follows the live PaymentStatusText — fixes the 'stuck on Generating address' bug");
@@ -120,9 +124,10 @@ public class InvestModalsViewFixesTest
         vm.IsProcessing.Should().BeTrue("Lightning tap must flip IsProcessing synchronously");
         vm.IsGeneratingLightningInvoice.Should().BeTrue(
             "Lightning tap must flip the spinner flag synchronously — fixes 'nothing happens when I tap'");
-        vm.PaymentStatusText.Should().Be("Creating Lightning invoice...",
+        var validLightningProgress = new[] { "Creating Lightning invoice...", "Creating wallet...", "Refreshing wallet..." };
+        vm.PaymentStatusText.Should().BeOneOf(validLightningProgress,
             "synchronous Lightning status text replaces the stale 'Tap Lightning to generate' placeholder");
-        vm.InvoiceString.Should().Be("Creating Lightning invoice...",
+        vm.InvoiceString.Should().BeOneOf(validLightningProgress,
             "InvoiceString reflects Lightning progress");
 
         // ── Fix 5: tab-driven label/icon flip ──


### PR DESCRIPTION
## Summary

Fix flaky InvestModalsViewFixesTest that always fails because PaymentStatusText assertions expect exact strings that get overwritten by the reactive command synchronous preamble.

## Root Cause

ShowInvoice() sets PaymentStatusText then immediately fires PayViaInvoice(). The ReactiveCommand runs synchronously up to its first await - when no wallet exists (clean test profile), EnsureWalletExistsAsync overwrites the text to Creating wallet before the test assertion runs. Same issue on the Lightning tab path.

## Fix

Replace exact string assertions with BeOneOf(validProgressStrings) that accept any legitimate progress message. The test still verifies the core invariant: the user sees immediate feedback (not a frozen placeholder).