### PR TITLE
fix: add spinner feedback to cancel/refresh buttons and navigate back after cancel

### DIFF
--- a/src/design/App.Test.Integration/InvestmentCancellationTest.cs
+++ b/src/design/App.Test.Integration/InvestmentCancellationTest.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using FluentAssertions;
@@ -237,14 +238,71 @@ public class InvestmentCancellationTest
         var balanceBeforeCancel = fundsVm?.TotalBalance ?? "0.0000";
         Log(profileName, $"Balance before cancellation: {balanceBeforeCancel}");
 
+        // Record investment count before cancel
+        var investmentCountBefore = portfolioVm.Investments.Count;
+
         // ── Step 2: Cancel the pending investment (before founder approval) ──
         Log(profileName, "Cancelling pending investment (before founder approval)...");
-        await window.ClickInvestmentDetailActionAsync(portfolioVm, pendingInvestment, "CancelInvestmentStep1Button");
+
+        // Open investment detail and verify UI elements before clicking cancel
+        await window.NavigateToSectionAndVerify("Funded");
+        portfolioVm.OpenInvestmentDetail(pendingInvestment);
         Dispatcher.UIThread.RunJobs();
 
+        var detailOpened = await TestHelpers.WaitForCondition(
+            () => ReferenceEquals(portfolioVm.SelectedInvestment, pendingInvestment),
+            TestHelpers.UiTimeout);
+        detailOpened.Should().BeTrue("Investment detail should open");
+
+        // Verify cancel button is visible and enabled before clicking
+        var cancelBtnVisible = await TestHelpers.WaitForCondition(
+            () => window.GetVisualDescendants().OfType<Button>().Any(b => b.IsVisible && b.Name == "CancelInvestmentStep1Button"),
+            TestHelpers.UiTimeout);
+        cancelBtnVisible.Should().BeTrue("CancelInvestmentStep1Button should be visible in Step 1 detail");
+
+        var cancelBtn = window.GetVisualDescendants().OfType<Button>().First(b => b.IsVisible && b.Name == "CancelInvestmentStep1Button");
+        cancelBtn.IsEnabled.Should().BeTrue("Cancel button should be enabled before clicking");
+
+        // Verify spinner is NOT visible before clicking
+        var cancelSpinner = window.FindByName<StackPanel>("CancelStep1BtnSpinner");
+        if (cancelSpinner != null)
+        {
+            cancelSpinner.IsVisible.Should().BeFalse("Cancel spinner should be hidden before clicking");
+        }
+
+        // Click the cancel button
+        cancelBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, cancelBtn));
+        Dispatcher.UIThread.RunJobs();
+
+        // Verify spinner appears during processing (may complete instantly in test)
+        if (pendingInvestment.IsProcessing)
+        {
+            cancelBtn.IsEnabled.Should().BeFalse("Cancel button should be disabled during processing");
+            cancelSpinner = window.FindByName<StackPanel>("CancelStep1BtnSpinner");
+            if (cancelSpinner != null)
+            {
+                cancelSpinner.IsVisible.Should().BeTrue("Cancel spinner should be visible during processing");
+                Log(profileName, "Verified: Cancel spinner visible during processing.");
+            }
+        }
+
+        // Wait for processing to complete (cancel involves Nostr notification, may take time)
+        var actionCompleted = await TestHelpers.WaitForCondition(
+            () => !pendingInvestment.IsProcessing,
+            TimeSpan.FromSeconds(60));
+        actionCompleted.Should().BeTrue("Cancel action should complete");
+
+        // ── Step 2b: Verify cancel removed the investment and closed detail ──
         pendingInvestment.StatusText.Should().Be("Cancelled", "Status should be 'Cancelled' after cancellation");
         pendingInvestment.Status.Should().Be("Cancelled", "Status field should be 'Cancelled'");
