### PR TITLE
fix: show refresh/scan buttons on empty state in Funders and My Projects

### DIFF
--- a/src/design/App/UI/Sections/Funders/FundersView.axaml
+++ b/src/design/App/UI/Sections/Funders/FundersView.axaml
@@ -48,12 +48,41 @@
         <!-- EMPTY STATE: shown when HasFunders = false              -->
         <!-- Vue: Users icon, "No Funders Yet", description          -->
         <!-- ═══════════════════════════════════════════════════════ -->
-        <controls:EmptyState Title="No Funders Yet"
-                             Description="When investors fund your projects, they'll appear here. You can review and approve funding requests from this page."
-                             HasButton="False"
-                             UseCustomIcon="True"
-                             IconData="{StaticResource NavIconUsers}"
-                             IsVisible="{Binding !HasFunders}" />
+        <Panel IsVisible="{Binding !HasFunders}">
+            <controls:EmptyState Title="No Funders Yet"
+                                 Description="When investors fund your projects, they'll appear here. You can review and approve funding requests from this page."
+                                 HasButton="False"
+                                 UseCustomIcon="True"
+                                 IconData="{StaticResource NavIconUsers}" />
+            <!-- Refresh button — visible even when no funders -->
+            <Button Name="EmptyRefreshButton"
+                    AutomationProperties.AutomationId="FundersEmptyRefreshButton"
+                    Classes="Outlined"
+                    Padding="10"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Margin="24"
+                    IsEnabled="{Binding !IsRefreshing}">
+                <i:Icon Value="fa-solid fa-arrows-rotate"
+                        FontSize="16"
+                        Foreground="{DynamicResource TextStrong}">
+                    <i:Icon.Styles>
+                        <Style Selector="i|Icon.Spinning">
+                            <Style.Animations>
+                                <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                    <KeyFrame Cue="0%">
+                                        <Setter Property="RotateTransform.Angle" Value="0" />
+                                    </KeyFrame>
+                                    <KeyFrame Cue="100%">
+                                        <Setter Property="RotateTransform.Angle" Value="360" />
+                                    </KeyFrame>
+                                </Animation>
+                            </Style.Animations>
+                        </Style>
+                    </i:Icon.Styles>
+                </i:Icon>
+            </Button>
+        </Panel>
 
         <!-- ═══════════════════════════════════════════════════════ -->
         <!-- FUNDERS OVERVIEW: shown when HasFunders = true          -->

--- a/src/design/App/UI/Sections/Funders/FundersView.axaml.cs
+++ b/src/design/App/UI/Sections/Funders/FundersView.axaml.cs
@@ -94,6 +94,10 @@ public partial class FundersView : UserControl, ISectionView
               var refreshBtn = this.FindControl<Button>("RefreshButton");
               var icon = refreshBtn?.GetLogicalDescendants().OfType<Projektanker.Icons.Avalonia.Icon>().FirstOrDefault();
               icon?.Classes.Set("Spinning", isRefreshing);
+
+              var emptyRefreshBtn = this.FindControl<Button>("EmptyRefreshButton");
+              var emptyIcon = emptyRefreshBtn?.GetLogicalDescendants().OfType<Projektanker.Icons.Avalonia.Icon>().FirstOrDefault();
+              emptyIcon?.Classes.Set("Spinning", isRefreshing);
           });
         _subscriptions.Add(refreshSub);
 
@@ -152,6 +156,7 @@ public partial class FundersView : UserControl, ISectionView
                 break;
 
             case "RefreshButton":
+            case "EmptyRefreshButton":
                 _ = vm.RefreshAsync();
                 e.Handled = true;
                 break;

--- a/src/design/App/UI/Sections/MyProjects/MyProjectsView.axaml
+++ b/src/design/App/UI/Sections/MyProjects/MyProjectsView.axaml
@@ -25,6 +25,49 @@
                                  DescriptionFontSize="20"
                                  ButtonText="Launch a Project"
                                  HasButton="True" />
+            <!-- Scan button — visible even when no projects -->
+            <Button Name="EmptyScanButton"
+                    Classes="Primary"
+                    Padding="12,8"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Margin="24"
+                    IsEnabled="{Binding !IsLoading}">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <i:Icon Value="fa-solid fa-arrows-rotate"
+                            FontSize="14"
+                            IsVisible="{Binding !IsLoading}"
+                            Foreground="{DynamicResource PrimaryButtonForeground}"
+                            VerticalAlignment="Center" />
+                    <i:Icon Value="fa-solid fa-spinner"
+                            FontSize="14"
+                            IsVisible="{Binding IsLoading}"
+                            Foreground="{DynamicResource PrimaryButtonForeground}"
+                            VerticalAlignment="Center"
+                            RenderTransformOrigin="50%,50%">
+                        <i:Icon.RenderTransform>
+                            <RotateTransform />
+                        </i:Icon.RenderTransform>
+                        <i:Icon.Styles>
+                            <Style Selector="i|Icon[IsVisible=True]">
+                                <Style.Animations>
+                                    <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                        <KeyFrame Cue="0%">
+                                            <Setter Property="RotateTransform.Angle" Value="0" />
+                                        </KeyFrame>
+                                        <KeyFrame Cue="100%">
+                                            <Setter Property="RotateTransform.Angle" Value="360" />
+                                        </KeyFrame>
+                                    </Animation>
+                                </Style.Animations>
+                            </Style>
+                        </i:Icon.Styles>
+                    </i:Icon>
+                    <TextBlock Text="Scan for Projects"
+                               VerticalAlignment="Center"
+                               FontSize="13" FontWeight="SemiBold" />
+                </StackPanel>
+            </Button>
         </Panel>
 
         <!-- ═══ PROJECT LIST (has projects, wizard not open) ═══ -->

--- a/src/design/App/UI/Sections/MyProjects/MyProjectsView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/MyProjectsView.axaml.cs
@@ -375,6 +375,7 @@ public partial class MyProjectsView : UserControl
 
             case "ScanProjectsButton":
             case "MobileScanButton":
+            case "EmptyScanButton":
                 _ = vm.ScanForProjectsAsync();
                 e.Handled = true;
                 return;


### PR DESCRIPTION
## Summary
- Funders: The refresh button is now visible on the empty state (top-right) so users can check for new funding requests even when no funders are listed yet
- My Projects: The Scan for Projects button is now visible on the empty state (top-right) so users can scan for existing projects even before any are loaded locally

Both buttons include the same spinning animation and click handling as their counterparts in the populated views.