### PR TITLE
fix: prevent bottom tab bar from being pushed up on Android startup

### DIFF
--- a/src/design/App.Android/MainActivity.cs
+++ b/src/design/App.Android/MainActivity.cs
@@ -1,6 +1,7 @@
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
+using Android.Views;
 using App.UI.Shared.Helpers;
 using Avalonia.Android;
 using Avalonia.Threading;
@@ -13,6 +14,7 @@ namespace App.Android;
     Icon = "@drawable/icon",
     MainLauncher = true,
     ScreenOrientation = ScreenOrientation.Portrait,
+    WindowSoftInputMode = SoftInput.AdjustNothing,
     ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
 public class MainActivity : AvaloniaMainActivity
 {


### PR DESCRIPTION
## Summary

- Set `WindowSoftInputMode = SoftInput.AdjustNothing` on `MainActivity` to prevent Android from resizing the app viewport on startup
- Fixes the bottom tab bar appearing ~25%% above the screen bottom when the app first opens, caused by Android default AdjustResize behavior interacting with edge-to-edge mode
- The app already handles inset padding manually via `ApplySafeAreaInsets`, so OS-level viewport resizing is unnecessary