### PR TITLE
fix: show actual error message and spinner on send button

### DIFF
--- a/src/design/App/UI/Sections/Funds/FundsViewModel.cs
+++ b/src/design/App/UI/Sections/Funds/FundsViewModel.cs
@@ -219,7 +219,7 @@ public partial class FundsViewModel : ReactiveObject
     /// Send funds from a wallet to a destination address.
     /// Returns the transaction ID on success.
     /// </summary>
-    public async Task<(bool Success, string? TxId)> SendAsync(string walletId, string destinationAddress, double amountBtc, long feeRateSatsPerVByte)
+    public async Task<(bool Success, string? TxId, string? Error)> SendAsync(string walletId, string destinationAddress, double amountBtc, long feeRateSatsPerVByte)
     {
         try
         {
@@ -235,17 +235,17 @@ public partial class FundsViewModel : ReactiveObject
             {
                 // Refresh the sending wallet's balance from the indexer
                 await _walletContext.RefreshBalanceAsync(id);
-                return (true, result.Value.Value);
+                return (true, result.Value.Value, null);
             }
 
             _logger.LogError("SendAmount failed for wallet {WalletId} to address '{Address}' amount {Sats} sats feeRate {FeeRate}: {Error}", walletId, destinationAddress, sats, feeRateSatsPerVByte, result.Error);
+            return (false, null, result.Error);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "SendAsync threw an exception for wallet {WalletId}", walletId);
+            return (false, null, ex.Message);
         }
-
-        return (false, null);
     }
 
     /// <summary>

--- a/src/design/App/UI/Sections/Funds/SendFundsModal.axaml
+++ b/src/design/App/UI/Sections/Funds/SendFundsModal.axaml
@@ -194,12 +194,22 @@
                                         <GradientStop Color="#3D6448" Offset="1" />
                                     </LinearGradientBrush>
                                 </Button.Background>
-                                <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <i:Icon Value="fa-solid fa-paper-plane"
-                                           FontSize="14" Foreground="White"
-                                           VerticalAlignment="Center" />
-                                    <TextBlock Text="Send" VerticalAlignment="Center" />
-                                </StackPanel>
+                                <Panel>
+                                    <StackPanel Name="SendBtnContent" Orientation="Horizontal" Spacing="8"
+                                                HorizontalAlignment="Center">
+                                        <i:Icon Value="fa-solid fa-paper-plane"
+                                               FontSize="14" Foreground="White"
+                                               VerticalAlignment="Center" />
+                                        <TextBlock Text="Send" VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <StackPanel Name="SendBtnSpinner" Orientation="Horizontal" Spacing="8"
+                                                HorizontalAlignment="Center" IsVisible="False">
+                                        <i:Icon Value="fa-solid fa-spinner" FontSize="14"
+                                                Foreground="White" VerticalAlignment="Center"
+                                                Classes="spin" />
+                                        <TextBlock Text="Sending..." VerticalAlignment="Center" />
+                                    </StackPanel>
+                                </Panel>
                             </Button>
                         </Grid>
                     </StackPanel>

--- a/src/design/App/UI/Sections/Funds/SendFundsModal.axaml.cs
+++ b/src/design/App/UI/Sections/Funds/SendFundsModal.axaml.cs
@@ -146,13 +146,19 @@ public partial class SendFundsModal : UserControl, IBackdropCloseable
         if (!double.TryParse(AmountInput.Text, System.Globalization.NumberStyles.Any,
                 System.Globalization.CultureInfo.InvariantCulture, out var amount)) return;
 
-        // Disable send button during operation
+        // Disable send button and show spinner during operation
         var sendBtn = this.FindControl<Button>("BtnSend");
+        var sendBtnContent = this.FindControl<StackPanel>("SendBtnContent");
+        var sendBtnSpinner = this.FindControl<StackPanel>("SendBtnSpinner");
         if (sendBtn != null) sendBtn.IsEnabled = false;
+        if (sendBtnContent != null) sendBtnContent.IsVisible = false;
+        if (sendBtnSpinner != null) sendBtnSpinner.IsVisible = true;
 
-        var (success, txId) = await fundsVm.SendAsync(_walletId, address, amount, feeRate);
+        var (success, txId, error) = await fundsVm.SendAsync(_walletId, address, amount, feeRate);
 
         if (sendBtn != null) sendBtn.IsEnabled = true;
+        if (sendBtnContent != null) sendBtnContent.IsVisible = true;
+        if (sendBtnSpinner != null) sendBtnSpinner.IsVisible = false;
 
         if (success && txId != null)
         {
@@ -164,7 +170,7 @@ public partial class SendFundsModal : UserControl, IBackdropCloseable
         }
         else
         {
-            AmountError.Text = "Transaction failed. Please try again.";
+            AmountError.Text = error ?? "Transaction failed. Please try again.";
             AmountError.IsVisible = true;
         }
     }


### PR DESCRIPTION
## Summary
- **Show actual SDK error messages** in the send funds UI instead of the generic "Transaction failed. Please try again." message. Errors like insufficient funds or fee calculation failures are now displayed directly.
- **Add loading spinner** to the Send button while the transaction is being processed, following the existing spinner pattern used elsewhere in the app (e.g. CreateWalletModal).

### Changes
- `FundsViewModel.SendAsync` now returns `(bool Success, string? TxId, string? Error)` instead of `(bool, string?)`, propagating the error from the SDK layer.
- `SendFundsModal.axaml` adds a spinner panel to the Send button that toggles during the async operation.
- `SendFundsModal.axaml.cs` toggles spinner visibility and displays the error string when present.
