### PR TITLE
fix: prevent duplicate wallet import and add import button spinner

### DIFF
--- a/src/design/App/UI/Sections/Funds/CreateWalletModal.axaml.cs
+++ b/src/design/App/UI/Sections/Funds/CreateWalletModal.axaml.cs
@@ -190,6 +190,11 @@ public partial class CreateWalletModal : UserControl, IBackdropCloseable
         SeedError.IsVisible = false;
         SeedSuccess.IsVisible = true;
 
+        // Show spinner and disable button during import
+        BtnSubmitImport.IsEnabled = false;
+        ImportBtnContent.IsVisible = false;
+        ImportBtnSpinner.IsVisible = true;
+
         // Import wallet with the user's seed words
         try
         {
@@ -199,6 +204,12 @@ public partial class CreateWalletModal : UserControl, IBackdropCloseable
         {
             _logger.LogError(ex, "Unhandled exception during wallet import");
             ShellVm?.ShowToast($"Wallet import failed: {ex.Message}");
+        }
+        finally
+        {
+            BtnSubmitImport.IsEnabled = true;
+            ImportBtnContent.IsVisible = true;
+            ImportBtnSpinner.IsVisible = false;
         }
     }
 

--- a/src/sdk/Angor.Sdk/Wallet/Infrastructure/Impl/WalletFactory.cs
+++ b/src/sdk/Angor.Sdk/Wallet/Infrastructure/Impl/WalletFactory.cs
@@ -26,7 +26,12 @@ public class WalletFactory(
         var walletWords = new WalletWords { Words = seedwords, Passphrase = passphrase.GetValueOrDefault() };
         var accountInfo = walletOperations.BuildAccountInfoForWalletWords(walletWords);
         var walletId = new WalletId(accountInfo.walletId);
-        
+
+        // Check if a wallet with this ID already exists
+        var existingWallets = await walletStore.GetAll();
+        if (existingWallets.IsSuccess && existingWallets.Value.Any(w => w.Id == walletId.Value))
+            return Result.Failure<Domain.Wallet>("A wallet with the same seed words already exists.");
+
         var descriptor = WalletDescriptorFactory.Create(seedwords, passphrase, network.ToNBitcoin());
         var wallet = new Domain.Wallet(walletId, descriptor);
         


### PR DESCRIPTION
## Summary
- Check if a wallet with the same derived ID already exists before creating, failing with a descriptive error if seed words were already imported
- Show spinner and disable import button during wallet creation to prevent accidental double-clicks