### PR TITLE
fix: handle unexpected JSON response in mempool transaction fetch

### DIFF
--- a/src/shared/Angor.Shared/Services/MempoolIndexerAngorApi.cs
+++ b/src/shared/Angor.Shared/Services/MempoolIndexerAngorApi.cs
@@ -73,7 +73,16 @@ public class MempoolIndexerAngorApi : IAngorIndexerService
                 return allTransactions;
             }
 
-            var page = await response.Content.ReadFromJsonAsync<List<MempoolSpaceIndexerApi.MempoolTransaction>>(jsonOptions);
+            List<MempoolSpaceIndexerApi.MempoolTransaction>? page;
+            try
+            {
+                page = await response.Content.ReadFromJsonAsync<List<MempoolSpaceIndexerApi.MempoolTransaction>>(jsonOptions);
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex, "Failed to deserialize transactions for address {Address}, treating as empty", projectAddress);
+                break;
+            }
 
             if (page == null || page.Count == 0)
             {


### PR DESCRIPTION
## Summary
- Catches JsonException in FetchAllAddressTransactionsAsync when the mempool API returns non-array JSON instead of letting it crash GetProjectStatsAsync
- Logs a warning and treats the unexpected response as an empty result