### PR TITLE
feat: add project search by ID in Find Projects

### DIFF
--- a/src/design/App.Test.Integration/CreateProjectTest.cs
+++ b/src/design/App.Test.Integration/CreateProjectTest.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Angor.Sdk.Common;
 using Angor.Sdk.Funding.Projects;
 using App.Test.Integration.Helpers;
+using App.UI.Sections.FindProjects;
 using App.UI.Sections.MyProjects.Deploy;
 using App.UI.Shared.PaymentFlow;
 using App.UI.Shell;
@@ -534,9 +535,40 @@ public class CreateProjectTest
             "Penalty duration should be ~0 days (debug mode value)");
         TestHelpers.Log($"[STEP 8] Penalty duration: {projectDto.PenaltyDuration.TotalDays} days");
 
+        // ──────────────────────────────────────────────────────────────
+        // STEP 9: Navigate to Find Projects and search by project ID
+        // ──────────────────────────────────────────────────────────────
+        TestHelpers.Log("[STEP 9] Navigating to Find Projects to search by project ID...");
+        var projectIdentifier = sdkProject.ProjectIdentifier;
+        window.NavigateToSection("Find Projects");
+        await Task.Delay(500);
+        Dispatcher.UIThread.RunJobs();
+
+        var findProjectsVm = window.GetFindProjectsViewModel();
+        findProjectsVm.Should().NotBeNull("FindProjectsViewModel should be available");
+
+        TestHelpers.Log($"[STEP 9] Searching for project ID: {projectIdentifier}");
+        findProjectsVm!.SearchText = projectIdentifier;
+        Dispatcher.UIThread.RunJobs();
+
+        await findProjectsVm.SearchByProjectIdAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        findProjectsVm.SearchError.Should().BeNullOrEmpty(
+            $"Search should not produce an error. Got: {findProjectsVm.SearchError}");
+        findProjectsVm.IsSearching.Should().BeFalse("Search should have completed");
+        findProjectsVm.SearchText.Should().BeEmpty("Search text should be cleared after success");
+
+        findProjectsVm.SelectedProject.Should().NotBeNull("Search should open the project detail");
+        findProjectsVm.SelectedProject!.ProjectId.Should().Be(projectIdentifier,
+            "Opened project should match the searched project ID");
+        findProjectsVm.SelectedProject.ProjectName.Should().Be(projectName,
+            "Opened project should have the correct name");
+
+        TestHelpers.Log($"[STEP 9] Found: '{findProjectsVm.SelectedProject.ProjectName}' (ID: {findProjectsVm.SelectedProject.ProjectId})");
+
         // Cleanup: close window
         window.Close();
         TestHelpers.Log("========== FullCreateInvestmentProjectFlow PASSED ==========");
     }
-
 }

--- a/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml
@@ -32,13 +32,80 @@
         <!-- ═══════════════════════════════════════════════════════ -->
         <controls:ScrollableView Name="ProjectListPanel" ContentPadding="24,24,24,24">
             <StackPanel Spacing="16">
-                <!-- Header with refresh button -->
-                <Grid ColumnDefinitions="*,Auto">
+                <!-- Header with search bar and refresh button -->
+                <Grid ColumnDefinitions="Auto,*,Auto">
                     <TextBlock Grid.Column="0"
                                Text="Discover Projects"
                                FontSize="20" FontWeight="Bold"
                                VerticalAlignment="Center" />
