### PR TITLE
fix: update webapp to use IIndexerService.PublishTransactionAsync

### DIFF
--- a/src/webapp/Angor.Client/Pages/Create.razor
+++ b/src/webapp/Angor.Client/Pages/Create.razor
@@ -18,6 +18,7 @@
 @inject ICacheStorage _cacheStorage;
 @inject NavigationManager NavigationManager
 @inject IWalletOperations _WalletOperations
+@inject IIndexerService _IndexerService
 @inject IPsbtOperations _PsbtOperations
 @inject IRelayService _RelayService
 @inject ILogger<Create> _Logger;
@@ -1602,11 +1603,11 @@
         {
             showCreateModal = false;
 
-            var response = await _WalletOperations.PublishTransactionAsync(network, signedTransaction.Transaction);
+            var publishError = await _IndexerService.PublishTransactionAsync(signedTransaction.Transaction.ToHex(network.Consensus.ConsensusFactory));
 
-            if (!response.Success)
+            if (!string.IsNullOrEmpty(publishError))
             {
-                notificationComponent.ShowErrorMessage("Transaction failed", response.Message);
+                notificationComponent.ShowErrorMessage("Transaction failed", publishError);
                 return;
             }
 

--- a/src/webapp/Angor.Client/Pages/Invest.razor
+++ b/src/webapp/Angor.Client/Pages/Invest.razor
@@ -24,6 +24,7 @@
 @inject IClientStorage storage;
 @inject ICacheStorage SessionStorage;
 @inject IWalletOperations _WalletOperations;
+@inject IIndexerService _indexerService;
 @inject IPsbtOperations _PsbtOperations
 @inject IApplicationLogicService applicationLogicService;
 @inject ISignService _SignService;
@@ -1373,11 +1374,11 @@ else
                 return;
             }
 
-            var response = await _WalletOperations.PublishTransactionAsync(network, signedTransaction.Transaction);
+            var publishError = await _indexerService.PublishTransactionAsync(signedTransaction.Transaction.ToHex(network.Consensus.ConsensusFactory));
 
-            if (!response.Success)
+            if (!string.IsNullOrEmpty(publishError))
             {
-                notificationComponent.ShowErrorMessage("Transaction failed", response.Message);
+                notificationComponent.ShowErrorMessage("Transaction failed", publishError);
                 return;
             }
 

--- a/src/webapp/Angor.Client/Pages/InvestView.razor
+++ b/src/webapp/Angor.Client/Pages/InvestView.razor
@@ -1250,11 +1250,11 @@
                 return;
             }
 
-            var response = await _WalletOperations.PublishTransactionAsync(network, signedTransaction.Transaction);
+            var publishError = await _indexerService.PublishTransactionAsync(signedTransaction.Transaction.ToHex(network.Consensus.ConsensusFactory));
 
-            if (!response.Success)
+            if (!string.IsNullOrEmpty(publishError))
             {
-                notificationComponent.ShowErrorMessage("Transaction failed", response.Message);
+                notificationComponent.ShowErrorMessage("Transaction failed", publishError);
                 return;
             }
 

--- a/src/webapp/Angor.Client/Pages/Recover.razor
+++ b/src/webapp/Angor.Client/Pages/Recover.razor
@@ -988,11 +988,11 @@
 
             Logger.LogInformation($"recover trx hex = {recoveryTransaction.Transaction.ToHex(network.Consensus.ConsensusFactory)}");
 
-            var response = await _WalletOperations.PublishTransactionAsync(network, recoveryTransaction.Transaction);
+            var publishError = await _IndexerService.PublishTransactionAsync(recoveryTransaction.Transaction.ToHex(network.Consensus.ConsensusFactory));
 
-            if (!response.Success)
+            if (!string.IsNullOrEmpty(publishError))
             {
-                notificationComponent.ShowErrorMessage("Transaction failed", response.Message);
+                notificationComponent.ShowErrorMessage("Transaction failed", publishError);
                 return;
             }
 
@@ -1136,11 +1136,11 @@
 
             Logger.LogInformation($"release trx hex = {releaseRecoveryTransaction.Transaction.ToHex(network.Consensus.ConsensusFactory)}");
 
-            var response = await _WalletOperations.PublishTransactionAsync(network, releaseRecoveryTransaction.Transaction);
+            var publishError = await _IndexerService.PublishTransactionAsync(releaseRecoveryTransaction.Transaction.ToHex(network.Consensus.ConsensusFactory));
 
-            if (!response.Success)
+            if (!string.IsNullOrEmpty(publishError))
             {
-                notificationComponent.ShowErrorMessage("Transaction failed", response.Message);
+                notificationComponent.ShowErrorMessage("Transaction failed", publishError);
                 return;
             }
 
