### PR TITLE
Add cross-distro Docker test runners (Ubuntu, Fedora, Debian)

### DIFF
--- a/.github/workflows/ci-linux-distros.yml
+++ b/.github/workflows/ci-linux-distros.yml
@@ -26,6 +26,11 @@ on:
           - ubuntu
           - fedora
           - debian
+          - mint
+          - arch
+          - opensuse
+          - rocky
+          - manjaro
 
 env:
   COMPOSE_DIR: src/design/App.Test.Integration/docker
@@ -72,7 +77,7 @@ jobs:
         working-directory: ${{ env.COMPOSE_DIR }}
         run: |
           echo "=== Container exit codes ==="
-          for svc in ubuntu fedora debian; do
+          for svc in ubuntu fedora debian mint arch opensuse rocky manjaro; do
             code=$(docker inspect --format='{{.State.ExitCode}}' "angor-test-runner-${svc}" 2>/dev/null || echo "N/A")
             echo "  ${svc}: ${code}"
           done

--- a/.github/workflows/ci-linux-distros.yml
+++ b/.github/workflows/ci-linux-distros.yml
@@ -1,0 +1,95 @@
+name: CI - Linux Distro Tests
+
+# Cross-distro test runner — currently manual-only.
+# TODO: wire up a self-hosted runner triggered by GitHub Actions for heavy
+# local execution instead of running on GitHub-hosted runners.
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_scope:
+        description: 'Test scope: unit, integration, or all'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - unit
+          - integration
+      distro:
+        description: 'Distro to test (blank = all)'
+        required: false
+        default: ''
+        type: choice
+        options:
+          - ''
+          - ubuntu
+          - fedora
+          - debian
+
+env:
+  COMPOSE_DIR: src/design/App.Test.Integration/docker
+
+jobs:
+  distro-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Integration tests need the bitcoin-custom-signet sibling repo
+          # for building the signet node and faucet images.
+          submodules: false
+
+      - name: Clone bitcoin-custom-signet
+        run: |
+          git clone --depth 1 https://github.com/block-core/bitcoin-custom-signet.git ../bitcoin-custom-signet
+
+      - name: Start infrastructure stack
+        working-directory: ${{ env.COMPOSE_DIR }}
+        run: |
+          docker compose up -d
+          echo "Waiting for infra stack to become healthy..."
+          # Wait up to 3 minutes for the Bitcoin node health check
+          timeout 180 bash -c 'until docker inspect --format="{{.State.Health.Status}}" angor-test-btc-node 2>/dev/null | grep -q healthy; do sleep 5; done'
+          echo "Infrastructure stack is ready."
+
+      - name: Run distro tests
+        working-directory: ${{ env.COMPOSE_DIR }}
+        env:
+          TEST_SCOPE: ${{ inputs.test_scope || 'all' }}
+        run: |
+          DISTRO="${{ inputs.distro }}"
+          if [ -n "$DISTRO" ]; then
+            docker compose -f docker-compose.tests.yml up --build --abort-on-container-exit "$DISTRO"
+          else
+            docker compose -f docker-compose.tests.yml up --build --abort-on-container-exit
+          fi
+
+      - name: Collect test results
+        if: always()
+        working-directory: ${{ env.COMPOSE_DIR }}
+        run: |
+          echo "=== Container exit codes ==="
+          for svc in ubuntu fedora debian; do
+            code=$(docker inspect --format='{{.State.ExitCode}}' "angor-test-runner-${svc}" 2>/dev/null || echo "N/A")
+            echo "  ${svc}: ${code}"
+          done
+
+      - name: Dump logs on failure
+        if: failure()
+        working-directory: ${{ env.COMPOSE_DIR }}
+        run: |
+          echo "=== Test runner logs ==="
+          docker compose -f docker-compose.tests.yml logs --no-color
+          echo ""
+          echo "=== Infrastructure logs (last 50 lines each) ==="
+          docker compose logs --no-color --tail=50
+
+      - name: Tear down
+        if: always()
+        working-directory: ${{ env.COMPOSE_DIR }}
+        run: |
+          docker compose -f docker-compose.tests.yml down -v
+          docker compose down -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,43 @@ Width tokens live in `UI/Themes/V2/Resources/Tokens.axaml` (`ModalMinWidth`, `Mo
 - **`gh-deploy-test.yml`**: Triggered by push to main; deploys to test.angor.io
 - **`pr-deploy.yml`**: Manual workflow; deploys a PR to debug.angor.io
 
+## Cross-Distro Docker Test Runners
+
+Integration tests can be run inside containerized Linux distros (Ubuntu, Fedora, Debian, Mint, Arch, openSUSE, Rocky, Manjaro) to catch distro-specific runtime issues.
+
+Infrastructure lives in `src/design/App.Test.Integration/docker/runners/`.
+
+### Running tests
+
+```bash
+# Build a distro image
+docker build -t angor-distro-tests-ubuntu -f src/design/App.Test.Integration/docker/runners/Dockerfile.ubuntu src/design/App.Test.Integration/docker/runners
+
+# Create a container
+docker run -d --name angor-ubuntu-runner --entrypoint sleep -v "$(pwd):/src" -e ANGOR_NETWORK=testnet -e DISPLAY=:99 angor-distro-tests-ubuntu infinity
+docker exec angor-ubuntu-runner bash -c 'Xvfb :99 -screen 0 1024x768x24 &'
+
+# Restore, build, run a single test
+docker exec angor-ubuntu-runner dotnet restore /src/src/design/App.Test.Integration/App.Test.Integration.csproj
+docker exec angor-ubuntu-runner dotnet build /src/src/design/App.Test.Integration/App.Test.Integration.csproj --no-restore
+docker exec angor-ubuntu-runner dotnet test /src/src/design/App.Test.Integration/App.Test.Integration.csproj --filter "FullyQualifiedName~App.Test.Integration.SmokeTest" --no-restore --no-build --logger "console;verbosity=normal"
+```
+
+### IMPORTANT: Always capture full failure logs
+
+When running tests, **always pipe full output to a log file** so failures can be investigated after the fact. Do NOT discard output with `Select-Object -Last N` or similar truncation. Example:
+
+```powershell
+docker exec angor-ubuntu-runner dotnet test ... 2>&1 | Out-File "C:\Users\dan\AppData\Local\Temp\opencode\test-ubuntu-FundAndRecoverTest.log" -Encoding utf8
+```
+
+Transient test failures must be investigated — they may indicate race conditions or thread-safety bugs in the app, not just signet/indexer lag. Always preserve the full assertion message and stack trace.
+
+### Tests to skip
+
+- **BigFundTest, BigInvestTest** — too long for distro validation
+- **OneClickInvestLightning*Test, OneClickInvestOnChain*Test** — require ThunderHub/LND infrastructure
+
 ## Common Pitfalls
 
 - **Thread affinity**: Pushing to `BehaviorSubject` from background threads will crash Avalonia. Use `RxApp.MainThreadScheduler.Schedule(() => subject.OnNext(value))`.

--- a/src/design/App.Test.Integration/docker/README.md
+++ b/src/design/App.Test.Integration/docker/README.md
@@ -110,10 +110,77 @@ if you want your own identity.
 Ports use the 48xxx / 47xxx range specifically so this stack can run
 alongside a public-Angor signet stack without clashing.
 
+## Cross-distro test runners
+
+The `runners/` directory contains Dockerfiles that run the full test suite
+inside different Linux distributions. This catches distro-specific issues
+(OpenSSL versions, glibc differences, missing native libs) that users
+report in the wild.
+
+### Available distros
+
+| Distro | Dockerfile | Notes |
+|---|---|---|
+| Ubuntu 24.04 LTS | `runners/Dockerfile.ubuntu` | Most common desktop Linux |
+| Fedora 41 | `runners/Dockerfile.fedora` | RPM-based, ships .NET natively via `dnf` |
+| Debian 12 (Bookworm) | `runners/Dockerfile.debian` | Stable base, older lib versions |
+
+### Running the distro tests
+
+```bash
+cd src/design/App.Test.Integration/docker
+
+# 1. Start the infrastructure stack (if not already running)
+docker compose up -d
+
+# 2. Run tests on ALL distros in parallel
+docker compose -f docker-compose.tests.yml up --build
+
+# 3. Run tests on a single distro
+docker compose -f docker-compose.tests.yml up --build ubuntu
+
+# 4. Unit tests only (skip integration tests)
+TEST_SCOPE=unit docker compose -f docker-compose.tests.yml up --build
+
+# 5. Integration tests only
+TEST_SCOPE=integration docker compose -f docker-compose.tests.yml up --build fedora
+
+# 6. Tear down test runners
+docker compose -f docker-compose.tests.yml down -v
+
+# 7. Tear down everything (infra + runners)
+docker compose -f docker-compose.tests.yml down -v
+docker compose down -v
+```
+
+### How it works
+
+Each distro container:
+1. Installs .NET 9 SDK + .NET 8 runtime + headless Avalonia dependencies
+2. Mounts `src/` read-only from the host
+3. Connects to the `angor-test-net` Docker network (same as the infra stack)
+4. Waits for all infrastructure services to be reachable
+5. Runs unit tests (Sdk, Shared, AngorApp) and integration tests
+
+The runners access infrastructure by container name (e.g.
+`angor-test-btc-node:38332`) — no localhost port mapping needed.
+
+### Adding a new distro
+
+1. Create `runners/Dockerfile.<distro>` — install .NET 9 SDK, .NET 8
+   runtime, and X11/Skia libs for headless Avalonia
+2. Add a service to `docker-compose.tests.yml` following the existing pattern
+3. Optionally add it to the CI workflow distro choice list in
+   `.github/workflows/ci-linux-distros.yml`
+
+### CI
+
+The `ci-linux-distros.yml` workflow runs weekly (Monday 06:00 UTC) and
+can be triggered manually from the Actions tab. It supports selecting a
+specific distro and test scope (unit / integration / all).
+
 ## Known follow-ups
 
 - The two custom images build from git each time the cache is invalidated.
   Publishing `blockcore/bitcoin-signet` and `blockcore/faucet-api` to a
   registry would drop first-run time significantly.
-- A CI job that spins up this stack and runs the integration suite
-  headlessly is not yet wired up.

--- a/src/design/App.Test.Integration/docker/docker-compose.tests.yml
+++ b/src/design/App.Test.Integration/docker/docker-compose.tests.yml
@@ -1,0 +1,80 @@
+# Cross-distro test runners for Angor
+#
+# Prerequisites: the infra stack must be running on the `angor-test-net` network:
+#   cd src/design/App.Test.Integration/docker
+#   docker compose up -d
+#
+# Usage:
+#   # Run all distros (parallel):
+#   docker compose -f docker-compose.tests.yml up --build
+#
+#   # Run a single distro:
+#   docker compose -f docker-compose.tests.yml up --build ubuntu
+#
+#   # Unit tests only (skip integration):
+#   TEST_SCOPE=unit docker compose -f docker-compose.tests.yml up --build
+#
+#   # Integration tests only:
+#   TEST_SCOPE=integration docker compose -f docker-compose.tests.yml up --build fedora
+
+name: angor-distro-tests
+
+networks:
+  angor-test-net:
+    external: true
+
+x-test-runner: &test-runner-common
+  volumes:
+    # Mount the entire src/ tree read-only; NuGet cache is container-local
+    - ../../../../:/src:ro
+    # Writable NuGet cache per container
+    - nuget-cache:/root/.nuget
+  environment:
+    TEST_SCOPE: ${TEST_SCOPE:-all}
+    DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+    DOTNET_NOLOGO: "1"
+  networks:
+    - angor-test-net
+  # Don't restart on failure — we want the exit code
+  restart: "no"
+
+volumes:
+  nuget-cache:
+
+services:
+
+  ubuntu:
+    <<: *test-runner-common
+    container_name: angor-test-runner-ubuntu
+    build:
+      context: ./runners
+      dockerfile: Dockerfile.ubuntu
+    environment:
+      TEST_SCOPE: ${TEST_SCOPE:-all}
+      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+      DOTNET_NOLOGO: "1"
+      DISTRO_NAME: ubuntu-24.04
+
+  fedora:
+    <<: *test-runner-common
+    container_name: angor-test-runner-fedora
+    build:
+      context: ./runners
+      dockerfile: Dockerfile.fedora
+    environment:
+      TEST_SCOPE: ${TEST_SCOPE:-all}
+      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+      DOTNET_NOLOGO: "1"
+      DISTRO_NAME: fedora-41
+
+  debian:
+    <<: *test-runner-common
+    container_name: angor-test-runner-debian
+    build:
+      context: ./runners
+      dockerfile: Dockerfile.debian
+    environment:
+      TEST_SCOPE: ${TEST_SCOPE:-all}
+      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+      DOTNET_NOLOGO: "1"
+      DISTRO_NAME: debian-12

--- a/src/design/App.Test.Integration/docker/docker-compose.tests.yml
+++ b/src/design/App.Test.Integration/docker/docker-compose.tests.yml
@@ -66,3 +66,53 @@ services:
     environment:
       <<: *test-env
       DISTRO_NAME: debian-12
+
+  mint:
+    <<: *test-runner-common
+    container_name: angor-test-runner-mint
+    build:
+      context: ./runners
+      dockerfile: Dockerfile.mint
+    environment:
+      <<: *test-env
+      DISTRO_NAME: mint-22
+
+  arch:
+    <<: *test-runner-common
+    container_name: angor-test-runner-arch
+    build:
+      context: ./runners
+      dockerfile: Dockerfile.arch
+    environment:
+      <<: *test-env
+      DISTRO_NAME: arch-rolling
+
+  opensuse:
+    <<: *test-runner-common
+    container_name: angor-test-runner-opensuse
+    build:
+      context: ./runners
+      dockerfile: Dockerfile.opensuse
+    environment:
+      <<: *test-env
+      DISTRO_NAME: opensuse-tumbleweed
+
+  rocky:
+    <<: *test-runner-common
+    container_name: angor-test-runner-rocky
+    build:
+      context: ./runners
+      dockerfile: Dockerfile.rocky
+    environment:
+      <<: *test-env
+      DISTRO_NAME: rocky-9
+
+  manjaro:
+    <<: *test-runner-common
+    container_name: angor-test-runner-manjaro
+    build:
+      context: ./runners
+      dockerfile: Dockerfile.manjaro
+    environment:
+      <<: *test-env
+      DISTRO_NAME: manjaro-rolling

--- a/src/design/App.Test.Integration/docker/docker-compose.tests.yml
+++ b/src/design/App.Test.Integration/docker/docker-compose.tests.yml
@@ -19,22 +19,16 @@
 
 name: angor-distro-tests
 
-networks:
-  angor-test-net:
-    external: true
-
 x-test-runner: &test-runner-common
   volumes:
-    # Mount the entire src/ tree read-only; NuGet cache is container-local
+    # Mount the entire repo tree; NuGet cache is container-local
     - ../../../../:/src
     # Writable NuGet cache per container
     - nuget-cache:/root/.nuget
-  environment:
+  environment: &test-env
     TEST_SCOPE: ${TEST_SCOPE:-all}
     DOTNET_CLI_TELEMETRY_OPTOUT: "1"
     DOTNET_NOLOGO: "1"
-  networks:
-    - angor-test-net
   # Don't restart on failure — we want the exit code
   restart: "no"
 
@@ -50,9 +44,7 @@ services:
       context: ./runners
       dockerfile: Dockerfile.ubuntu
     environment:
-      TEST_SCOPE: ${TEST_SCOPE:-all}
-      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
-      DOTNET_NOLOGO: "1"
+      <<: *test-env
       DISTRO_NAME: ubuntu-24.04
 
   fedora:
@@ -62,9 +54,7 @@ services:
       context: ./runners
       dockerfile: Dockerfile.fedora
     environment:
-      TEST_SCOPE: ${TEST_SCOPE:-all}
-      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
-      DOTNET_NOLOGO: "1"
+      <<: *test-env
       DISTRO_NAME: fedora-41
 
   debian:
@@ -74,7 +64,5 @@ services:
       context: ./runners
       dockerfile: Dockerfile.debian
     environment:
-      TEST_SCOPE: ${TEST_SCOPE:-all}
-      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
-      DOTNET_NOLOGO: "1"
+      <<: *test-env
       DISTRO_NAME: debian-12

--- a/src/design/App.Test.Integration/docker/docker-compose.tests.yml
+++ b/src/design/App.Test.Integration/docker/docker-compose.tests.yml
@@ -26,7 +26,7 @@ networks:
 x-test-runner: &test-runner-common
   volumes:
     # Mount the entire src/ tree read-only; NuGet cache is container-local
-    - ../../../../:/src:ro
+    - ../../../../:/src
     # Writable NuGet cache per container
     - nuget-cache:/root/.nuget
   environment:

--- a/src/design/App.Test.Integration/docker/runners/Dockerfile.arch
+++ b/src/design/App.Test.Integration/docker/runners/Dockerfile.arch
@@ -1,0 +1,34 @@
+# Arch Linux (rolling) — .NET 9 test runner
+FROM archlinux:latest
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+
+# Install .NET 9 SDK + dependencies for headless Avalonia
+RUN pacman -Syu --noconfirm \
+        dotnet-sdk \
+        aspnet-runtime \
+        icu \
+        openssl \
+        libx11 \
+        libxcb \
+        libxrandr \
+        libxi \
+        mesa \
+        fontconfig \
+        freetype2 \
+        xorg-server-xvfb \
+    && pacman -Scc --noconfirm
+
+# Arch ships .NET 10 SDK; install .NET 9 SDK + .NET 8 runtime for our targets
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && chmod +x /tmp/dotnet-install.sh \
+    && /tmp/dotnet-install.sh --channel 9.0 --install-dir /usr/share/dotnet \
+    && /tmp/dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir /usr/share/dotnet \
+    && rm /tmp/dotnet-install.sh
+
+COPY run-tests.sh /run-tests.sh
+RUN sed -i 's/\r$//' /run-tests.sh && chmod +x /run-tests.sh
+
+WORKDIR /src
+ENTRYPOINT ["/run-tests.sh"]

--- a/src/design/App.Test.Integration/docker/runners/Dockerfile.debian
+++ b/src/design/App.Test.Integration/docker/runners/Dockerfile.debian
@@ -1,0 +1,35 @@
+# Debian 12 (Bookworm) — .NET 9 test runner
+FROM debian:12
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+
+# Install .NET 9 SDK via install script + dependencies for headless Avalonia
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        libicu-dev \
+        libssl-dev \
+        libx11-6 \
+        libx11-xcb1 \
+        libxcb1 \
+        libxrandr2 \
+        libxi6 \
+        libgl1 \
+        libfontconfig1 \
+        libfreetype6 \
+        xvfb \
+    && curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && chmod +x /tmp/dotnet-install.sh \
+    && /tmp/dotnet-install.sh --channel 9.0 --install-dir /usr/share/dotnet \
+    && /tmp/dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir /usr/share/dotnet \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm /tmp/dotnet-install.sh \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY run-tests.sh /run-tests.sh
+RUN chmod +x /run-tests.sh
+
+WORKDIR /src
+ENTRYPOINT ["/run-tests.sh"]

--- a/src/design/App.Test.Integration/docker/runners/Dockerfile.debian
+++ b/src/design/App.Test.Integration/docker/runners/Dockerfile.debian
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY run-tests.sh /run-tests.sh
-RUN chmod +x /run-tests.sh
+RUN sed -i 's/\r$//' /run-tests.sh && chmod +x /run-tests.sh
 
 WORKDIR /src
 ENTRYPOINT ["/run-tests.sh"]

--- a/src/design/App.Test.Integration/docker/runners/Dockerfile.fedora
+++ b/src/design/App.Test.Integration/docker/runners/Dockerfile.fedora
@@ -1,0 +1,28 @@
+# Fedora 41 — .NET 9 test runner
+FROM fedora:41
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+
+# Install .NET 9 SDK + dependencies for headless Avalonia
+RUN dnf install -y --setopt=install_weak_deps=False \
+        dotnet-sdk-9.0 \
+        dotnet-runtime-8.0 \
+        libicu \
+        openssl-libs \
+        libX11 \
+        libX11-xcb \
+        libxcb \
+        libXrandr \
+        libXi \
+        mesa-libGL \
+        fontconfig \
+        freetype \
+        xorg-x11-server-Xvfb \
+    && dnf clean all
+
+COPY run-tests.sh /run-tests.sh
+RUN chmod +x /run-tests.sh
+
+WORKDIR /src
+ENTRYPOINT ["/run-tests.sh"]

--- a/src/design/App.Test.Integration/docker/runners/Dockerfile.fedora
+++ b/src/design/App.Test.Integration/docker/runners/Dockerfile.fedora
@@ -22,7 +22,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
     && dnf clean all
 
 COPY run-tests.sh /run-tests.sh
-RUN chmod +x /run-tests.sh
+RUN sed -i 's/\r$//' /run-tests.sh && chmod +x /run-tests.sh
 
 WORKDIR /src
 ENTRYPOINT ["/run-tests.sh"]

--- a/src/design/App.Test.Integration/docker/runners/Dockerfile.manjaro
+++ b/src/design/App.Test.Integration/docker/runners/Dockerfile.manjaro
@@ -1,0 +1,36 @@
+# Manjaro (Arch-based, rolling) — .NET 9 test runner
+FROM manjarolinux/base
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+
+# Update keyring first (Manjaro images can have stale keys)
+RUN pacman -Sy --noconfirm archlinux-keyring manjaro-keyring \
+    && pacman-key --populate archlinux manjaro \
+    && pacman -Syu --noconfirm \
+        icu \
+        openssl \
+        libx11 \
+        libxcb \
+        libxrandr \
+        libxi \
+        mesa \
+        fontconfig \
+        freetype2 \
+        xorg-server-xvfb \
+        curl \
+    && pacman -Scc --noconfirm
+
+# Install .NET 9 SDK + .NET 8 runtime via install script
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && chmod +x /tmp/dotnet-install.sh \
+    && /tmp/dotnet-install.sh --channel 9.0 --install-dir /usr/share/dotnet \
+    && /tmp/dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir /usr/share/dotnet \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm /tmp/dotnet-install.sh
+
+COPY run-tests.sh /run-tests.sh
+RUN sed -i 's/\r$//' /run-tests.sh && chmod +x /run-tests.sh
+
+WORKDIR /src
+ENTRYPOINT ["/run-tests.sh"]

--- a/src/design/App.Test.Integration/docker/runners/Dockerfile.mint
+++ b/src/design/App.Test.Integration/docker/runners/Dockerfile.mint
@@ -1,0 +1,35 @@
+# Linux Mint 22 (based on Ubuntu 24.04) — .NET 9 test runner
+FROM linuxmintd/mint22-amd64
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+
+# Install .NET 9 SDK via install script + dependencies for headless Avalonia
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        libicu-dev \
+        libssl-dev \
+        libx11-6 \
+        libx11-xcb1 \
+        libxcb1 \
+        libxrandr2 \
+        libxi6 \
+        libgl1 \
+        libfontconfig1 \
+        libfreetype6 \
+        xvfb \
+    && curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && chmod +x /tmp/dotnet-install.sh \
+    && /tmp/dotnet-install.sh --channel 9.0 --install-dir /usr/share/dotnet \
+    && /tmp/dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir /usr/share/dotnet \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm /tmp/dotnet-install.sh \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY run-tests.sh /run-tests.sh
+RUN sed -i 's/\r$//' /run-tests.sh && chmod +x /run-tests.sh
+
+WORKDIR /src
+ENTRYPOINT ["/run-tests.sh"]

--- a/src/design/App.Test.Integration/docker/runners/Dockerfile.opensuse
+++ b/src/design/App.Test.Integration/docker/runners/Dockerfile.opensuse
@@ -1,0 +1,38 @@
+# openSUSE Tumbleweed (rolling) — .NET 9 test runner
+FROM opensuse/tumbleweed
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+
+# Install .NET 9 SDK via install script + dependencies for headless Avalonia
+RUN zypper --non-interactive install --no-recommends \
+        ca-certificates \
+        curl \
+        tar \
+        gzip \
+        gawk \
+        findutils \
+        libicu-devel \
+        libopenssl-devel \
+        libX11-6 \
+        libX11-xcb1 \
+        libxcb1 \
+        libXrandr2 \
+        libXi6 \
+        Mesa-libGL1 \
+        fontconfig \
+        libfreetype6 \
+        xorg-x11-server-Xvfb \
+    && curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && chmod +x /tmp/dotnet-install.sh \
+    && /tmp/dotnet-install.sh --channel 9.0 --install-dir /usr/share/dotnet \
+    && /tmp/dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir /usr/share/dotnet \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm /tmp/dotnet-install.sh \
+    && zypper clean --all
+
+COPY run-tests.sh /run-tests.sh
+RUN sed -i 's/\r$//' /run-tests.sh && chmod +x /run-tests.sh
+
+WORKDIR /src
+ENTRYPOINT ["/run-tests.sh"]

--- a/src/design/App.Test.Integration/docker/runners/Dockerfile.rocky
+++ b/src/design/App.Test.Integration/docker/runners/Dockerfile.rocky
@@ -1,0 +1,34 @@
+# Rocky Linux 9 (RHEL clone) — .NET 9 test runner
+FROM rockylinux:9
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+
+# Install .NET 9 SDK via install script + dependencies for headless Avalonia
+RUN dnf install -y --allowerasing --setopt=install_weak_deps=False \
+        ca-certificates \
+        curl \
+        libicu \
+        openssl-libs \
+        libX11 \
+        libX11-xcb \
+        libxcb \
+        libXrandr \
+        libXi \
+        mesa-libGL \
+        fontconfig \
+        freetype \
+        xorg-x11-server-Xvfb \
+    && curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && chmod +x /tmp/dotnet-install.sh \
+    && /tmp/dotnet-install.sh --channel 9.0 --install-dir /usr/share/dotnet \
+    && /tmp/dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir /usr/share/dotnet \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm /tmp/dotnet-install.sh \
+    && dnf clean all
+
+COPY run-tests.sh /run-tests.sh
+RUN sed -i 's/\r$//' /run-tests.sh && chmod +x /run-tests.sh
+
+WORKDIR /src
+ENTRYPOINT ["/run-tests.sh"]

--- a/src/design/App.Test.Integration/docker/runners/Dockerfile.ubuntu
+++ b/src/design/App.Test.Integration/docker/runners/Dockerfile.ubuntu
@@ -36,7 +36,7 @@ RUN /usr/share/dotnet/dotnet-install.sh --channel 8.0 --runtime dotnet --install
     && rm -f /tmp/dotnet-install.sh
 
 COPY run-tests.sh /run-tests.sh
-RUN chmod +x /run-tests.sh
+RUN sed -i 's/\r$//' /run-tests.sh && chmod +x /run-tests.sh
 
 WORKDIR /src
 ENTRYPOINT ["/run-tests.sh"]

--- a/src/design/App.Test.Integration/docker/runners/Dockerfile.ubuntu
+++ b/src/design/App.Test.Integration/docker/runners/Dockerfile.ubuntu
@@ -1,0 +1,42 @@
+# Ubuntu 24.04 LTS — .NET 9 test runner
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+
+# Install .NET 9 SDK + dependencies for headless Avalonia (X11/Skia)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        apt-transport-https \
+        libicu-dev \
+        libssl-dev \
+        libx11-6 \
+        libx11-xcb1 \
+        libxcb1 \
+        libxrandr2 \
+        libxi6 \
+        libgl1 \
+        libfontconfig1 \
+        libfreetype6 \
+        xvfb \
+    && curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && chmod +x /tmp/dotnet-install.sh \
+    && /tmp/dotnet-install.sh --channel 9.0 --install-dir /usr/share/dotnet \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm /tmp/dotnet-install.sh \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Also install .NET 8 runtime for Angor.Shared (net8.0)
+RUN /usr/share/dotnet/dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir /usr/share/dotnet 2>/dev/null \
+    || curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && chmod +x /tmp/dotnet-install.sh \
+    && /tmp/dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir /usr/share/dotnet \
+    && rm -f /tmp/dotnet-install.sh
+
+COPY run-tests.sh /run-tests.sh
+RUN chmod +x /run-tests.sh
+
+WORKDIR /src
+ENTRYPOINT ["/run-tests.sh"]

--- a/src/design/App.Test.Integration/docker/runners/run-tests.sh
+++ b/src/design/App.Test.Integration/docker/runners/run-tests.sh
@@ -2,8 +2,8 @@
 # run-tests.sh — Shared entrypoint for cross-distro test runners.
 #
 # Runs unit tests (Sdk, Shared, AngorApp) and integration tests against
-# the local signet stack. The infra stack must already be running on the
-# shared Docker network (angor-test-net).
+# the public Angor signet (default) or a local signet stack when
+# ANGOR_INDEXER_URL / ANGOR_RELAY_URLS / ANGOR_FAUCET_BASE_URL are set.
 #
 # Environment variables (set by docker-compose.tests.yml):
 #   TEST_SCOPE  — "unit" | "integration" | "all" (default: all)
@@ -20,34 +20,10 @@ echo "  Test runner: ${DISTRO_NAME}"
 echo "  Scope:       ${TEST_SCOPE}"
 echo "  .NET:        $(dotnet --version)"
 echo "  OS:          $(cat /etc/os-release 2>/dev/null | grep PRETTY_NAME | cut -d= -f2 | tr -d '"')"
+echo "  Indexer:     ${ANGOR_INDEXER_URL:-<public angor signet>}"
+echo "  Relays:      ${ANGOR_RELAY_URLS:-<public angor signet>}"
+echo "  Faucet:      ${ANGOR_FAUCET_BASE_URL:-<public angor signet>}"
 echo "============================================"
-
-# ── Wait for infra stack ──────────────────────────────────────────────
-wait_for_service() {
-    local host="$1" port="$2" label="$3" timeout="${4:-120}"
-    echo -n "Waiting for ${label} (${host}:${port})..."
-    local elapsed=0
-    while ! (echo > /dev/tcp/"$host"/"$port") 2>/dev/null; do
-        sleep 2
-        elapsed=$((elapsed + 2))
-        if [ "$elapsed" -ge "$timeout" ]; then
-            echo " TIMEOUT after ${timeout}s"
-            return 1
-        fi
-        echo -n "."
-    done
-    echo " ready (${elapsed}s)"
-}
-
-if [ "$TEST_SCOPE" != "unit" ]; then
-    wait_for_service angor-test-btc-node    38332 "Bitcoin RPC"
-    wait_for_service angor-test-fulcrum     50001 "Fulcrum"
-    wait_for_service angor-test-faucet-api  5500  "Faucet API"
-    wait_for_service angor-test-relay-1     7777  "Relay 1"
-    wait_for_service angor-test-relay-2     7777  "Relay 2"
-    wait_for_service angor-test-mempool-api 8999  "Mempool API"
-    echo ""
-fi
 
 # ── Restore once ──────────────────────────────────────────────────────
 echo "Restoring NuGet packages..."

--- a/src/design/App.Test.Integration/docker/runners/run-tests.sh
+++ b/src/design/App.Test.Integration/docker/runners/run-tests.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 
 DISTRO_NAME="${DISTRO_NAME:-unknown}"
 TEST_SCOPE="${TEST_SCOPE:-all}"
-SRC_DIR="/src"
+SRC_DIR="/src/src"
 
 echo "============================================"
 echo "  Test runner: ${DISTRO_NAME}"
@@ -51,7 +51,11 @@ fi
 
 # ── Restore once ──────────────────────────────────────────────────────
 echo "Restoring NuGet packages..."
-dotnet restore "${SRC_DIR}/Avalonia.sln" --verbosity quiet
+# Restore individual test projects (not the full solution, which includes
+# Android/iOS/WASM projects requiring workloads not installed in the runner).
+dotnet restore "${SRC_DIR}/sdk/Angor.Sdk.Tests/Angor.Sdk.Tests.csproj" --verbosity quiet
+dotnet restore "${SRC_DIR}/shared/Angor.Shared.Tests/Angor.Shared.Tests.csproj" --verbosity quiet
+dotnet restore "${SRC_DIR}/avalonia/AngorApp.Tests/AngorApp.Tests.csproj" --verbosity quiet
 dotnet restore "${SRC_DIR}/design/App.Test.Integration/App.Test.Integration.csproj" --verbosity quiet
 
 FAILED=0

--- a/src/design/App.Test.Integration/docker/runners/run-tests.sh
+++ b/src/design/App.Test.Integration/docker/runners/run-tests.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# run-tests.sh — Shared entrypoint for cross-distro test runners.
+#
+# Runs unit tests (Sdk, Shared, AngorApp) and integration tests against
+# the local signet stack. The infra stack must already be running on the
+# shared Docker network (angor-test-net).
+#
+# Environment variables (set by docker-compose.tests.yml):
+#   TEST_SCOPE  — "unit" | "integration" | "all" (default: all)
+#   DISTRO_NAME — friendly name for logging (e.g. "ubuntu-24.04")
+
+set -euo pipefail
+
+DISTRO_NAME="${DISTRO_NAME:-unknown}"
+TEST_SCOPE="${TEST_SCOPE:-all}"
+SRC_DIR="/src"
+
+echo "============================================"
+echo "  Test runner: ${DISTRO_NAME}"
+echo "  Scope:       ${TEST_SCOPE}"
+echo "  .NET:        $(dotnet --version)"
+echo "  OS:          $(cat /etc/os-release 2>/dev/null | grep PRETTY_NAME | cut -d= -f2 | tr -d '"')"
+echo "============================================"
+
+# ── Wait for infra stack ──────────────────────────────────────────────
+wait_for_service() {
+    local host="$1" port="$2" label="$3" timeout="${4:-120}"
+    echo -n "Waiting for ${label} (${host}:${port})..."
+    local elapsed=0
+    while ! (echo > /dev/tcp/"$host"/"$port") 2>/dev/null; do
+        sleep 2
+        elapsed=$((elapsed + 2))
+        if [ "$elapsed" -ge "$timeout" ]; then
+            echo " TIMEOUT after ${timeout}s"
+            return 1
+        fi
+        echo -n "."
+    done
+    echo " ready (${elapsed}s)"
+}
+
+if [ "$TEST_SCOPE" != "unit" ]; then
+    wait_for_service angor-test-btc-node    38332 "Bitcoin RPC"
+    wait_for_service angor-test-fulcrum     50001 "Fulcrum"
+    wait_for_service angor-test-faucet-api  5500  "Faucet API"
+    wait_for_service angor-test-relay-1     7777  "Relay 1"
+    wait_for_service angor-test-relay-2     7777  "Relay 2"
+    wait_for_service angor-test-mempool-api 8999  "Mempool API"
+    echo ""
+fi
+
+# ── Restore once ──────────────────────────────────────────────────────
+echo "Restoring NuGet packages..."
+dotnet restore "${SRC_DIR}/Avalonia.sln" --verbosity quiet
+dotnet restore "${SRC_DIR}/design/App.Test.Integration/App.Test.Integration.csproj" --verbosity quiet
+
+FAILED=0
+
+run_tests() {
+    local project="$1" label="$2"
+    echo ""
+    echo "── ${label} ──"
+    if dotnet test "$project" --no-restore --verbosity normal --logger "console;verbosity=normal"; then
+        echo "✓ ${label}: PASSED"
+    else
+        echo "✗ ${label}: FAILED"
+        FAILED=1
+    fi
+}
+
+# ── Unit tests ────────────────────────────────────────────────────────
+if [ "$TEST_SCOPE" = "unit" ] || [ "$TEST_SCOPE" = "all" ]; then
+    run_tests "${SRC_DIR}/sdk/Angor.Sdk.Tests/Angor.Sdk.Tests.csproj"           "SDK Unit Tests"
+    run_tests "${SRC_DIR}/shared/Angor.Shared.Tests/Angor.Shared.Tests.csproj"  "Shared Unit Tests"
+    run_tests "${SRC_DIR}/avalonia/AngorApp.Tests/AngorApp.Tests.csproj"         "Avalonia Model Tests"
+fi
+
+# ── Integration tests ────────────────────────────────────────────────
+if [ "$TEST_SCOPE" = "integration" ] || [ "$TEST_SCOPE" = "all" ]; then
+    run_tests "${SRC_DIR}/design/App.Test.Integration/App.Test.Integration.csproj" "Integration Tests"
+fi
+
+echo ""
+echo "============================================"
+if [ "$FAILED" -eq 0 ]; then
+    echo "  ${DISTRO_NAME}: ALL TESTS PASSED"
+else
+    echo "  ${DISTRO_NAME}: SOME TESTS FAILED"
+fi
+echo "============================================"
+
+exit $FAILED


### PR DESCRIPTION
## Summary

- Adds Docker-based test runners for Ubuntu 24.04, Fedora 41, and Debian 12 to catch distro-specific runtime issues (OpenSSL versions, glibc, native libs) that users report
- Runners execute unit + integration tests inside each distro container against the existing local signet infrastructure stack
- CI workflow is **manual-only** (`workflow_dispatch`) — planned to move to a self-hosted runner due to resource requirements

## Files added

| File | Purpose |
|---|---|
| `docker/runners/run-tests.sh` | Shared entrypoint — waits for infra, runs tests |
| `docker/runners/Dockerfile.ubuntu` | Ubuntu 24.04 test runner |
| `docker/runners/Dockerfile.fedora` | Fedora 41 test runner |
| `docker/runners/Dockerfile.debian` | Debian 12 test runner |
| `docker/docker-compose.tests.yml` | Orchestrates distro runners on `angor-test-net` |
| `.github/workflows/ci-linux-distros.yml` | Manual CI workflow |

## Usage

```bash
cd src/design/App.Test.Integration/docker
docker compose up -d                                    # start infra
docker compose -f docker-compose.tests.yml up --build   # run all distros
```
