### PR TITLE
fix: Nostr relay deadlock prevention with disconnect handler and TCS timeouts

### DIFF
--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectInfo.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectInfo.cs
@@ -72,6 +72,8 @@ public static class CreateProjectInfo
         private async Task<Result<string>> CreateProjectInfoOnNostr(string nostrKeyHex, CreateProjectDto project, ProjectSeedDto founderKeys)
         {
             var tsc = new TaskCompletionSource<Result<string>>();
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => { tsc.TrySetResult(Result.Failure<string>("Nostr project info creation timed out after 30s")); cts.Dispose(); });
 
             // Create base ProjectInfo with common properties
             var projectInfo = new ProjectInfo

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectProfile.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectProfile.cs
@@ -66,6 +66,8 @@ public static class CreateProjectProfile
         private async Task<Result<string>> CreateNostrProfileAsync(string nostrKey, CreateProjectDto project)
         {
             var tcs = new TaskCompletionSource<Result<string>>();
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => { tcs.TrySetResult(Result.Failure<string>("Nostr profile creation timed out after 30s")); cts.Dispose(); });
 
             var nostrMetadata = new NostrMetadata
             {

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetReleasableTransactions.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetReleasableTransactions.cs
@@ -51,9 +51,10 @@ public static class GetReleasableTransactions
 
         public Task<IEnumerable<SignatureReleaseItem>> FetchSignatureRequestsAsync(string projectNostrPubKey)
         {
-            var tcs = new TaskCompletionSource<IEnumerable<SignatureReleaseItem>>();
-
             var collectedItems = new List<SignatureReleaseItem>();
+            var tcs = new TaskCompletionSource<IEnumerable<SignatureReleaseItem>>();
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => { tcs.TrySetResult(collectedItems); cts.Dispose(); });
 
             try
             {
@@ -130,6 +131,8 @@ public static class GetReleasableTransactions
         protected Task FetchFounderReleaseSignaturesAsync(string nostrPubKey, List<SignatureReleaseItem> signaturesReleaseItems)
         {
             var tcs = new TaskCompletionSource();
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => { tcs.TrySetResult(); cts.Dispose(); });
 
             signService.LookupSignedReleaseSigs(nostrPubKey,
                 (item) =>
@@ -157,6 +160,8 @@ public static class GetReleasableTransactions
         private Task FetchFounderApprovalsSignaturesAsync(string nostrPubKey, List<SignatureReleaseItem> signaturesReleaseItems)
         {
             var tcs = new TaskCompletionSource();
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => { tcs.TrySetResult(); cts.Dispose(); });
 
             signService.LookupInvestmentRequestApprovals(nostrPubKey,
                 (investorNostrPubKey, timeEventCreated, reqEventId) =>

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/ReleaseFunds.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/ReleaseFunds.cs
@@ -69,9 +69,10 @@ public static class ReleaseFunds
         
         public Task<IEnumerable<SignatureReleaseItem>> FetchSignatureRequestsAsync(string projectNostrPubKey, List<string> eventIds)
         {
-            var tcs = new TaskCompletionSource<IEnumerable<SignatureReleaseItem>>();
-
             var collectedItems = new List<SignatureReleaseItem>();
+            var tcs = new TaskCompletionSource<IEnumerable<SignatureReleaseItem>>();
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => { tcs.TrySetResult(collectedItems); cts.Dispose(); });
 
             try
             {

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/UpdateProjectProfile.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/UpdateProjectProfile.cs
@@ -65,6 +65,8 @@ public static class UpdateProjectProfile
 
             // Publish kind 0 (profile metadata)
             var profileTcs = new TaskCompletionSource<Result<string>>();
+            var profileCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            profileCts.Token.Register(() => { profileTcs.TrySetResult(Result.Failure<string>("Nostr profile update timed out after 30s")); profileCts.Dispose(); });
             var nostrMetadata = new NostrMetadata
             {
                 Name = request.Metadata.Name,

--- a/src/sdk/Angor.Sdk/Funding/Investor/Domain/PortfolioService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Domain/PortfolioService.cs
@@ -131,6 +131,8 @@ public class PortfolioService(
         var encrypted = await encryptionService.EncryptData(serializer.Serialize(investments), password);
 
         var tcs = new TaskCompletionSource<bool>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        cts.Token.Register(() => tcs.TrySetResult(false));
         relayService.SendDirectMessagesForPubKeyAsync(storageKeyHex, storageAccountKey, encrypted, result => { tcs.TrySetResult(result.Accepted); });
 
         var success = await tcs.Task;

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildRecoveryTransaction.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildRecoveryTransaction.cs
@@ -123,6 +123,8 @@ public static class BuildRecoveryTransaction
 
             var signatureInfo = new SignatureInfo();
             var tcs = new TaskCompletionSource<Result<SignatureInfo?>>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => { if (!tcs.Task.IsCompleted) tcs.TrySetResult(Result.Success<SignatureInfo?>(null)); });
 
             var projectPubKey = project.NostrPubKey;
 

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildUnfundedReleaseTransaction.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildUnfundedReleaseTransaction.cs
@@ -141,6 +141,8 @@ public static class BuildUnfundedReleaseTransaction
             var privateKeyHex = Encoders.Hex.EncodeData(nostrPrivateKey.ToBytes());
             
             var tcs = new TaskCompletionSource<Result<SignatureInfo?>>();
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => { tcs.TrySetResult(Result.Success<SignatureInfo?>(null)); cts.Dispose(); });
 
             var projectPubKey = project.NostrPubKey;
             

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/CheckForReleaseSignatures.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/CheckForReleaseSignatures.cs
@@ -52,6 +52,8 @@ public static class CheckForReleaseSignatures
             var projectNostrPubKey = project.Value.NostrPubKey;
 
             var tcs = new TaskCompletionSource<bool>();
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => { tcs.TrySetResult(false); cts.Dispose(); });
 
             signService.LookupReleaseSigs(
                 investorNostrPubKey,

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/PublishInvestment.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/PublishInvestment.cs
@@ -161,6 +161,8 @@ public static class PublishInvestment
 
             TransactionInfo investment = null;
             var tcs = new TaskCompletionSource<Result<bool>>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => tcs.TrySetResult(Result.Failure<bool>("Timed out waiting for Nostr response")));
 
 
             // TODO replace the old logic with better optimized one
@@ -223,6 +225,8 @@ public static class PublishInvestment
             
             var signatureInfo = new SignatureInfo();
             var tcs = new TaskCompletionSource<Result<bool>>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => { if (!tcs.Task.IsCompleted) tcs.TrySetResult(Result.Success(false)); });
 
             signService.LookupSignatureForInvestmentRequest(pubKey, projectPubKey, createdAt, eventId,
                 async content =>

--- a/src/sdk/Angor.Sdk/Funding/Services/InvestmentHandshakeService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Services/InvestmentHandshakeService.cs
@@ -302,6 +302,8 @@ public class InvestmentHandshakeService(
         try
         {
             var tcs = new TaskCompletionSource<bool>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => tcs.TrySetResult(true));
             
             var requests = new List<DirectMessage>();
             var notifications = new List<DirectMessage>();

--- a/src/shared/Angor.Shared/Services/INostrCommunicationFactory.cs
+++ b/src/shared/Angor.Shared/Services/INostrCommunicationFactory.cs
@@ -14,4 +14,11 @@ public interface INostrCommunicationFactory
     bool OkEventReceivedOnAllRelays(string eventId);
     void MonitoringOkReceivedOnSubscription(string eventId);
     void ClearOkReceivedOnSubscriptionMonitoring(string eventId);
+
+    /// <summary>
+    /// Raised when a relay disconnects. Subscribers (e.g. RelaySubscriptionsHandling)
+    /// should re-evaluate pending EOSE/OK actions that may now be satisfied.
+    /// The argument is the disconnected relay name.
+    /// </summary>
+    event Action<string>? RelayDisconnected;
 }

--- a/src/shared/Angor.Shared/Services/NostrCommunicationFactory.cs
+++ b/src/shared/Angor.Shared/Services/NostrCommunicationFactory.cs
@@ -19,6 +19,8 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
     private ConcurrentDictionary<string, ConcurrentHashSet<string>> _eoseCalledOnSubscriptionClients;
     private ConcurrentDictionary<string, ConcurrentHashSet<string>> _okCalledOnSubscriptionClients;
 
+    public event Action<string>? RelayDisconnected;
+
     public NostrCommunicationFactory(ILogger<NostrWebsocketClient> clientLogger, ILogger<NostrCommunicationFactory> logger)
     {
         _clientLogger = clientLogger;
@@ -245,6 +247,37 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
                 _logger.LogDebug(
                     "Relay {relayName} disconnected, type: {Type}, reason: {CloseStatusDescription}", 
                     relayName, e.Type, e.CloseStatusDescription);
+
+            // Remove the disconnected relay from all pending EOSE tracking sets
+            // so that remaining healthy relays can satisfy the "all relays responded" check.
+            foreach (var kvp in _eoseCalledOnSubscriptionClients)
+            {
+                if (kvp.Value.TryRemove(relayName))
+                {
+                    _logger.LogWarning(
+                        "Removed disconnected relay {RelayName} from EOSE tracking for subscription {Subscription}",
+                        relayName, kvp.Key);
+                }
+            }
+
+            foreach (var kvp in _okCalledOnSubscriptionClients)
+            {
+                if (kvp.Value.TryRemove(relayName))
+                {
+                    _logger.LogWarning(
+                        "Removed disconnected relay {RelayName} from OK tracking for event {EventId}",
+                        relayName, kvp.Key);
+                }
+            }
+
+            try
+            {
+                RelayDisconnected?.Invoke(relayName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in RelayDisconnected handler for relay {RelayName}", relayName);
+            }
         }));
 
         if (_logger.IsEnabled(LogLevel.Information))

--- a/src/shared/Angor.Shared/Services/RelaySubscriptionsHandling.cs
+++ b/src/shared/Angor.Shared/Services/RelaySubscriptionsHandling.cs
@@ -44,6 +44,59 @@ public class RelaySubscriptionsHandling : IDisposable, IRelaySubscriptionsHandli
         
         _okHandlingDiscoverySubscription = discoveryClient.Streams.OkStream.Subscribe(HandleOkMessages);
         _eoseHandlingDiscoverySubscription = discoveryClient.Streams.EoseStream.Subscribe(HandleEoseMessages);
+
+        _communicationFactory.RelayDisconnected += OnRelayDisconnected;
+    }
+
+    private void OnRelayDisconnected(string relayName)
+    {
+        // After a relay disconnects and is removed from EOSE/OK tracking sets,
+        // re-evaluate all pending actions — some may now be satisfied.
+        foreach (var subscription in userEoseActions.Keys.ToList())
+        {
+            if (_communicationFactory.EoseEventReceivedOnAllRelays(subscription))
+            {
+                if (userEoseActions.Remove(subscription, out var action))
+                {
+                    _logger.LogWarning(
+                        "Relay {RelayName} disconnect unblocked EOSE action for subscription {Subscription}",
+                        relayName, subscription);
+                    try
+                    {
+                        action.Invoke();
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, "Failed to invoke EOSE action after relay disconnect");
+                    }
+                }
+
+                _communicationFactory.ClearEoseReceivedOnSubscriptionMonitoring(subscription);
+            }
+        }
+
+        foreach (var eventId in OkVerificationActions.Keys.ToList())
+        {
+            if (_communicationFactory.OkEventReceivedOnAllRelays(eventId))
+            {
+                if (OkVerificationActions.Remove(eventId, out var action))
+                {
+                    _logger.LogWarning(
+                        "Relay {RelayName} disconnect unblocked OK action for event {EventId}",
+                        relayName, eventId);
+                    try
+                    {
+                        action.Invoke(new NostrOkResponse { Accepted = true, EventId = eventId });
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, "Failed to invoke OK action after relay disconnect");
+                    }
+                }
+
+                _communicationFactory.ClearOkReceivedOnSubscriptionMonitoring(eventId);
+            }
+        }
     }
 
     // public void Init(INetworkService networkService)
