### PR TITLE
Persist create-project wizard draft to disk

### DIFF
--- a/src/design/App/Composition/CompositionRoot.cs
+++ b/src/design/App/Composition/CompositionRoot.cs
@@ -165,6 +165,7 @@ public static class CompositionRoot
         services.AddTransient<MyProjectsViewModel>();
         services.AddTransient<FundersViewModel>();
         services.AddTransient<CreateProjectViewModel>();
+        services.AddSingleton<ProjectDraftStorage>();
         services.AddTransient<DeployFlowViewModel>();
         services.AddTransient<HomeViewModel>();
 

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectView.axaml.cs
@@ -535,7 +535,7 @@ public partial class CreateProjectView : UserControl
         var myProjectsView = this.FindAncestorOfType<MyProjectsView>();
         if (myProjectsView?.DataContext is MyProjectsViewModel myVm)
         {
-            myVm.ShowCreateWizard = false;
+            myVm.CancelCreateWizard();
         }
     }
 }

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
@@ -149,6 +149,9 @@ public partial class CreateProjectViewModel : ReactiveObject
 
     private readonly ICurrencyService _currencyService;
     private readonly INetworkConfiguration _networkConfiguration;
+    private readonly ProjectDraftStorage _draftStorage;
+    private readonly IWalletContext _walletContext;
+    private bool _isLoadingDraft;
 
     /// <summary>
     /// True when debug mode is enabled AND on testnet.
@@ -169,11 +172,13 @@ public partial class CreateProjectViewModel : ReactiveObject
     /// <summary>e.g. "Price per period (BTC) *"</summary>
     public string PricePerPeriodLabel => _currencyService.PricePerPeriodLabel;
 
-    public CreateProjectViewModel(DeployFlowViewModel deployFlow, ICurrencyService currencyService, INetworkConfiguration networkConfiguration)
+    public CreateProjectViewModel(DeployFlowViewModel deployFlow, ICurrencyService currencyService, INetworkConfiguration networkConfiguration, ProjectDraftStorage draftStorage, IWalletContext walletContext)
     {
         DeployFlow = deployFlow;
         _currencyService = currencyService;
         _networkConfiguration = networkConfiguration;
+        _draftStorage = draftStorage;
+        _walletContext = walletContext;
         // Default start date to today (UTC)
         StartDate = DateTime.UtcNow.ToString("yyyy-MM-dd");
         InvestStartDate = DateTime.UtcNow;
@@ -256,6 +261,36 @@ public partial class CreateProjectViewModel : ReactiveObject
                 this.RaisePropertyChanged(nameof(HasFormError));
                 this.RaisePropertyChanged(nameof(HasEndDateError));
             });
+
+        // ── Auto-save draft on any user input change (debounced) ──
+        Observable.Merge(
+                this.WhenAnyValue(x => x.ProjectType).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.ProjectName).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.ProjectAbout).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.ProjectWebsite).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.BannerUrl).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.ProfileUrl).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.TargetAmount).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.InvestStartDate).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.InvestEndDate).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.PenaltyDays).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.ApprovalThreshold).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.SubscriptionPrice).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.DurationValue).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.DurationUnit).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.DurationPreset).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.ReleaseFrequency).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.PayoutFrequency).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.MonthlyPayoutDate).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.WeeklyPayoutDay).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.CurrentStep).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.ShowWelcome).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.ShowStep5Welcome).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.IsAdvancedEditor).Select(_ => Unit.Default),
+                this.WhenAnyValue(x => x.ShowGenerateForm).Select(_ => Unit.Default))
+            .Throttle(TimeSpan.FromSeconds(2))
+            .Where(_ => !_isLoadingDraft && HasInProgressData)
+            .Subscribe(unit => { Task.Run(() => SaveDraftAsync()); });
     }
 
     public string DeployButtonText => IsDeploying ? "Deploying..." : "Deploy Project";
@@ -619,6 +654,7 @@ public partial class CreateProjectViewModel : ReactiveObject
         {
             IsDeployed = true;
             this.RaisePropertyChanged(nameof(DeployButtonText));
+            _ = DeleteDraftAsync();
             // Matches Vue goToMyProjects(): add project to list + close wizard + navigate to list
             OnProjectDeployed?.Invoke();
         };
@@ -1200,7 +1236,193 @@ public partial class CreateProjectViewModel : ReactiveObject
 
         // Re-evaluate debug mode (may have changed in settings since last open)
         this.RaisePropertyChanged(nameof(IsDebugMode));