-                    <Button Name="RefreshProjectsButton" Grid.Column="1"
+                    <!-- Search bar -->
+                    <Border Grid.Column="1"
+                            Background="{DynamicResource CardBackground}"
+                            CornerRadius="8"
+                            Padding="4"
+                            Margin="16,0"
+                            BorderBrush="{DynamicResource BorderBrush}"
+                            BorderThickness="1"
+                            VerticalAlignment="Center">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <TextBox Grid.Column="0"
+                                     Name="SearchTextBox"
+                                     Text="{Binding SearchText, Mode=TwoWay}"
+                                     Watermark="Search by Project ID..."
+                                     BorderThickness="0"
+                                     Background="Transparent"
+                                     VerticalAlignment="Center"
+                                     Padding="8,6" />
+                            <Button Grid.Column="1"
+                                    Name="SearchButton"
+                                    Classes="Primary Light MobileAction"
+                                    Padding="10,6"
+                                    Margin="4,0,0,0"
+                                    VerticalAlignment="Center"
+                                    IsEnabled="{Binding !IsSearching}">
+                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                    <i:Icon Value="fa-solid fa-magnifying-glass"
+                                            FontSize="13"
+                                            IsVisible="{Binding !IsSearching}"
+                                            Foreground="{DynamicResource LightPrimaryButtonForeground}"
+                                            VerticalAlignment="Center" />
+                                    <i:Icon Value="fa-solid fa-spinner"
+                                            FontSize="13"
+                                            IsVisible="{Binding IsSearching}"
+                                            Foreground="{DynamicResource LightPrimaryButtonForeground}"
+                                            VerticalAlignment="Center"
+                                            RenderTransformOrigin="50%,50%">
+                                        <i:Icon.RenderTransform>
+                                            <RotateTransform />
+                                        </i:Icon.RenderTransform>
+                                        <i:Icon.Styles>
+                                            <Style Selector="i|Icon">
+                                                <Style.Animations>
+                                                    <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                        <KeyFrame Cue="0%">
+                                                            <Setter Property="RotateTransform.Angle" Value="0" />
+                                                        </KeyFrame>
+                                                        <KeyFrame Cue="100%">
+                                                            <Setter Property="RotateTransform.Angle" Value="360" />
+                                                        </KeyFrame>
+                                                    </Animation>
+                                                </Style.Animations>
+                                            </Style>
+                                        </i:Icon.Styles>
+                                    </i:Icon>
+                                </StackPanel>
+                            </Button>
+                        </Grid>
+                    </Border>
+                    <!-- Search error message -->
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding SearchError}"
+                               IsVisible="{Binding SearchError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                               Foreground="Red"
+                               FontSize="12"
+                               Margin="16,4,0,0"
+                               VerticalAlignment="Bottom" />
+                    <Button Name="RefreshProjectsButton" Grid.Column="2"
                             Classes="Primary Light MobileAction"
                             Padding="12,8"
                             VerticalAlignment="Center"

--- a/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml.cs
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml.cs
@@ -60,6 +60,26 @@ public partial class FindProjectsView : UserControl, ISectionView
             };
         }
 
+        // Wire search button and Enter key on search TextBox
+        var searchBtn = this.FindControl<Button>("SearchButton");
+        var searchBox = this.FindControl<TextBox>("SearchTextBox");
+        if (searchBtn != null)
+        {
+            searchBtn.Click += async (_, _) =>
+            {
+                if (DataContext is FindProjectsViewModel fvm)
+                    await fvm.SearchByProjectIdAsync();
+            };
+        }
+        if (searchBox != null)
+        {
+            searchBox.KeyDown += async (_, args) =>
+            {
+                if (args.Key == Key.Enter && DataContext is FindProjectsViewModel fvm)
+                    await fvm.SearchByProjectIdAsync();
+            };
+        }
+
         // Wire "Load More" button — explicit reveal only, no scroll trigger.
         // The VM's IsLoadingMore flag disables the button across the batch
         // insert so repeated taps can't pile up concurrent layout passes.

--- a/src/design/App/UI/Sections/FindProjects/FindProjectsViewModel.cs
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsViewModel.cs
@@ -299,6 +299,84 @@ public partial class FindProjectsViewModel : ReactiveObject
     [Reactive] private InvestPageViewModel? investPageViewModel;
     [Reactive] private bool isLoading;
     [Reactive] private bool isInitialLoad = true;