@@ -162,6 +215,7 @@ public class RelaySubscriptionsHandling : IDisposable, IRelaySubscriptionsHandli
 
     public void Dispose()
     {
+        _communicationFactory.RelayDisconnected -= OnRelayDisconnected;
         relaySubscriptions.Values.ToList().ForEach(_ => _.Dispose());
         _okHandlingSubscription.Dispose();
         _eoseHandlingSubscription.Dispose();


### PR DESCRIPTION
## Summary

- **Bug**: 14 `TaskCompletionSource` instances across the SDK were awaited without timeout. When a relay disconnects, pending EOSE/OK checks could never complete, causing deadlocks.
- Add disconnect handler in `NostrCommunicationFactory` that removes the relay from EOSE/OK tracking sets
- Add `RelayDisconnected` event on `INostrCommunicationFactory`
- Add `RelaySubscriptionsHandling` re-evaluation on disconnect to unblock pending actions
- Add 30s `CancellationToken` timeouts to all 14 TCS await sites across SDK operations

## Changed files

### Shared
- `INostrCommunicationFactory.cs` -- `RelayDisconnected` event
- `NostrCommunicationFactory.cs` -- disconnect handler removes relay from tracking sets
- `RelaySubscriptionsHandling.cs` -- re-evaluates pending actions on disconnect

### SDK operations (TCS timeouts)
- `CreateProjectInfo.cs`, `CreateProjectProfile.cs`, `GetReleasableTransactions.cs`, `PublishInvestment.cs`, `ReleaseFunds.cs`, `UpdateProjectProfile.cs`, `PortfolioService.cs`, `BuildRecoveryTransaction.cs`, `BuildUnfundedReleaseTransaction.cs`, `CheckForReleaseSignatures.cs`, `InvestmentHandshakeService.cs`

Split from #789.
