### PR TITLE
fix: add 3-attempt broadcast retry with exponential backoff

### DIFF
--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/PublishFounderTransactionTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/PublishFounderTransactionTests.cs
@@ -15,7 +15,7 @@ public class PublishFounderTransactionTests
     public PublishFounderTransactionTests()
     {
         _mockIndexerService = new Mock<IIndexerService>();
-        _sut = new PublishFounderTransaction.Handler(_mockIndexerService.Object);
+        _sut = new PublishFounderTransaction.Handler(_mockIndexerService.Object, new Mock<Microsoft.Extensions.Logging.ILogger<PublishFounderTransaction.Handler>>().Object);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class PublishFounderTransactionTests
 
         // Assert
         result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be("Transaction rejected: insufficient fee");
+        result.Error.Should().Contain("Failed to publish founder transaction");
     }
 
     [Fact]

--- a/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/PublishAndStoreInvestorTransactionTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/PublishAndStoreInvestorTransactionTests.cs
@@ -27,7 +27,8 @@ public class PublishAndStoreInvestorTransactionTests
         _sut = new PublishAndStoreInvestorTransaction.Handler(
             _mockIndexerService.Object,
             _mockPortfolioService.Object,
-            _mockMediator.Object);
+            _mockMediator.Object,
+            new Mock<Microsoft.Extensions.Logging.ILogger<PublishAndStoreInvestorTransaction.Handler>>().Object);
     }
 
     [Fact]

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/PublishFounderTransaction.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/PublishFounderTransaction.cs
@@ -2,6 +2,7 @@ using Angor.Sdk.Funding.Shared;
 using Angor.Shared.Services;
 using CSharpFunctionalExtensions;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace Angor.Sdk.Funding.Founder.Operations;
 
@@ -11,7 +12,7 @@ public static class PublishFounderTransaction
 
     public record PublishFounderTransactionResponse(string TransactionId);
 
-    public class Handler(IIndexerService indexerService) : IRequestHandler<PublishFounderTransactionRequest, Result<PublishFounderTransactionResponse>>
+    public class Handler(IIndexerService indexerService, ILogger<Handler> logger) : IRequestHandler<PublishFounderTransactionRequest, Result<PublishFounderTransactionResponse>>
     {
         public async Task<Result<PublishFounderTransactionResponse>> Handle(PublishFounderTransactionRequest request, CancellationToken cancellationToken)
         {
@@ -23,14 +24,38 @@ public static class PublishFounderTransaction
             if (cancellationToken.IsCancellationRequested)
                 return Result.Failure<PublishFounderTransactionResponse>("Operation was cancelled");
 
-            var errorMessage = await indexerService.PublishTransactionAsync(request.TransactionDraft.SignedTxHex);
+            const int maxAttempts = 3;
+            var txId = request.TransactionDraft.TransactionId;
 
-            if (!string.IsNullOrEmpty(errorMessage)) 
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
             {
-                return Result.Failure<PublishFounderTransactionResponse>(errorMessage);
+                var errorMessage = await indexerService.PublishTransactionAsync(request.TransactionDraft.SignedTxHex);
+
+                if (string.IsNullOrEmpty(errorMessage))
+                {
+                    logger.LogInformation("PublishFounderTransaction: broadcast succeeded on attempt {Attempt} for TxId={TxId}", attempt, txId);
+                    return Result.Success(new PublishFounderTransactionResponse(txId));
+                }
+
+                // "Already in block chain" or "already known" means the tx exists — treat as success
+                if (errorMessage.Contains("already in block", StringComparison.OrdinalIgnoreCase) ||
+                    errorMessage.Contains("already known", StringComparison.OrdinalIgnoreCase) ||
+                    errorMessage.Contains("txn-already-in-mempool", StringComparison.OrdinalIgnoreCase))
+                {
+                    logger.LogInformation("PublishFounderTransaction: tx {TxId} already exists (attempt {Attempt}): {Message}", txId, attempt, errorMessage);
+                    return Result.Success(new PublishFounderTransactionResponse(txId));
+                }
+
+                logger.LogError("PublishFounderTransaction: broadcast attempt {Attempt}/{Max} failed for TxId={TxId}: {Message}",
+                    attempt, maxAttempts, txId, errorMessage);
+
+                if (attempt < maxAttempts)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(2 * attempt), cancellationToken);
+                }
             }
 