-        Log(profileName, $"Investment cancelled. Status='{pendingInvestment.StatusText}'");
+
+        portfolioVm.SelectedInvestment.Should().BeNull("Detail should be closed after cancellation (navigated back to list)");
+        portfolioVm.Investments.Should().NotContain(pendingInvestment,
+            "Cancelled investment should be removed from the Investments collection");
+        portfolioVm.Investments.Count.Should().Be(investmentCountBefore - 1,
+            "Investment count should decrease by one after cancellation");
+
+        Log(profileName, $"Investment cancelled and removed from list. Remaining investments: {portfolioVm.Investments.Count}");
 
         // ── Step 3: Verify funds are released ──
         await VerifyFundsReleasedAsync(window, profileName, balanceBeforeCancel);
@@ -363,14 +421,71 @@ public class InvestmentCancellationTest
         var balanceBeforeCancel = fundsVm?.TotalBalance ?? "0.0000";
         Log(profileName, $"Balance before cancellation: {balanceBeforeCancel}");
 
+        // Record investment count before cancel
+        var investmentCountBefore = portfolioVm.Investments.Count;
+
         // Cancel the approved investment
         Log(profileName, "Cancelling approved investment (after founder approval)...");
-        await window.ClickInvestmentDetailActionAsync(portfolioVm, approvedInvestment, "CancelInvestmentButton");
+
+        // Open investment detail and verify UI elements before clicking cancel
+        await window.NavigateToSectionAndVerify("Funded");
+        portfolioVm.OpenInvestmentDetail(approvedInvestment);
         Dispatcher.UIThread.RunJobs();
 
+        var detailOpened = await TestHelpers.WaitForCondition(
+            () => ReferenceEquals(portfolioVm.SelectedInvestment, approvedInvestment),
+            TestHelpers.UiTimeout);
+        detailOpened.Should().BeTrue("Investment detail should open");
+
+        // Verify cancel button is visible and enabled (Step 2 uses CancelInvestmentButton)
+        var cancelBtnVisible = await TestHelpers.WaitForCondition(
+            () => window.GetVisualDescendants().OfType<Button>().Any(b => b.IsVisible && b.Name == "CancelInvestmentButton"),
+            TestHelpers.UiTimeout);
+        cancelBtnVisible.Should().BeTrue("CancelInvestmentButton should be visible in Step 2 detail");
+
+        var cancelBtn = window.GetVisualDescendants().OfType<Button>().First(b => b.IsVisible && b.Name == "CancelInvestmentButton");
+        cancelBtn.IsEnabled.Should().BeTrue("Cancel button should be enabled before clicking");
+
+        // Verify spinner is NOT visible before clicking
+        var cancelSpinner = window.FindByName<StackPanel>("CancelBtnSpinner");
+        if (cancelSpinner != null)
+        {
+            cancelSpinner.IsVisible.Should().BeFalse("Cancel spinner should be hidden before clicking");
+        }
+
+        // Click the cancel button
+        cancelBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, cancelBtn));
+        Dispatcher.UIThread.RunJobs();
+
+        // Verify spinner appears during processing (may complete instantly in test)
+        if (approvedInvestment.IsProcessing)
+        {
+            cancelBtn.IsEnabled.Should().BeFalse("Cancel button should be disabled during processing");
+            cancelSpinner = window.FindByName<StackPanel>("CancelBtnSpinner");
+            if (cancelSpinner != null)
+            {
+                cancelSpinner.IsVisible.Should().BeTrue("Cancel spinner should be visible during processing");
+                Log(profileName, "Verified: Cancel spinner visible during processing.");
+            }
+        }
+
+        // Wait for processing to complete (cancel involves Nostr notification, may take time)
+        var actionCompleted = await TestHelpers.WaitForCondition(
+            () => !approvedInvestment.IsProcessing,
+            TimeSpan.FromSeconds(60));
+        actionCompleted.Should().BeTrue("Cancel action should complete");
+
+        // Verify cancel removed the investment and closed detail
         approvedInvestment.StatusText.Should().Be("Cancelled", "Status should be 'Cancelled' after cancellation");
         approvedInvestment.Status.Should().Be("Cancelled", "Status field should be 'Cancelled'");