-    }    /// <summary>
+
+        // Delete persisted draft
+        _ = DeleteDraftAsync();
+    }
+
+    /// <summary>
+    /// Load a previously saved draft from disk and populate all wizard fields.
+    /// Called by MyProjectsView when opening the wizard.
+    /// </summary>
+    public async Task<bool> LoadDraftAsync()
+    {
+        try
+        {
+            string? walletId = _walletContext.SelectedWallet?.Id.Value;
+            if (string.IsNullOrEmpty(walletId)) return false;
+
+            var result = await _draftStorage.LoadAsync(walletId);
+            if (result.IsFailure) return false;
+
+            ProjectDraft? draft = result.Value;
+            if (draft == null) return false;
+
+            _isLoadingDraft = true;
+            try
+            {
+            // Navigation
+            ShowWelcome = draft.ShowWelcome;
+            ShowStep5Welcome = draft.ShowStep5Welcome;
+
+            // Step 1
+            ProjectType = draft.ProjectType;
+            this.RaisePropertyChanged(nameof(IsInvestment));
+            this.RaisePropertyChanged(nameof(IsFund));
+            this.RaisePropertyChanged(nameof(IsSubscription));
+            this.RaisePropertyChanged(nameof(IsTypeSelected));
+            this.RaisePropertyChanged(nameof(StepNames));
+
+            // Step 2
+            ProjectName = draft.ProjectName;
+            ProjectAbout = draft.ProjectAbout;
+            ProjectWebsite = draft.ProjectWebsite;
+
+            // Step 3
+            BannerUrl = draft.BannerUrl;
+            ProfileUrl = draft.ProfileUrl;
+
+            // Step 4
+            TargetAmount = draft.TargetAmount;
+            StartDate = draft.StartDate;
+            EndDate = draft.EndDate;
+            PenaltyDays = draft.PenaltyDays;
+            ApprovalThreshold = draft.ApprovalThreshold;
+            SubscriptionPrice = draft.SubscriptionPrice;
+            InvestStartDate = draft.InvestStartDate;
+            InvestEndDate = draft.InvestEndDate;
+
+            // Step 5
+            DurationValue = draft.DurationValue;
+            DurationUnit = draft.DurationUnit;
+            DurationPreset = draft.DurationPreset;
+            ReleaseFrequency = draft.ReleaseFrequency;
+            PayoutFrequency = draft.PayoutFrequency;
+            MonthlyPayoutDate = draft.MonthlyPayoutDate;
+            WeeklyPayoutDay = draft.WeeklyPayoutDay;
+            SelectedInstallmentCounts.Clear();
+            foreach (int count in draft.SelectedInstallmentCounts)
+                SelectedInstallmentCounts.Add(count);
+            IsAdvancedEditor = draft.IsAdvancedEditor;
+            ShowGenerateForm = draft.ShowGenerateForm;
+            SelectedPayoutPattern = draft.SelectedPayoutPattern;
+            PayoutDay = draft.PayoutDay;
+
+            // Stages
+            Stages.Clear();
+            foreach (StageDraft stageDraft in draft.Stages)
+            {
+                Stages.Add(new ProjectStageViewModel
+                {
+                    StageNumber = stageDraft.StageNumber,
+                    PercentageValue = stageDraft.PercentageValue,
+                    ReleaseDateValue = stageDraft.ReleaseDateValue,
+                    StageLabel = stageDraft.StageLabel,
+                    Percentage = $"{stageDraft.PercentageValue:F0}%",
+                    ReleaseDate = stageDraft.ReleaseDateValue.ToString("d MMMM yyyy"),
+                });
+            }
+            this.RaisePropertyChanged(nameof(HasStages));
+            this.RaisePropertyChanged(nameof(ScheduleSummary));
+
+            // Navigation (set last so step visibility is correct after all data is loaded)
+            CurrentStep = draft.CurrentStep;
+            MaxStepReached = draft.MaxStepReached;
+            RaiseAllStepProperties();
+
+            return true;
+            }
+            finally
+            {
+                _isLoadingDraft = false;
+            }
+        }
+        catch
+        {
+            // Draft may be corrupted or incompatible — discard it
+            _isLoadingDraft = false;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Persist current wizard state to disk.
+    /// </summary>
+    public async Task SaveDraftAsync()
+    {
+        try
+        {
+            string? walletId = _walletContext.SelectedWallet?.Id.Value;
+            if (string.IsNullOrEmpty(walletId)) return;
+
+            var draft = new ProjectDraft
+            {
+                WalletId = walletId,
+                CurrentStep = CurrentStep,
+                MaxStepReached = MaxStepReached,
+                ShowWelcome = ShowWelcome,
+                ShowStep5Welcome = ShowStep5Welcome,
+                ProjectType = ProjectType,
+                ProjectName = ProjectName,
+                ProjectAbout = ProjectAbout,
+                ProjectWebsite = ProjectWebsite,
+                BannerUrl = BannerUrl,
+                ProfileUrl = ProfileUrl,
+                TargetAmount = TargetAmount,
+                StartDate = StartDate,
+                EndDate = EndDate,
+                PenaltyDays = PenaltyDays,
+                ApprovalThreshold = ApprovalThreshold,
+                SubscriptionPrice = SubscriptionPrice,
+                InvestStartDate = InvestStartDate,
+                InvestEndDate = InvestEndDate,
+                DurationValue = DurationValue,
+                DurationUnit = DurationUnit,
+                DurationPreset = DurationPreset,
+                ReleaseFrequency = ReleaseFrequency,
+                PayoutFrequency = PayoutFrequency,
+                MonthlyPayoutDate = MonthlyPayoutDate,
+                WeeklyPayoutDay = WeeklyPayoutDay,
+                SelectedInstallmentCounts = SelectedInstallmentCounts.ToList(),
+                IsAdvancedEditor = IsAdvancedEditor,
+                ShowGenerateForm = ShowGenerateForm,
+                SelectedPayoutPattern = SelectedPayoutPattern,
+                PayoutDay = PayoutDay,
+                Stages = Stages.Select(s => new StageDraft
+                {
+                    StageNumber = s.StageNumber,
+                    PercentageValue = s.PercentageValue,
+                    ReleaseDateValue = s.ReleaseDateValue,
+                    StageLabel = s.StageLabel,
+                }).ToList(),
+            };
+
+            await _draftStorage.SaveAsync(draft);
+        }
+        catch
+        {
+            // Silently ignore save failures — draft persistence is best-effort
+        }
+    }
+
+    /// <summary>
+    /// Delete the persisted draft for the current wallet.
+    /// </summary>
+    public async Task DeleteDraftAsync()
+    {
+        try
+        {
+            string? walletId = _walletContext.SelectedWallet?.Id.Value;
+            if (string.IsNullOrEmpty(walletId)) return;
+            await _draftStorage.DeleteAsync(walletId);
+        }
+        catch
+        {
+            // Silently ignore delete failures
+        }
+    }
+
+    /// <summary>
     /// Prepopulate all wizard fields with debug/test data so the user can
     /// click Next through every step and deploy quickly on testnet.
     /// Values mirror the Avalonia app's PopulateInvestDebugDefaults / PopulateFundDebugDefaults.

--- a/src/design/App/UI/Sections/MyProjects/EditProfile/EditProfileView.axaml
+++ b/src/design/App/UI/Sections/MyProjects/EditProfile/EditProfileView.axaml
@@ -410,7 +410,8 @@
                                                    Foreground="{DynamicResource TextMuted}" />
                                         <TextBox Name="PicBlossomServerBox"
                                                  Classes="EditField"
-                                                 Watermark="https://nostr.build"
+                                                 Text="https://blossom.angor.io"
+                                                 Watermark="Blossom server URL"
                                                  FontSize="13" />
                                         <DockPanel>
                                             <Button Name="PicUploadBtn"
@@ -553,7 +554,8 @@
                                                Foreground="{DynamicResource TextMuted}" />
                                     <TextBox Name="BannerBlossomServerBox"
                                              Classes="EditField"
-                                             Watermark="https://nostr.build"
+                                             Text="https://blossom.angor.io"
+                                             Watermark="Blossom server URL"
                                              FontSize="13" />
                                     <DockPanel>
                                         <Button Name="BannerUploadBtn"

--- a/src/design/App/UI/Sections/MyProjects/MyProjectsView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/MyProjectsView.axaml.cs
@@ -479,12 +479,16 @@ public partial class MyProjectsView : UserControl, ISectionView
         }
     }
 
