### PR TITLE
Plan: Android emulator integration testing via docker-android

### DIFF
--- a/src/design/App.Android/MainActivity.cs
+++ b/src/design/App.Android/MainActivity.cs
@@ -1,6 +1,7 @@
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
+using Android.Views;
 using App.UI.Shared.Helpers;
 using Avalonia.Android;
 using Avalonia.Threading;
@@ -13,6 +14,7 @@ namespace App.Android;
     Icon = "@drawable/icon",
     MainLauncher = true,
     ScreenOrientation = ScreenOrientation.Portrait,
+    WindowSoftInputMode = SoftInput.AdjustNothing,
     ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
 public class MainActivity : AvaloniaMainActivity
 {

--- a/src/design/App.Test.Integration/docker/ANDROID_EMULATOR_PLAN.md
+++ b/src/design/App.Test.Integration/docker/ANDROID_EMULATOR_PLAN.md
@@ -1,0 +1,117 @@
+# Android Emulator Integration Testing Plan
+
+Use [docker-android](https://github.com/HQarroum/docker-android) to run the Angor app in a containerized Android emulator and validate it against the local test signet stack.
+
+## Prerequisites
+
+- **KVM required**: The docker-android image needs `/dev/kvm` for hardware acceleration. Docker Desktop on Windows does not expose KVM natively. Use WSL2 with nested virtualization, a Linux VM, or a Linux CI runner.
+- **x86_64 APK**: Debug builds target x86_64 by default, which matches the emulator architecture.
+
+## Phase 1 — Enable KVM in WSL2
+
+1. Update WSL: `wsl --update`
+2. Ensure Intel VT-x / AMD-V is enabled in BIOS.
+3. Add to `%USERPROFILE%\.wslconfig` if needed:
+   ```ini
+   [wsl2]
+   nestedVirtualization=true
+   ```
+4. Verify inside WSL2:
+   ```bash
+   ls -la /dev/kvm
+   docker run --rm --device /dev/kvm alpine ls -la /dev/kvm
+   ```
+
+## Phase 2 — Run the Android Emulator Container
+
+Pull the pre-built image and start the emulator:
+
+```bash
+docker pull halimqarroum/docker-android:api-33
+
+docker run -d --name android-emu \
+  --device /dev/kvm \
+  -p 5555:5555 \
+  -e MEMORY=4096 \
+  -e CORES=2 \
+  -e DISABLE_ANIMATION=true \
+  halimqarroum/docker-android:api-33
+```
+
+Connect ADB and verify:
+
+```bash
+adb connect 127.0.0.1:5555
+adb devices
+```
+
+## Phase 3 — Build and Deploy the Angor App
+
+Build the APK:
+
+```bash
+dotnet build src/design/App.Android/App.Android.csproj \
+  -f net9.0-android -c Debug
+```
+
+Install and launch on the emulator:
+
+```bash
+adb install <path-to-apk>/io.angor.app.apk
+adb shell monkey -p io.angor.app 1
+```
+
+Optionally use [scrcpy](https://github.com/Genymobile/scrcpy) to observe the UI remotely.
+
+## Phase 4 — Connect Emulator to the Test Signet Stack
+
+The existing `docker-compose.yml` creates the `angor-test-net` network. Connect the emulator container so the app can reach signet-node, mempool, relays, and faucet:
+
+```bash
+docker network connect angor-test-net android-emu
+```
+
+Configure the app inside the emulator to point at the docker service hostnames/ports (see `docker/README.md` for the endpoint map).
+
+## Phase 5 — Add Android Emulator to Docker Compose
+
+Add as a service in `src/design/App.Test.Integration/docker/docker-compose.yml`:
+
+```yaml
+android-emulator:
+  image: halimqarroum/docker-android:api-33
+  devices:
+    - /dev/kvm
+  ports:
+    - "5555:5555"
+  environment:
+    - MEMORY=4096
+    - CORES=2
+    - DISABLE_ANIMATION=true
+  networks:
+    - angor-test-net
+```
+
+Add a helper script that:
+1. Waits for the emulator to finish booting (`adb wait-for-device && adb shell getprop sys.boot_completed`).
+2. Installs the APK.
+3. Launches the app.
+
+## Phase 6 — Automated Test Execution (Future)
+
+Choose a test framework for driving the Android UI:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Appium + .NET** | C# tests, same language as codebase, rich UI assertions | Extra infrastructure (Appium server) |
+| **ADB shell scripting** | Lightweight, no extra deps | Limited to basic smoke checks |
+| **Separate xUnit suite** | Familiar test runner | Need Appium or similar driver underneath |
+
+Initial goal: deploy APK, verify app starts, check basic navigation works.
+
+## Risks & Considerations
+
+- **KVM in WSL2** is not guaranteed — depends on hardware, Windows version, and WSL kernel version. Fall back to a Linux VM if unavailable.
+- **Performance** — emulator in Docker in WSL2 adds two virtualization layers; expect slowness.
+- **CI integration** — standard GitHub Actions `ubuntu-latest` runners lack KVM. Requires self-hosted runners or the `reactivecircus/android-emulator-runner` action (macOS runners with HAXM).
+- **Google Play Services** — if the app needs them, use `IMG_TYPE=google_apis_playstore` when building the docker-android image and provide matching ADB keys in the `keys/` directory.

--- a/src/design/App/UI/Sections/FindProjects/ProjectDetailView.axaml.cs
+++ b/src/design/App/UI/Sections/FindProjects/ProjectDetailView.axaml.cs
@@ -511,7 +511,7 @@ public partial class ProjectDetailView : UserControl
             var shell = this.FindAncestorOfType<ShellView>();
             if (shell?.DataContext is ShellViewModel shellVm && !shellVm.IsModalOpen)
             {
-                var modal = new ShareModal(project.ProjectName, project.ShortDescription);
+                var modal = new ShareModal(project.ProjectId, project.ProjectName, project.ShortDescription);
                 shellVm.ShowModal(modal);
                 e.Handled = true;
             }

--- a/src/design/App/UI/Sections/MyProjects/ManageProjectView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/ManageProjectView.axaml.cs
@@ -170,7 +170,7 @@ public partial class ManageProjectView : UserControl
         var shell = this.FindAncestorOfType<ShellView>();
         if (shell?.DataContext is ShellViewModel shellVm && !shellVm.IsModalOpen)
         {
-            var modal = new ShareModal(Vm.Project.Name, Vm.Project.Description);
+            var modal = new ShareModal(Vm.Project.ProjectIdentifier, Vm.Project.Name, Vm.Project.Description);
             shellVm.ShowModal(modal);
         }
     }

--- a/src/design/App/UI/Sections/MyProjects/MyProjectsView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/MyProjectsView.axaml.cs
@@ -452,7 +452,7 @@ public partial class MyProjectsView : UserControl, ISectionView
                     var shell = this.FindAncestorOfType<ShellView>();
                     if (shell?.DataContext is ShellViewModel shellVm && !shellVm.IsModalOpen)
                     {
-                        var modal = new ShareModal(shareProject.Name, shareProject.Description);
+                        var modal = new ShareModal(shareProject.ProjectIdentifier, shareProject.Name, shareProject.Description);
                         shellVm.ShowModal(modal);
                     }
                     e.Handled = true;

--- a/src/design/App/UI/Shared/Controls/ShareModal.axaml
+++ b/src/design/App/UI/Shared/Controls/ShareModal.axaml
@@ -157,7 +157,7 @@
                         </Button>
                         <TextBox Name="ShareLinkInput"
                                  IsReadOnly="True"
-                                 Text="https://angor.io/project/abc123"
+                                 Text="https://angor.io/project/angor1..."
                                  Background="{DynamicResource ShareInputBg}"
                                  BorderBrush="{DynamicResource StrokeSubtle}"
                                  CornerRadius="8"

--- a/src/design/App/UI/Shared/Controls/ShareModal.axaml.cs
+++ b/src/design/App/UI/Shared/Controls/ShareModal.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using Angor.Sdk.Wallet.Domain;
 using App.UI.Shared.Helpers;
 using App.UI.Shell;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,16 +28,21 @@ public partial class ShareModal : UserControl, IBackdropCloseable
     /// Parameterless constructor for XAML designer/loader.
     /// Not used at runtime — use the parameterized constructor instead.
     /// </summary>
-    public ShareModal() : this("Sample Project", "A sample project description")
+    public ShareModal() : this("angor1abc123", "Sample Project", "A sample project description")
     {
     }
 
-    public ShareModal(string projectName, string projectDescription, string? avatarUrl = null)
+    public ShareModal(string projectId, string projectName, string projectDescription, string? avatarUrl = null)
     {
         _logger = App.Services.GetRequiredService<ILoggerFactory>().CreateLogger<ShareModal>();
         _projectName = projectName;
         _projectDescription = projectDescription;
-        _shareUrl = $"https://angor.io/project/{projectName.ToLowerInvariant().Replace(" ", "-")}";
+
+        var getNetwork = App.Services.GetRequiredService<Func<BitcoinNetwork>>();
+        var isTestnet = getNetwork() != BitcoinNetwork.Mainnet;
+        _shareUrl = isTestnet
+            ? $"https://angor.io/project/{projectId}?network=testnet"
+            : $"https://angor.io/project/{projectId}";
 
         InitializeComponent();
 

--- a/src/design/App/UI/Shell/ShellViewModel.cs
+++ b/src/design/App/UI/Shell/ShellViewModel.cs
@@ -914,7 +914,7 @@ public partial class ShellViewModel : ReactiveObject, IDisposable
             fpVm.SelectedProject is not { } project)
             return;
 
-        ShowModal(new Shared.Controls.ShareModal(project.ProjectName, project.ShortDescription));
+        ShowModal(new Shared.Controls.ShareModal(project.ProjectId, project.ProjectName, project.ShortDescription));
     }
 
     /// <summary>

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectProfile.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectProfile.cs
@@ -81,6 +81,8 @@ public static class CreateProjectProfile
                 Nip57 = project.Nip57
             };
 
+            var nip65Published = 0;
+
             var resultId = await relayService.CreateNostrProfileAsync(
                 nostrMetadata,
                 nostrKey,
@@ -92,6 +94,10 @@ public static class CreateProjectProfile
                           tcs.TrySetResult(Result.Failure<string>($"Failed to store the project profile on the relay: {okResponse.CommunicatorName} - {okResponse.Message}"));
                           return;
                       }
+
+                      // The OK callback fires once per relay. Only publish NIP-65 once.
+                      if (Interlocked.CompareExchange(ref nip65Published, 1, 0) != 0)
+                          return;
 
                       relayService.PublishNip65List(nostrKey, nip65OkResponse =>
                       {


### PR DESCRIPTION
## Summary
- Adds a plan document for using [docker-android](https://github.com/HQarroum/docker-android) to run Angor integration tests against a containerized Android emulator
- Covers KVM/WSL2 setup, emulator container config, APK deployment, connecting to the existing test signet stack, and future automated test options