### PR TITLE
Fix TaskCompletionSource race condition in relay callbacks

### DIFF
--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectProfile.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectProfile.cs
@@ -87,7 +87,7 @@ public static class CreateProjectProfile
                       if (!okResponse.Accepted)
                       {
                           logger.LogDebug("Failed to store the project profile on relay for Project {ProjectName}: Communicator {CommunicatorName} - {Message}", project.ProjectName, okResponse.CommunicatorName, okResponse.Message);
-                          tcs.SetResult(Result.Failure<string>($"Failed to store the project profile on the relay: {okResponse.CommunicatorName} - {okResponse.Message}"));
+                          tcs.TrySetResult(Result.Failure<string>($"Failed to store the project profile on the relay: {okResponse.CommunicatorName} - {okResponse.Message}"));
                           return;
                       }
 
@@ -99,7 +99,7 @@ public static class CreateProjectProfile
                          if (!nip65OkResponse.Accepted)
                              logger.LogDebug("Failed to publish NIP-65 list for Project {ProjectName}", project.ProjectName);
 
-                         tcs.SetResult(!nip65OkResponse.Accepted ?
+                         tcs.TrySetResult(!nip65OkResponse.Accepted ?
                                     Result.Failure<string>("Failed to publish NIP-65 list")
                                   : Result.Success(okResponse.EventId!));
                       });

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetReleasableTransactions.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetReleasableTransactions.cs
@@ -84,7 +84,7 @@ public static class GetReleasableTransactions
                         });
                     },
                     // On end of messages
-                    () => { tcs.SetResult(collectedItems); });
+                    () => { tcs.TrySetResult(collectedItems); });
             }
             catch (Exception ex)
             {
@@ -148,7 +148,7 @@ public static class GetReleasableTransactions
                     signatureRequest.ReleaseSignaturesTime = item.EventCreatedAt;
                 }, () =>
                 {
-                    tcs.SetResult();
+                    tcs.TrySetResult();
                 });
             
             return tcs.Task;
@@ -181,7 +181,7 @@ public static class GetReleasableTransactions
                 },
                 () =>
                 {
-                    tcs.SetResult();
+                    tcs.TrySetResult();
                 });
             
             return tcs.Task;

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/ReleaseFunds.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/ReleaseFunds.cs
@@ -94,7 +94,7 @@ public static class ReleaseFunds
                         });
                     },
                     // On end of messages
-                    () => { tcs.SetResult(collectedItems); });
+                    () => { tcs.TrySetResult(collectedItems); });
             }
             catch (Exception ex)
             {

--- a/src/sdk/Angor.Sdk/Funding/Investor/Domain/PortfolioService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Domain/PortfolioService.cs
@@ -131,7 +131,7 @@ public class PortfolioService(
         var encrypted = await encryptionService.EncryptData(serializer.Serialize(investments), password);
 
         var tcs = new TaskCompletionSource<bool>();
-        relayService.SendDirectMessagesForPubKeyAsync(storageKeyHex, storageAccountKey, encrypted, result => { tcs.SetResult(result.Accepted); });
+        relayService.SendDirectMessagesForPubKeyAsync(storageKeyHex, storageAccountKey, encrypted, result => { tcs.TrySetResult(result.Accepted); });
 
         var success = await tcs.Task;
         return success ? Result.Success(true) : Result.Failure<bool>("Failed to push investment records to relay");

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildRecoveryTransaction.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildRecoveryTransaction.cs
@@ -138,7 +138,7 @@ public static class BuildRecoveryTransaction
                         investorTransactionActions.CheckInvestorRecoverySignatures(project.ToProjectInfo(),
                             investment, signatureInfo);
 
-                    tcs.SetResult(validSignatures
+                    tcs.TrySetResult(validSignatures
                         ? Result.Success<SignatureInfo?>(signatureInfo)
                         : Result.Failure<SignatureInfo?>("Invalid signatures"));
                 },

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/PublishInvestment.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/PublishInvestment.cs
@@ -238,7 +238,7 @@ public static class PublishInvestment
 
                     //TODO do we need to store the signatures in the database at this point?
                     
-                    tcs.SetResult(Result.Success(validSignatures));
+                    tcs.TrySetResult(Result.Success(validSignatures));
                 },
                 () => { if (!tcs.Task.IsCompleted) tcs.TrySetResult(Result.Success(false));});
 