-            return Result.Success(new PublishFounderTransactionResponse(request.TransactionDraft.TransactionId));
+            return Result.Failure<PublishFounderTransactionResponse>($"Failed to publish founder transaction {txId} after {maxAttempts} attempts");
         }
     }
 }

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/PublishAndStoreInvestorTransaction.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/PublishAndStoreInvestorTransaction.cs
@@ -5,6 +5,7 @@ using Angor.Sdk.Funding.Shared.TransactionDrafts;
 using Angor.Shared.Services;
 using CSharpFunctionalExtensions;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace Angor.Sdk.Funding.Investor.Operations;
 
@@ -14,7 +15,7 @@ public static class PublishAndStoreInvestorTransaction
 
     public record PublishAndStoreInvestorTransactionResponse(string TransactionId);
 
-    public class Handler(IIndexerService indexerService, IPortfolioService portfolioService, IMediator mediator) : IRequestHandler<PublishAndStoreInvestorTransactionRequest, Result<PublishAndStoreInvestorTransactionResponse>>
+    public class Handler(IIndexerService indexerService, IPortfolioService portfolioService, IMediator mediator, ILogger<Handler> logger) : IRequestHandler<PublishAndStoreInvestorTransactionRequest, Result<PublishAndStoreInvestorTransactionResponse>>
     {
         public async Task<Result<PublishAndStoreInvestorTransactionResponse>> Handle(PublishAndStoreInvestorTransactionRequest request, CancellationToken cancellationToken)
         {
@@ -31,11 +32,43 @@ public static class PublishAndStoreInvestorTransaction
             if (cancellationToken.IsCancellationRequested)
                 return Result.Failure<PublishAndStoreInvestorTransactionResponse>("Operation was cancelled");
 
-            // Publish the transaction
-            var errorMessage = await indexerService.PublishTransactionAsync(request.TransactionDraft.SignedTxHex);
+            // Publish the transaction with retry
+            const int maxAttempts = 3;
+            var txId = request.TransactionDraft.TransactionId;
+            string? lastError = null;
 
-            if (!string.IsNullOrEmpty(errorMessage))
-                return Result.Failure<PublishAndStoreInvestorTransactionResponse>(errorMessage);
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                var errorMessage = await indexerService.PublishTransactionAsync(request.TransactionDraft.SignedTxHex);
+
+                if (string.IsNullOrEmpty(errorMessage))
+                {
+                    logger.LogInformation("PublishAndStoreInvestorTransaction: broadcast succeeded on attempt {Attempt} for TxId={TxId}", attempt, txId);
+                    break;
+                }
+
+                // "Already in block chain" or similar means the tx exists — treat as success
+                if (errorMessage.Contains("already in block", StringComparison.OrdinalIgnoreCase) ||
+                    errorMessage.Contains("already known", StringComparison.OrdinalIgnoreCase) ||
+                    errorMessage.Contains("txn-already-in-mempool", StringComparison.OrdinalIgnoreCase))
+                {
+                    logger.LogInformation("PublishAndStoreInvestorTransaction: tx {TxId} already exists (attempt {Attempt}): {Message}", txId, attempt, errorMessage);
+                    break;
+                }
+
+                lastError = errorMessage;
+                logger.LogError("PublishAndStoreInvestorTransaction: broadcast attempt {Attempt}/{Max} failed for TxId={TxId}: {Message}",
+                    attempt, maxAttempts, txId, errorMessage);
+
+                if (attempt < maxAttempts)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(2 * attempt), cancellationToken);
+                }
+                else
+                {
+                    return Result.Failure<PublishAndStoreInvestorTransactionResponse>(lastError);
+                }
+            }
 
             // Update or create the investment record with the transaction ID
             var updateResult = await UpdateInvestmentRecordWithTransaction(

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/PublishInvestment.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/PublishInvestment.cs
@@ -272,23 +272,52 @@ public static class PublishInvestment
 
         private async Task<Result<string>> PublishSignedTransactionAsync(TransactionInfo signedTransaction)
         {
-            try
-            { 
-                var response = await walletOperations.PublishTransactionAsync(networkConfiguration.GetNetwork(),
-                    signedTransaction.Transaction);
-                
-                if (response.Success)
-                    return Result.Success(signedTransaction.Transaction.GetHash().ToString());
-                
-                logger.Error("Failed to publish investment transaction: {Message}", response.Message);
-                
-                return Result.Failure<string>($"Failed to publish the transaction to the blockchain: {response.Message}");
-            }
-            catch (Exception e)
+            const int maxAttempts = 3;
+            var txId = signedTransaction.Transaction.GetHash().ToString();
+
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
             {
-                logger.Error(e, "Error publishing signed transaction");
-                return Result.Failure<string>("An error occurred while publishing the transaction");
+                try
+                {
+                    var response = await walletOperations.PublishTransactionAsync(networkConfiguration.GetNetwork(),
+                        signedTransaction.Transaction);
+
+                    if (response.Success)
+                    {
+                        logger.Information("PublishInvestment: broadcast succeeded on attempt {Attempt} for TxId={TxId}", attempt, txId);
+                        return Result.Success(txId);
+                    }
+
+                    // "Transaction already in block chain" or similar means it was already broadcast — treat as success
+                    if (response.Message != null &&
+                        (response.Message.Contains("already in block", StringComparison.OrdinalIgnoreCase) ||
+                         response.Message.Contains("already known", StringComparison.OrdinalIgnoreCase) ||
+                         response.Message.Contains("txn-already-in-mempool", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        logger.Information("PublishInvestment: tx {TxId} already exists (attempt {Attempt}): {Message}", txId, attempt, response.Message);
+                        return Result.Success(txId);
+                    }
+
+                    logger.Error("PublishInvestment: broadcast attempt {Attempt}/{Max} failed for TxId={TxId}: {Message}",
+                        attempt, maxAttempts, txId, response.Message);
+
+                    if (attempt < maxAttempts)
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(2 * attempt));
+                    }
+                }
+                catch (Exception e)
+                {
+                    logger.Error(e, "PublishInvestment: broadcast attempt {Attempt}/{Max} threw for TxId={TxId}", attempt, maxAttempts, txId);
+
+                    if (attempt < maxAttempts)
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(2 * attempt));
+                    }
+                }
             }
+
+            return Result.Failure<string>($"Failed to publish transaction {txId} after {maxAttempts} attempts");
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Bug**: Transaction broadcasts made a single attempt. Network hiccups or temporary node issues would cause permanent failure.
- Add 3-attempt retry with exponential backoff (2s, 4s) to `PublishFounderTransaction`, `PublishInvestment`, and `PublishAndStoreInvestorTransaction`
- Treat "already in block chain", "already known", and "txn-already-in-mempool" responses as success
- Add `ILogger` dependency for broadcast attempt logging

## Changed files

- `src/sdk/Angor.Sdk/Funding/Founder/Operations/PublishFounderTransaction.cs`
- `src/sdk/Angor.Sdk/Funding/Investor/Operations/PublishAndStoreInvestorTransaction.cs`
- `src/sdk/Angor.Sdk/Funding/Investor/Operations/PublishInvestment.cs`
- `src/sdk/Angor.Sdk.Tests/Funding/Founder/PublishFounderTransactionTests.cs`
- `src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/PublishAndStoreInvestorTransactionTests.cs`

Split from #789.