@@ -1274,11 +1274,11 @@
 
             Logger.LogInformation($"end of project trx hex = {endOfProjectTransaction.Transaction.ToHex(network.Consensus.ConsensusFactory)}");
 
-            var response = await _WalletOperations.PublishTransactionAsync(network, endOfProjectTransaction.Transaction);
+            var publishError = await _IndexerService.PublishTransactionAsync(endOfProjectTransaction.Transaction.ToHex(network.Consensus.ConsensusFactory));
 
-            if (!response.Success)
+            if (!string.IsNullOrEmpty(publishError))
             {
-                notificationComponent.ShowErrorMessage("Transaction failed", response.Message);
+                notificationComponent.ShowErrorMessage("Transaction failed", publishError);
                 return;
             }
 

--- a/src/webapp/Angor.Client/Pages/Release.razor
+++ b/src/webapp/Angor.Client/Pages/Release.razor
@@ -486,11 +486,11 @@
 
             Storage.UpdateInvestmentProject(InvestorProject);
 
-            var response = await _WalletOperations.PublishTransactionAsync(network, releaseTransaction.Transaction);
+            var publishError = await _IndexerService.PublishTransactionAsync(releaseTransaction.Transaction.ToHex(network.Consensus.ConsensusFactory));
 
-            if (!response.Success)
+            if (!string.IsNullOrEmpty(publishError))
             {
-                notificationComponent.ShowErrorMessage("Transaction failed", response.Message);
+                notificationComponent.ShowErrorMessage("Transaction failed", publishError);
                 return;
             }
 

--- a/src/webapp/Angor.Client/Pages/Spend.razor
+++ b/src/webapp/Angor.Client/Pages/Spend.razor
@@ -978,11 +978,11 @@
         {
             showCreateModal = false;
 
-            var response = await _WalletOperations.PublishTransactionAsync(network, signedTransaction.Transaction);
+            var publishError = await _IndexerService.PublishTransactionAsync(signedTransaction.Transaction.ToHex(network.Consensus.ConsensusFactory));
 
-            if (!response.Success)
+            if (!string.IsNullOrEmpty(publishError))
             {
-                notificationComponent.ShowErrorMessage("Transaction failed", response.Message);
+                notificationComponent.ShowErrorMessage("Transaction failed", publishError);
                 return;
             }
 

--- a/src/webapp/Angor.Client/Pages/Wallet.razor
+++ b/src/webapp/Angor.Client/Pages/Wallet.razor
@@ -22,6 +22,7 @@
 @inject IDerivationOperations _derivationOperations
 @inject NavMenuState NavMenuState
 @inject IEncryptionService _encryptionService
+@inject IIndexerService _indexerService
 @inject IClipboardService ClipboardService
 @inject IWalletUIService _walletUIService
 
@@ -1648,11 +1649,11 @@ else
             var accountInfo = storage.GetAccountInfo(network.Name);
             var unconfirmedInfo = _cacheStorage.GetUnconfirmedInboundFunds();
 
-            var res = await _walletOperations.PublishTransactionAsync(network, _sendInfo.SignedTransaction.Transaction);
+            var publishError = await _indexerService.PublishTransactionAsync(_sendInfo.SignedTransaction.Transaction.ToHex(network.Consensus.ConsensusFactory));
 
-            if (res.Success)
+            if (string.IsNullOrEmpty(publishError))
             {
-                var pendingInbound = _walletOperations.UpdateAccountUnconfirmedInfoWithSpentTransaction(accountInfo, res.Data);
+                var pendingInbound = _walletOperations.UpdateAccountUnconfirmedInfoWithSpentTransaction(accountInfo, _sendInfo.SignedTransaction.Transaction);
                 unconfirmedInfo.AddRange(pendingInbound);
                 accountBalanceInfo.UpdateAccountBalanceInfo(accountInfo, unconfirmedInfo);
                 storage.SetAccountInfo(network.Name, accountInfo);
@@ -1662,7 +1663,7 @@ else
             }
             else
             {
-                notificationComponent.ShowErrorMessage($"Sending failed! {res.Message}");
+                notificationComponent.ShowErrorMessage($"Sending failed! {publishError}");
             }
 
             _sendInfo = new SendInfo();


### PR DESCRIPTION
## Summary
- Replaces calls to the removed IWalletOperations.PublishTransactionAsync with direct calls to IIndexerService.PublishTransactionAsync in all 7 affected Blazor razor pages
- Adds missing IIndexerService injection to Wallet.razor, Invest.razor, and Create.razor
- Fixes 9 build errors introduced when PublishTransactionAsync was removed from IWalletOperations in #800 without updating the webapp callers