-        Log(profileName, $"Investment cancelled after approval. Status='{approvedInvestment.StatusText}'");
+
+        portfolioVm.SelectedInvestment.Should().BeNull("Detail should be closed after cancellation (navigated back to list)");
+        portfolioVm.Investments.Should().NotContain(approvedInvestment,
+            "Cancelled investment should be removed from the Investments collection");
+        portfolioVm.Investments.Count.Should().Be(investmentCountBefore - 1,
+            "Investment count should decrease by one after cancellation");
+
+        Log(profileName, $"Investment cancelled after approval and removed. Remaining investments: {portfolioVm.Investments.Count}");
 
         // Verify funds are released
         await VerifyFundsReleasedAsync(window, profileName, balanceBeforeCancel);

--- a/src/design/App.Test.Integration/InvestmentCancellationTest.cs
+++ b/src/design/App.Test.Integration/InvestmentCancellationTest.cs
@@ -303,8 +303,13 @@ public class InvestmentCancellationTest
             "Investment count should decrease by one after cancellation");
 
         Log(profileName, $"Investment cancelled and removed from list. Remaining investments: {portfolioVm.Investments.Count}");
+        portfolioVm.HasInvestments.Should().Be(portfolioVm.Investments.Count > 0,
+            "HasInvestments should reflect the updated collection count");
 
-        // ── Step 3: Verify funds are released ──
+        // ── Step 3: Verify project is investable again on Find Projects ──
+        await VerifyProjectIsInvestableAsync(window, profileName, project);
+
+        // ── Step 4: Verify funds are released ──
         await VerifyFundsReleasedAsync(window, profileName, balanceBeforeCancel);
 
         Log(profileName, "Cancel-before-approval flow validated.");
@@ -486,6 +491,11 @@ public class InvestmentCancellationTest
             "Investment count should decrease by one after cancellation");
 
         Log(profileName, $"Investment cancelled after approval and removed. Remaining investments: {portfolioVm.Investments.Count}");
+        portfolioVm.HasInvestments.Should().Be(portfolioVm.Investments.Count > 0,
+            "HasInvestments should reflect the updated collection count");
+
+        // Verify project is investable again on Find Projects
+        await VerifyProjectIsInvestableAsync(window, profileName, project);
 
         // Verify funds are released
         await VerifyFundsReleasedAsync(window, profileName, balanceBeforeCancel);
@@ -565,6 +575,45 @@ public class InvestmentCancellationTest
 
         balanceAfterCancel.Should().NotBe("0.0000",
             "Balance should be non-zero after cancellation (funds released)");
