### PR TITLE
fix: correct inverted testnet/mainnet cache key in MempoolSpaceIndexerApi

### DIFF
--- a/src/shared/Angor.Shared/Services/MempoolSpaceIndexerApi.cs
+++ b/src/shared/Angor.Shared/Services/MempoolSpaceIndexerApi.cs
@@ -125,7 +125,7 @@ public class MempoolSpaceIndexerApi : IIndexerService
     private HttpClient GetIndexerClient()
     {
         var indexer = _networkService.GetPrimaryIndexer();
-        var key = string.IsNullOrEmpty(indexer.Name) ? indexer.Name : indexer.Url;
+        var key = string.IsNullOrEmpty(indexer.Name) ? indexer.Url : indexer.Name;
         if (_clients.TryGetValue(key, out var indexerClient))
             return indexerClient;
 


### PR DESCRIPTION
## Summary
- Fix swapped ternary branches for the API URL cache key in MempoolSpaceIndexerApi, which caused testnet requests to use the mainnet URL and vice versa.