-    private void OpenCreateWizard(MyProjectsViewModel vm)
+    private async void OpenCreateWizard(MyProjectsViewModel vm)
     {
         CreateProjectViewModel wvm = vm.CreateProjectVm;
         // Only reset when there is no in-progress data: fresh start or after a successful deploy.
         if (!wvm.HasInProgressData)
-            wvm.ResetWizard();
+        {
+            bool loaded = await wvm.LoadDraftAsync();
+            if (!loaded)
+                wvm.ResetWizard();
+        }
         WireWizardCallbacks(vm, wvm);
         vm.LaunchCreateWizard();
         EnsureCreateWizardView(vm, resetVisualState: true);

--- a/src/design/App/UI/Sections/MyProjects/MyProjectsViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/MyProjectsViewModel.cs
@@ -246,7 +246,19 @@ public partial class MyProjectsViewModel : ReactiveObject
         this.RaisePropertyChanged(nameof(TotalRaised));
     }
 
-    public void CloseCreateWizard() => ShowCreateWizard = false;
+    public void CloseCreateWizard()
+    {
+        ShowCreateWizard = false;
+    }
+
+    /// <summary>
+    /// Cancel the wizard: reset all data, delete the draft, and close.
+    /// </summary>
+    public void CancelCreateWizard()
+    {
+        CreateProjectVm.ResetWizard();
+        ShowCreateWizard = false;
+    }
 
     public void ClearProjects()
     {
@@ -259,7 +271,7 @@ public partial class MyProjectsViewModel : ReactiveObject
     public void ResetAfterNetworkSwitch()
     {
         CloseManageProject();
-        CloseCreateWizard();
+        CancelCreateWizard();
         SelectedEditProject = null;
         ClearProjects();
     }

--- a/src/design/App/UI/Sections/MyProjects/ProjectDraft.cs
+++ b/src/design/App/UI/Sections/MyProjects/ProjectDraft.cs
@@ -1,0 +1,69 @@
+namespace App.UI.Sections.MyProjects;
+
+/// <summary>
+/// Serializable snapshot of the Create Project wizard state.
+/// Persisted to LiteDB so the user can resume after closing the app.
+/// </summary>
+public class ProjectDraft
+{
+    /// <summary>Keyed by wallet ID so each wallet gets its own draft.</summary>
+    public string WalletId { get; set; } = "";
+
+    // ── Navigation ──
+    public int CurrentStep { get; set; } = 1;
+    public int MaxStepReached { get; set; } = 1;
+    public bool ShowWelcome { get; set; } = true;
+    public bool ShowStep5Welcome { get; set; } = true;
+
+    // ── Step 1: Project Type ──
+    public string ProjectType { get; set; } = "";
+
+    // ── Step 2: Project Profile ──
+    public string ProjectName { get; set; } = "";
+    public string ProjectAbout { get; set; } = "";
+    public string ProjectWebsite { get; set; } = "";
+
+    // ── Step 3: Project Images ──
+    public string BannerUrl { get; set; } = "";
+    public string ProfileUrl { get; set; } = "";
+
+    // ── Step 4: Funding Config ──
+    public string TargetAmount { get; set; } = "";
+    public string StartDate { get; set; } = "";
+    public string EndDate { get; set; } = "";
+    public int PenaltyDays { get; set; } = 90;
+    public string ApprovalThreshold { get; set; } = "0.001";
+    public string SubscriptionPrice { get; set; } = "";
+    public DateTime? InvestStartDate { get; set; }
+    public DateTime? InvestEndDate { get; set; }
+
+    // ── Step 5: Stages/Payouts ──
+    public string DurationValue { get; set; } = "0";
+    public string DurationUnit { get; set; } = "Months";
+    public int? DurationPreset { get; set; }
+    public string ReleaseFrequency { get; set; } = "";
+    public string PayoutFrequency { get; set; } = "";
+    public int? MonthlyPayoutDate { get; set; }
+    public string WeeklyPayoutDay { get; set; } = "";
+    public List<int> SelectedInstallmentCounts { get; set; } = new();
+    public bool IsAdvancedEditor { get; set; }
+    public bool ShowGenerateForm { get; set; } = true;
+    public string SelectedPayoutPattern { get; set; } = "";
+    public string PayoutDay { get; set; } = "1";
+
+    // ── Generated Stages ──
+    public List<StageDraft> Stages { get; set; } = new();
+
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// Serializable snapshot of a single stage in the wizard.
+/// </summary>
+public class StageDraft
+{
+    public int StageNumber { get; set; }
+    public double PercentageValue { get; set; }
+    public DateOnly ReleaseDateValue { get; set; }
+    public string StageLabel { get; set; } = "Stage";
+}

--- a/src/design/App/UI/Sections/MyProjects/ProjectDraftStorage.cs
+++ b/src/design/App/UI/Sections/MyProjects/ProjectDraftStorage.cs
@@ -1,0 +1,33 @@
+using Angor.Data.Documents.Interfaces;
+using CSharpFunctionalExtensions;
+
+namespace App.UI.Sections.MyProjects;
+
+/// <summary>
+/// Persists and retrieves project wizard drafts, keyed by wallet ID.
+/// </summary>
+public class ProjectDraftStorage
+{
+    private readonly IGenericDocumentCollection<ProjectDraft> _collection;
+
+    public ProjectDraftStorage(IGenericDocumentCollection<ProjectDraft> collection)
+    {
+        _collection = collection;
+    }
+
+    public async Task<Result> SaveAsync(ProjectDraft draft)
+    {
+        draft.UpdatedAt = DateTime.UtcNow;
+        return await _collection.UpsertAsync(d => d.WalletId, draft);
+    }
+
+    public async Task<Result<ProjectDraft?>> LoadAsync(string walletId)
+    {
+        return await _collection.FindByIdAsync(walletId);
+    }
+
+    public async Task<Result> DeleteAsync(string walletId)
+    {
+        return await _collection.DeleteAsync(walletId);
+    }
+}

--- a/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep3View.axaml
+++ b/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep3View.axaml
@@ -97,7 +97,8 @@
 
                     <!-- Blossom upload row -->
                     <TextBox Name="BannerBlossomServerTextBox"
-                             Watermark="Blossom server URL (e.g. https://nostr.build)"
+                             Text="https://blossom.angor.io"
+                             Watermark="Blossom server URL"
                              Padding="12,10" FontSize="14" CornerRadius="8" />
                     <DockPanel>
                         <Button Name="BannerUploadBtn"
@@ -193,7 +194,8 @@
 
                     <!-- Blossom upload row -->
                     <TextBox Name="ProfileBlossomServerTextBox"
-                             Watermark="Blossom server URL (e.g. https://nostr.build)"
+                             Text="https://blossom.angor.io"
+                             Watermark="Blossom server URL"
                              Padding="12,10" FontSize="14" CornerRadius="8" />
                     <DockPanel>
                         <Button Name="ProfileUploadBtn"

--- a/src/sdk/Angor.Data.Documents.LiteDb/LiteDbDocumentMapping.cs
+++ b/src/sdk/Angor.Data.Documents.LiteDb/LiteDbDocumentMapping.cs
@@ -9,5 +9,9 @@ public class LiteDbDocumentMapping
             .Id(x => x.Id)
             .Field(x => x.CreatedAt, "created_at")
             .Field(x => x.UpdatedAt, "updated_at");
+
+        BsonMapper.Global.RegisterType<DateOnly>(
+            serialize: d => d.ToString("O"),
+            deserialize: bson => DateOnly.ParseExact(bson.AsString, "O"));
     }
 }


### PR DESCRIPTION
## Summary
- Persist wizard state to LiteDB so users can resume after app restart (crash recovery)
- Auto-save on field changes with 2-second debounce; load draft on wizard open
- Draft is deleted on successful deploy or explicit cancel
- Split CloseCreateWizard (hide, preserve data) from CancelCreateWizard (reset + delete draft) so navigating between tabs no longer wipes wizard data
- Register DateOnly type mapping in LiteDB for stage release dates

## Files changed
- **ProjectDraft.cs** / **ProjectDraftStorage.cs** - new draft document and LiteDB-backed storage
- **CreateProjectViewModel.cs** - auto-save subscription, LoadDraftAsync, SaveDraftAsync, DeleteDraftAsync
- **MyProjectsViewModel.cs** - CancelCreateWizard for explicit discard vs CloseCreateWizard for hide
- **MyProjectsView.axaml.cs** - load draft on wizard open
- **CreateProjectView.axaml.cs** - cancel uses CancelCreateWizard
- **CompositionRoot.cs** - register ProjectDraftStorage
- **LiteDbDocumentMapping.cs** - DateOnly serialization support