+    }
+
+    /// <summary>
+    /// Navigate to Find Projects, locate the project, and verify that the invest/fund
+    /// button is available (IsOpenAndNotInvested == true, HasInvested == false).
+    /// This confirms that cancelling an investment correctly unmarks the project
+    /// so the user can invest again.
+    /// </summary>
+    private async Task VerifyProjectIsInvestableAsync(
+        Window window,
+        string profileName,
+        ProjectHandle project)
+    {
+        Log(profileName, "Verifying project is investable again on Find Projects...");
+
+        var foundProject = await FindProjectFromSdkAsync(window, profileName, project);
+
+        foundProject.HasInvested.Should().BeFalse(
+            "HasInvested should be false after cancellation removed the investment from the portfolio");
+        foundProject.IsOpenAndNotInvested.Should().BeTrue(
+            "IsOpenAndNotInvested should be true so the Invest/Fund button is available");
+
+        // Open project detail and verify the InvestButton is visible in the UI
+        var findProjectsVm = window.GetFindProjectsViewModel()!;
+        findProjectsVm.OpenProjectDetail(foundProject);
+        Dispatcher.UIThread.RunJobs();
+        await Task.Delay(300);
+
+        var investBtnVisible = await TestHelpers.WaitForCondition(
+            () => window.FindByName<Avalonia.Controls.Border>("InvestButton") is { IsVisible: true },
+            TestHelpers.UiTimeout);
+        investBtnVisible.Should().BeTrue(
+            "InvestButton should be visible on the project detail after cancellation");
+
+        Log(profileName, "Verified: Invest button is available. Project is investable again.");
+
+        // Close project detail to leave a clean state
+        findProjectsVm.CloseProjectDetail();
+        Dispatcher.UIThread.RunJobs();
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml
@@ -490,22 +490,86 @@
                                         Background="{DynamicResource WaitingBtnBg}"
                                         BorderBrush="{DynamicResource WaitingBtnBorder}"
                                         BorderThickness="1"
-                                        CornerRadius="8">
-                                    <TextBlock Text="Cancel"
-                                               FontSize="14"
-                                               FontWeight="SemiBold"
-                                               Foreground="{DynamicResource WaitingBtnFg}" />
+                                        CornerRadius="8"
+                                        IsEnabled="{Binding !IsProcessing}">
+                                    <Panel>
+                                        <TextBlock Text="Cancel"
+                                                   FontSize="14"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource WaitingBtnFg}"
+                                                   IsVisible="{Binding !IsProcessing}"
+                                                   HorizontalAlignment="Center" />
+                                        <StackPanel Name="CancelStep1BtnSpinner" Orientation="Horizontal" Spacing="6"
+                                                    IsVisible="{Binding IsProcessing}"
+                                                    HorizontalAlignment="Center">
+                                            <i:Icon Value="fa-solid fa-spinner" FontSize="14"
+                                                    Foreground="{DynamicResource WaitingBtnFg}"
+                                                    RenderTransformOrigin="50%,50%">
+                                                <i:Icon.RenderTransform>
+                                                    <RotateTransform />
+                                                </i:Icon.RenderTransform>
+                                                <i:Icon.Styles>
+                                                    <Style Selector="i|Icon[IsVisible=True]">
+                                                        <Style.Animations>
+                                                            <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                                <KeyFrame Cue="0%">
+                                                                    <Setter Property="RotateTransform.Angle" Value="0" />
+                                                                </KeyFrame>
+                                                                <KeyFrame Cue="100%">
+                                                                    <Setter Property="RotateTransform.Angle" Value="360" />
+                                                                </KeyFrame>
+                                                            </Animation>
+                                                        </Style.Animations>
+                                                    </Style>
+                                                </i:Icon.Styles>
+                                            </i:Icon>
+                                            <TextBlock Text="Cancelling..." FontSize="14" FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource WaitingBtnFg}" />
+                                        </StackPanel>
+                                    </Panel>
                                 </Button>
                                 <Button Name="RefreshInvestmentButton"
                                         Padding="14,8"
                                         Background="{DynamicResource WaitingBtnBg}"
                                         BorderBrush="{DynamicResource WaitingBtnBorder}"
                                         BorderThickness="1"
-                                        CornerRadius="8">
-                                    <TextBlock Text="Refresh"
-                                               FontSize="14"
-                                               FontWeight="SemiBold"
-                                               Foreground="{DynamicResource WaitingBtnFg}" />
+                                        CornerRadius="8"
+                                        IsEnabled="{Binding !IsProcessing}">
+                                    <Panel>
+                                        <TextBlock Text="Refresh"
+                                                   FontSize="14"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource WaitingBtnFg}"
+                                                   IsVisible="{Binding !IsProcessing}"
+                                                   HorizontalAlignment="Center" />
+                                        <StackPanel Name="RefreshBtnSpinner" Orientation="Horizontal" Spacing="6"
+                                                    IsVisible="{Binding IsProcessing}"
+                                                    HorizontalAlignment="Center">
+                                            <i:Icon Value="fa-solid fa-spinner" FontSize="14"
+                                                    Foreground="{DynamicResource WaitingBtnFg}"
+                                                    RenderTransformOrigin="50%,50%">
+                                                <i:Icon.RenderTransform>
+                                                    <RotateTransform />
+                                                </i:Icon.RenderTransform>
+                                                <i:Icon.Styles>
+                                                    <Style Selector="i|Icon[IsVisible=True]">
+                                                        <Style.Animations>
+                                                            <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                                <KeyFrame Cue="0%">
+                                                                    <Setter Property="RotateTransform.Angle" Value="0" />
+                                                                </KeyFrame>
+                                                                <KeyFrame Cue="100%">
+                                                                    <Setter Property="RotateTransform.Angle" Value="360" />
+                                                                </KeyFrame>
+                                                            </Animation>
+                                                        </Style.Animations>
+                                                    </Style>
+                                                </i:Icon.Styles>
+                                            </i:Icon>
+                                            <TextBlock Text="Refreshing..." FontSize="14" FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource WaitingBtnFg}" />
+                                        </StackPanel>
+                                    </Panel>
                                 </Button>
                                 <Button Padding="14,8"
                                         Background="{DynamicResource WaitingBtnBg}"
