### PR TITLE
fix: run refresh button load on threadpool to avoid blocking UI thread

### DIFF
--- a/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml.cs
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml.cs
@@ -53,10 +53,10 @@ public partial class FindProjectsView : UserControl, ISectionView
         var refreshBtn = this.FindControl<Button>("RefreshProjectsButton");
         if (refreshBtn != null)
         {
-            refreshBtn.Click += async (_, _) =>
+            refreshBtn.Click += (_, _) =>
             {
                 if (DataContext is FindProjectsViewModel fvm)
-                    await fvm.LoadProjectsFromSdkAsync();
+                    _ = Task.Run(fvm.LoadProjectsFromSdkAsync);
             };
         }
 


### PR DESCRIPTION
## Summary
- The Find Projects refresh button was calling await LoadProjectsFromSdkAsync() directly on the UI thread, causing the synchronous prefix of Latest() to block the UI
- Changed to Task.Run() to match the pattern already used in the constructor, keeping the UI responsive