### PR TITLE
fix: prevent duplicate NIP-65 publish causing profile creation timeout

### DIFF
--- a/src/design/App.Android/MainActivity.cs
+++ b/src/design/App.Android/MainActivity.cs
@@ -1,6 +1,7 @@
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
+using Android.Views;
 using App.UI.Shared.Helpers;
 using Avalonia.Android;
 using Avalonia.Threading;
@@ -13,6 +14,7 @@ namespace App.Android;
     Icon = "@drawable/icon",
     MainLauncher = true,
     ScreenOrientation = ScreenOrientation.Portrait,
+    WindowSoftInputMode = SoftInput.AdjustNothing,
     ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
 public class MainActivity : AvaloniaMainActivity
 {

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectProfile.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectProfile.cs
@@ -81,6 +81,8 @@ public static class CreateProjectProfile
                 Nip57 = project.Nip57
             };
 
+            var nip65Published = 0;
+
             var resultId = await relayService.CreateNostrProfileAsync(
                 nostrMetadata,
                 nostrKey,
@@ -92,6 +94,10 @@ public static class CreateProjectProfile
                           tcs.TrySetResult(Result.Failure<string>($"Failed to store the project profile on the relay: {okResponse.CommunicatorName} - {okResponse.Message}"));
                           return;
                       }
+
+                      // The OK callback fires once per relay. Only publish NIP-65 once.
+                      if (Interlocked.CompareExchange(ref nip65Published, 1, 0) != 0)
+                          return;
 
                       relayService.PublishNip65List(nostrKey, nip65OkResponse =>
                       {


### PR DESCRIPTION
## Summary

- The OK callback in `CreateNostrProfileAsync` fires once per relay, causing `PublishNip65List` to be called multiple times. When a relay disconnects mid-flow, the disconnect-unblock logic fires the callback again, creating competing NIP-65 publishes that never resolve — hitting the 30s timeout.
- Added an `Interlocked.CompareExchange` guard so `PublishNip65List` is invoked exactly once on the first accepted OK response.