+    [Reactive] private string? searchText;
+    [Reactive] private bool isSearching;
+    [Reactive] private string? searchError;
+
+    /// <summary>
+    /// Search for a project by its on-chain project ID.
+    /// Looks up the project on the blockchain, gets the nostr event ID from the
+    /// OP_RETURN, fetches the nostr event, and opens the project detail.
+    /// </summary>
+    public async Task SearchByProjectIdAsync()
+    {
+        var projectId = SearchText?.Trim();
+        if (string.IsNullOrEmpty(projectId))
+            return;
+
+        SearchError = null;
+        IsSearching = true;
+        _logger.LogInformation("Searching for project by ID: {ProjectId}", projectId);
+
+        try
+        {
+            var result = await _projectAppService.TryGet(
+                new TryGetProject.TryGetProjectRequest(new ProjectId(projectId)));
+
+            if (result.IsFailure)
+            {
+                SearchError = $"Search failed: {result.Error}";
+                _logger.LogWarning("Search failed for {ProjectId}: {Error}", projectId, result.Error);
+                return;
+            }
+
+            var maybeProject = result.Value.Project;
+            if (maybeProject.HasNoValue)
+            {
+                SearchError = "Project not found on the blockchain.";
+                _logger.LogInformation("Project not found: {ProjectId}", projectId);
+                return;
+            }
+
+            var dto = maybeProject.Value;
+            var vm = ProjectItemViewModel.FromDto(dto);
+            vm.CurrencySymbol = _currencyService.Symbol;
+
+            // Load statistics for the found project
+            try
+            {
+                var statsResult = await _projectAppService.GetProjectStatistics(new ProjectId(projectId));
+                if (statsResult.IsSuccess)
+                {
+                    var stats = statsResult.Value;
+                    var raisedBtc = (double)stats.TotalInvested.ToUnitBtc();
+                    vm.Raised = raisedBtc.ToString("F5", System.Globalization.CultureInfo.InvariantCulture);
+                    vm.InvestorCount = stats.TotalInvestors ?? 0;
+                    if (double.TryParse(vm.Target, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var target) && target > 0)
+                        vm.Progress = Math.Min(raisedBtc / target * 100, 100);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to load stats for searched project {ProjectId}", projectId);
+            }
+
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                SearchText = "";
+                OpenProjectDetail(vm);
+            });
+        }
+        catch (Exception ex)
+        {
+            SearchError = "An error occurred while searching.";
+            _logger.LogError(ex, "Exception searching for project {ProjectId}", projectId);
+        }
+        finally
+        {
+            IsSearching = false;
+        }
+    }
 
     public void OpenProjectDetail(ProjectItemViewModel project)
     {

--- a/src/shared/Angor.Shared/Services/RelayService.cs
+++ b/src/shared/Angor.Shared/Services/RelayService.cs
@@ -230,7 +230,7 @@ namespace Angor.Shared.Services
 
             var content = _serializer.Serialize(project);
 
-            var signed = GetNip3030NostrEvent(content)
+            var signed = GetNip3030NostrEvent(content, project.ProjectIdentifier)
                 .Sign(key);
 
             _subscriptionsHandling.TryAddOKAction(signed.Id, action);
@@ -462,7 +462,7 @@ namespace Angor.Shared.Services
             return Task.FromResult(signed.Id);
         }
 
-        private static NostrEvent GetNip3030NostrEvent(string content)
+        private static NostrEvent GetNip3030NostrEvent(string content, string? projectIdentifier = null)
         {
             // https://github.com/block-core/nips/blob/peer-to-peer-decentralized-funding/3030.md
 
@@ -471,7 +471,10 @@ namespace Angor.Shared.Services
                 //Kind = NostrKind.ApplicationSpecificData,
                 Kind = Nip3030NostrKind,
                 CreatedAt = DateTime.UtcNow,
-                Content = content
+                Content = content,
+                Tags = string.IsNullOrEmpty(projectIdentifier)
+                    ? new NostrEventTags()
+                    : new NostrEventTags(new NostrEventTag("d", projectIdentifier))
             };
             return ev;
         }


### PR DESCRIPTION
## Summary

- Adds a search bar to the Find Projects section that allows users to look up a project by its on-chain project ID
- Tags kind 3030 Nostr events with a `d` tag containing the `ProjectIdentifier` for future relay-side filtering
- Search uses existing `TryGet` flow: indexer lookup, get nostr event ID, fetch from relays, display project detail
- Search bar is inline with the Discover Projects header and Refresh button
- Clears search text after successfully finding a project

**Note:** Kind 3030 is outside the 30000-39999 range so the `d` tag does NOT make events replaceable. It is simply an indexed tag for relay queries.

---
_Replaces #815 (clean history to fix GitHub binary file display issue)_