@@ -595,11 +659,43 @@
                                             HorizontalContentAlignment="Center"
                                             Padding="20,12"
                                             Background="Transparent"
-                                            CornerRadius="8">
-                                        <TextBlock Text="Cancel"
-                                                   FontSize="14"
-                                                   FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource PreviewCardTitle}" />
+                                            CornerRadius="8"
+                                            IsEnabled="{Binding !IsProcessing}">
+                                        <Panel>
+                                            <TextBlock Text="Cancel"
+                                                       FontSize="14"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource PreviewCardTitle}"
+                                                       IsVisible="{Binding !IsProcessing}"
+                                                       HorizontalAlignment="Center" />
+                                            <StackPanel Name="CancelBtnSpinner" Orientation="Horizontal" Spacing="6"
+                                                        IsVisible="{Binding IsProcessing}"
+                                                        HorizontalAlignment="Center">
+                                                <i:Icon Value="fa-solid fa-spinner" FontSize="14"
+                                                        Foreground="{DynamicResource PreviewCardTitle}"
+                                                        RenderTransformOrigin="50%,50%">
+                                                    <i:Icon.RenderTransform>
+                                                        <RotateTransform />
+                                                    </i:Icon.RenderTransform>
+                                                    <i:Icon.Styles>
+                                                        <Style Selector="i|Icon[IsVisible=True]">
+                                                            <Style.Animations>
+                                                                <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                                    <KeyFrame Cue="0%">
+                                                                        <Setter Property="RotateTransform.Angle" Value="0" />
+                                                                    </KeyFrame>
+                                                                    <KeyFrame Cue="100%">
+                                                                        <Setter Property="RotateTransform.Angle" Value="360" />
+                                                                    </KeyFrame>
+                                                                </Animation>
+                                                            </Style.Animations>
+                                                        </Style>
+                                                    </i:Icon.Styles>
+                                                </i:Icon>
+                                                <TextBlock Text="Cancelling..." FontSize="14" FontWeight="SemiBold"
+                                                           Foreground="{DynamicResource PreviewCardTitle}" />
+                                            </StackPanel>
+                                        </Panel>
                                     </Button>
                                 </Border>
                             </StackPanel>

--- a/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml.cs
+++ b/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml.cs
@@ -336,6 +336,8 @@ public partial class InvestmentDetailView : UserControl
             await portfolioVm.CancelInvestmentAsync(investVm);
         }
 
+        // Always reset IsProcessing — even on success the VM may still be observed by tests
+        // or pending bindings. On success the detail is already closed (SelectedInvestment=null).
         investVm.IsProcessing = false;
     }
 

--- a/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
@@ -1127,6 +1127,11 @@ public partial class PortfolioViewModel : ReactiveObject
                 investment.StatusClass = "recovered";
                 investment.StatusPill2 = "Cancelled";
                 investment.Status = "Cancelled";
+
+                // Remove the cancelled investment and navigate back to list
+                Investments.Remove(investment);
+                SelectedInvestment = null;
+                HasInvestments = Investments.Count > 0;
                 return true;
             }
 


### PR DESCRIPTION
## Summary

- Cancel (Step 1 and Step 2) and Refresh buttons now show a spinning indicator and are disabled while processing
- After a successful cancel, the investment is removed from the `Investments` collection and the detail view closes (navigates back to portfolio list)
- Integration test updated to verify actual UI controls: button enabled/disabled state, spinner visibility, collection removal after cancel

## Changes

- **InvestmentDetailView.axaml** — Added spinner markup (fa-spinner with rotating animation + status text) to all three action buttons, toggled by `IsProcessing`
- **InvestmentDetailView.axaml.cs** — Minor cleanup ensuring `IsProcessing` always resets
- **PortfolioViewModel.cs** — After successful cancel: removes investment from `Investments`, sets `SelectedInvestment = null`, updates `HasInvestments`
- **InvestmentCancellationTest.cs** — Cancel phases now verify UI controls (find buttons by name, check `IsEnabled`, check spinner visibility, verify collection removal)