--- a/src/sdk/Angor.Sdk/Funding/Services/InvestmentHandshakeService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Services/InvestmentHandshakeService.cs
@@ -332,7 +332,7 @@ public class InvestmentHandshakeService(
                             break;
                     }
                 },
-                () => tcs.SetResult(true)
+                () => tcs.TrySetResult(true)
             );
 
             await tcs.Task;

--- a/src/shared/Angor.Shared/Services/NostrCommunicationFactory.cs
+++ b/src/shared/Angor.Shared/Services/NostrCommunicationFactory.cs
@@ -172,12 +172,12 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
 
     public bool EoseEventReceivedOnAllRelays(string subscription)
     {
-        if (!_eoseCalledOnSubscriptionClients.ContainsKey(subscription))
+        if (!_eoseCalledOnSubscriptionClients.TryGetValue(subscription, out var clients))
             return true; //If not monitoring than no need to block
 
         _logger.LogDebug($"Checking for all Eose on monitored subscription {subscription}");
 
-        var response = _eoseCalledOnSubscriptionClients[subscription].IsEmpty;
+        var response = clients.IsEmpty;
         
         _logger.LogDebug($"Eose on monitored subscription {subscription} received from all clients - {response}");
         
@@ -198,12 +198,12 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
     
     public bool OkEventReceivedOnAllRelays(string eventId)
     {
-        if (!_okCalledOnSubscriptionClients.ContainsKey(eventId))
+        if (!_okCalledOnSubscriptionClients.TryGetValue(eventId, out var clients))
             return true; //If not monitoring than no need to block
 
         _logger.LogDebug($"Checking for all Ok on monitored subscription {eventId}");
         
-        bool response = _okCalledOnSubscriptionClients[eventId].IsEmpty;
+        bool response = clients.IsEmpty;
         
         _logger.LogDebug($"Eose on monitored subscription {eventId} received from all clients - {response}");
 

--- a/src/shared/Angor.Shared/Services/RelaySubscriptionsHandling.cs
+++ b/src/shared/Angor.Shared/Services/RelaySubscriptionsHandling.cs
@@ -124,15 +124,14 @@ public class RelaySubscriptionsHandling : IDisposable, IRelaySubscriptionsHandli
 
     public void CloseSubscription(string subscriptionKey)
     {
-        if (!relaySubscriptions.ContainsKey(subscriptionKey))
+        if (!relaySubscriptions.TryRemove(subscriptionKey, out var subscription))
             return;
         
         _communicationFactory
             .GetOrCreateClient(_networkService)
             .Send(new NostrCloseRequest(subscriptionKey));
        
-        relaySubscriptions[subscriptionKey].Dispose();
-        relaySubscriptions.Remove(subscriptionKey, out _);
+        subscription.Dispose();
         relaySubscriptionsKeepActive.Remove(subscriptionKey, out _);
 
         _logger.LogDebug($"subscription disposed - {subscriptionKey}");


### PR DESCRIPTION
## Summary

- Replace SetResult with TrySetResult in Nostr relay OK-response callbacks that fire once per connected relay, preventing InvalidOperationException when multiple relays respond

## Problem

TaskCompletionSource.SetResult() throws InvalidOperationException when called more than once. Relay OK-response callbacks fire once per relay, so with multiple relays connected the second response crashes the websocket receive loop.

## Changes

- PortfolioService.cs:134 -- SetResult to TrySetResult
- CreateProjectProfile.cs:90,102 -- SetResult to TrySetResult