### PR TITLE
Add iOS App.iOS project with Apple Keychain ISecureKeyProvider

### DIFF
--- a/src/App.sln
+++ b/src/App.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App.Test.Integration", "des
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App.Android", "design\App.Android\App.Android.csproj", "{F9C55CB9-1D6A-48AD-B246-0E4C3F3FFF07}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App.iOS", "design\App.iOS\App.iOS.csproj", "{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -127,6 +129,18 @@ Global
 		{F9C55CB9-1D6A-48AD-B246-0E4C3F3FFF07}.Release|x64.Build.0 = Release|Any CPU
 		{F9C55CB9-1D6A-48AD-B246-0E4C3F3FFF07}.Release|x86.ActiveCfg = Release|Any CPU
 		{F9C55CB9-1D6A-48AD-B246-0E4C3F3FFF07}.Release|x86.Build.0 = Release|Any CPU
+		{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}.Debug|x64.Build.0 = Debug|Any CPU
+		{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}.Debug|x86.Build.0 = Debug|Any CPU
+		{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}.Release|x64.ActiveCfg = Release|Any CPU
+		{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}.Release|x64.Build.0 = Release|Any CPU
+		{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}.Release|x86.ActiveCfg = Release|Any CPU
+		{5EE5BA69-B721-4A1D-ACD2-167D3A1EEBAF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/design/App.iOS/App.iOS.csproj
+++ b/src/design/App.iOS/App.iOS.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0-ios</TargetFramework>
+        <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+        <Nullable>enable</Nullable>
+        <RootNamespace>App.iOS</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Avalonia.iOS" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\App\App.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/design/App.iOS/AppDelegate.cs
+++ b/src/design/App.iOS/AppDelegate.cs
@@ -1,0 +1,23 @@
+using Angor.Sdk.Wallet.Infrastructure.Interfaces;
+using Avalonia;
+using Avalonia.iOS;
+using Foundation;
+using Microsoft.Extensions.DependencyInjection;
+using UIKit;
+
+namespace App.iOS;
+
+[Register("AppDelegate")]
+public partial class AppDelegate : AvaloniaAppDelegate<global::App.App>
+{
+    protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
+    {
+        global::App.App.PlatformServices = services =>
+        {
+            services.AddSingleton<ISecureKeyProvider, KeychainSecureKeyProvider>();
+        };
+
+        return base.CustomizeAppBuilder(builder)
+            .WithInterFont();
+    }
+}

--- a/src/design/App.iOS/Info.plist
+++ b/src/design/App.iOS/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Angor</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.angor.app</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>15.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/src/design/App.iOS/KeychainSecureKeyProvider.cs
+++ b/src/design/App.iOS/KeychainSecureKeyProvider.cs
@@ -1,0 +1,97 @@
+using System.Security.Cryptography;
+using System.Text;
+using Angor.Sdk.Common;
+using Angor.Sdk.Wallet.Infrastructure.Interfaces;
+using CSharpFunctionalExtensions;
+using Foundation;
+using Security;
+
+namespace App.iOS;
+
+/// <summary>
+/// iOS ISecureKeyProvider backed by the Apple Keychain. Each per-wallet encryption
+/// key is stored as a separate generic-password item, scoped by a profile-specific
+/// service name. Keys are protected with WhenUnlockedThisDeviceOnly — they are only
+/// accessible while the device is unlocked and are never included in backups.
+/// </summary>
+public class KeychainSecureKeyProvider : ISecureKeyProvider
+{
+    private readonly string _service;
+
+    public KeychainSecureKeyProvider(IApplicationStorage storage, ProfileContext profileContext)
+    {
+        _service = $"{profileContext.AppName}-{profileContext.ProfileName}-WalletKeys";
+    }
+
+    public Task<Maybe<string>> Get(WalletId walletId)
+    {
+        var query = new SecRecord(SecKind.GenericPassword)
+        {
+            Service = _service,
+            Account = walletId.Value,
+        };
+
+        var status = SecKeyChain.QueryAsData(query, false, out var data);
+
+        if (status == SecStatusCode.Success && data != null)
+        {
+            var key = NSString.FromData(data, NSStringEncoding.UTF8)?.ToString();
+            return Task.FromResult(key != null
+                ? Maybe<string>.From(key)
+                : Maybe<string>.None);
+        }
+
+        return Task.FromResult(Maybe<string>.None);
+    }
+
+    public Task Save(WalletId walletId, string key)
+    {
+        var existing = new SecRecord(SecKind.GenericPassword)
+        {
+            Service = _service,
+            Account = walletId.Value,
+        };
+
+        var status = SecKeyChain.QueryAsData(existing, false, out _);
+
+        if (status == SecStatusCode.Success)
+        {
+            var update = new SecRecord
+            {
+                ValueData = NSData.FromString(key, NSStringEncoding.UTF8),
+            };
+            SecKeyChain.Update(existing, update);
+        }
+        else
+        {
+            var record = new SecRecord(SecKind.GenericPassword)
+            {
+                Service = _service,
+                Account = walletId.Value,
+                ValueData = NSData.FromString(key, NSStringEncoding.UTF8),
+                Accessible = SecAccessible.WhenUnlockedThisDeviceOnly,
+            };
+            SecKeyChain.Add(record);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task Remove(WalletId walletId)
+    {
+        var record = new SecRecord(SecKind.GenericPassword)
+        {
+            Service = _service,
+            Account = walletId.Value,
+        };
+        SecKeyChain.Remove(record);
+        return Task.CompletedTask;
+    }
+
+    public string GenerateKey()
+    {
+        var bytes = new byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes);
+    }
+}

--- a/src/design/App.iOS/Main.cs
+++ b/src/design/App.iOS/Main.cs
@@ -1,0 +1,11 @@
+using UIKit;
+
+namespace App.iOS;
+
+public class Application
+{
+    static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `design/App.iOS` project targeting `net9.0-ios` with Avalonia entry point (AppDelegate + Main.cs)
- Implement `KeychainSecureKeyProvider` using Apple Keychain (`SecKeyChain` API) with `WhenUnlockedThisDeviceOnly` protection
- Each wallet key stored as a separate generic-password Keychain item, scoped by profile service name

## Details
Mirrors the existing `App.Android` pattern:
- `AppDelegate` registers `KeychainSecureKeyProvider` via the `PlatformServices` callback
- No changes needed to `CompositionRoot` or `App.axaml.cs` — existing platform hooks handle iOS
- Info.plist configured with bundle ID `io.angor.app`, min iOS 15, portrait-only on iPhone

## Test plan
- [ ] Build `App.iOS` on macOS with Xcode to verify compilation
- [ ] Deploy to iOS simulator and verify wallet key creation/retrieval via Keychain
- [ ] Verify existing desktop and Android builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)