### PR TITLE
fix(critical): enforce UTC DateTime to prevent taproot witness mismatch across timezones

### DIFF
--- a/src/avalonia/AngorApp/UI/Flows/CreateProject/CreateProjectFlow.cs
+++ b/src/avalonia/AngorApp/UI/Flows/CreateProject/CreateProjectFlow.cs
@@ -194,7 +194,7 @@ namespace AngorApp.UI.Flows.CreateProject
             project.PenaltyDays = 0;
 
             project.PayoutFrequency = PayoutFrequency.Monthly;
-            project.MonthlyPayoutDate = DateTime.Now.Day;
+            project.MonthlyPayoutDate = DateTime.UtcNow.Day;
 
             // Pick reasonable default installment patterns (3-month and 6-month).
             project.SelectedInstallments.SelectionModel.Clear();
@@ -210,14 +210,14 @@ namespace AngorApp.UI.Flows.CreateProject
             project.Website = "https://angor.io";
             project.TargetAmount = AmountUI.FromBtc(0.01);
             project.PenaltyDays = 0;
-            project.StartDate = DateTime.Now.Date;
-            project.FundingEndDate = DateTime.Now.Date;
-            project.ExpiryDate = DateTime.Now.Date.AddDays(31);
+            project.StartDate = DateTime.UtcNow.Date;
+            project.FundingEndDate = DateTime.UtcNow.Date;
+            project.ExpiryDate = DateTime.UtcNow.Date.AddDays(31);
 
             // Add stages with dates matching the funding end date for immediate release
-            project.CreateAndAddStage(0.10m, DateTime.Now.Date);
-            project.CreateAndAddStage(0.30m, DateTime.Now.Date);
-            project.CreateAndAddStage(0.60m, DateTime.Now.Date);
+            project.CreateAndAddStage(0.10m, DateTime.UtcNow.Date);
+            project.CreateAndAddStage(0.30m, DateTime.UtcNow.Date);
+            project.CreateAndAddStage(0.60m, DateTime.UtcNow.Date);
         }
 
         private async Task<Result<ProjectSeedDto>> GetProjectSeed(WalletId walletId)

--- a/src/avalonia/AngorApp/UI/Flows/CreateProject/Wizard/FundProject/FundReviewAndDeployViewModel.cs
+++ b/src/avalonia/AngorApp/UI/Flows/CreateProject/Wizard/FundProject/FundReviewAndDeployViewModel.cs
@@ -49,7 +49,7 @@ namespace AngorApp.UI.Flows.CreateProject.Wizard.FundProject
                     var generated = PayoutGenerator.Generate(
                         newProject.PayoutFrequency.Value,
                         maxInstallments,
-                        DateTime.Now,
+                        DateTime.UtcNow,
                         newProject.MonthlyPayoutDate,
                         newProject.WeeklyPayoutDay
                     );

--- a/src/avalonia/AngorApp/UI/Flows/CreateProject/Wizard/FundProject/Mappers/CreateProjectDtoMapper.cs
+++ b/src/avalonia/AngorApp/UI/Flows/CreateProject/Wizard/FundProject/Mappers/CreateProjectDtoMapper.cs
@@ -26,7 +26,7 @@ public static class CreateProjectDtoMapper
 
             ProjectType = Angor.Shared.Models.ProjectType.Fund,
             Sats = satsValue,
-            StartDate = DateTime.Now.Date,
+            StartDate = DateTime.UtcNow.Date,
 
             EndDate = null,
 

--- a/src/avalonia/AngorApp/UI/Flows/CreateProject/Wizard/FundProject/Payouts/PayoutsViewModel.cs
+++ b/src/avalonia/AngorApp/UI/Flows/CreateProject/Wizard/FundProject/Payouts/PayoutsViewModel.cs
@@ -61,7 +61,7 @@ namespace AngorApp.UI.Flows.CreateProject.Wizard.FundProject.Payouts
             var generated = PayoutGenerator.Generate(
                 FundProject.PayoutFrequency.Value,
                 maxInstallments,
-                DateTime.Now,
+                DateTime.UtcNow,
                 FundProject.MonthlyPayoutDate,
                 FundProject.WeeklyPayoutDay
             );

--- a/src/avalonia/AngorApp/UI/Flows/CreateProject/Wizard/InvestmentProject/FundingConfigurationViewModel.cs
+++ b/src/avalonia/AngorApp/UI/Flows/CreateProject/Wizard/InvestmentProject/FundingConfigurationViewModel.cs
@@ -22,7 +22,7 @@ namespace AngorApp.UI.Flows.CreateProject.Wizard.InvestmentProject
 
             if (NewProject.StartDate == null)
             {
-                NewProject.StartDate = DateTime.Now.Date;
+                NewProject.StartDate = DateTime.UtcNow.Date;
             }
 
             if (NewProject.TargetAmount == null)

--- a/src/avalonia/AngorApp/UI/Flows/CreateProject/Wizard/InvestmentProject/Mappers/CreateProjectDtoMapper.cs
+++ b/src/avalonia/AngorApp/UI/Flows/CreateProject/Wizard/InvestmentProject/Mappers/CreateProjectDtoMapper.cs
@@ -26,7 +26,7 @@ public static class CreateProjectDtoMapper
 
             ProjectType = newProject.ProjectType,
             Sats = satsValue,
-            StartDate = (newProject.StartDate ?? DateTime.Now).Date,
+            StartDate = (newProject.StartDate ?? DateTime.UtcNow).Date,
 
             ExpiryDate = newProject.ExpiryDate?.Date,
             EndDate = newProject.FundingEndDate?.Date,

--- a/src/avalonia/AngorApp/UI/Flows/CreateProject/Wizard/InvestmentProject/Model/InvestmentProjectConfigBase.cs
+++ b/src/avalonia/AngorApp/UI/Flows/CreateProject/Wizard/InvestmentProject/Model/InvestmentProjectConfigBase.cs
@@ -151,13 +151,13 @@ namespace AngorApp.UI.Flows.CreateProject.Wizard.InvestmentProject.Model
             this.ValidationRule(x => x.PenaltyDays, x => x is null || x >= 10, "Penalty period must be at least 10 days.").DisposeWith(Disposables);
 
 
-            this.ValidationRule(x => x.FundingEndDate, x => x == null || x.Value.Date > DateTime.Now.Date, "Funding end date must be after today.").DisposeWith(Disposables);
-            this.ValidationRule(x => x.FundingEndDate, x => x == null || (x.Value - DateTime.Now) <= TimeSpan.FromDays(365), "Funding period cannot exceed one year.").DisposeWith(Disposables);
+            this.ValidationRule(x => x.FundingEndDate, x => x == null || x.Value.Date > DateTime.UtcNow.Date, "Funding end date must be after today.").DisposeWith(Disposables);
+            this.ValidationRule(x => x.FundingEndDate, x => x == null || (x.Value - DateTime.UtcNow) <= TimeSpan.FromDays(365), "Funding period cannot exceed one year.").DisposeWith(Disposables);
         }
 
         private void AddDebugValidations()
         {
-            this.ValidationRule(x => x.FundingEndDate, x => x == null || x.Value.Date >= DateTime.Now.Date, "Funding end date must be on or after today.").DisposeWith(Disposables);
+            this.ValidationRule(x => x.FundingEndDate, x => x == null || x.Value.Date >= DateTime.UtcNow.Date, "Funding end date must be on or after today.").DisposeWith(Disposables);
         }
 
         public void AddStage()

--- a/src/sdk/Angor.Data.Documents.LiteDb/LiteDbDocumentDatabase.cs
+++ b/src/sdk/Angor.Data.Documents.LiteDb/LiteDbDocumentDatabase.cs
@@ -20,6 +20,19 @@ public class LiteDbDocumentDatabase : IAngorDocumentDatabase
         
         try
         {
+            // Force LiteDB to store and retrieve all DateTime values in UTC.
+            // LiteDB 5.x stores DateTime as BSON DateTime (UTC milliseconds)
+            // but on deserialization may return DateTimeKind.Local, silently
+            // converting UTC dates to local time.  When those dates are later
+            // used to rebuild Bitcoin taproot scripts (CLTV locktimes, expiry
+            // dates), the different Kind causes .Date to return a different
+            // calendar day in non-UTC timezones, producing a different script
+            // hash and "Witness program hash mismatch".
+            BsonMapper.Global.RegisterType<DateTime>(
+                serialize: dt => new BsonValue(dt.ToUniversalTime()),
+                deserialize: bson => bson.AsDateTime.ToUniversalTime()
+            );
+
             _database = new LiteDatabase(connectionString);
             _logger.LogInformation("Initialized LiteDB database: {ConnectionString}", connectionString);
         }

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetRecoveryStatus.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetRecoveryStatus.cs
@@ -174,7 +174,7 @@ public static class GetRecoveryStatus
             var isAboveThreshold = projectInfo.ProjectType == ProjectType.Fund
                 && investorTransactionActions.IsInvestmentAbovePenaltyThreshold(projectInfo, totalInvestmentAmount);
             
-            var isEndOfProject = projectInfo.ExpiryDate < DateTime.Now;
+            var isEndOfProject = projectInfo.ExpiryDate < DateTime.UtcNow;
 
             var response = new InvestorProjectRecoveryDto
             {
@@ -294,7 +294,7 @@ public static class GetRecoveryStatus
                                     }
                                     else
                                     {
-                                        var days = (penaltyExpieryDate - DateTime.Now).TotalDays;
+                            var days = (penaltyExpieryDate - DateTime.UtcNow).TotalDays;
                                         item.Status = days > 0
                                             ? $"Penalty, released in {days.ToString("0.0")} days"
                                             : "Penalty can be released";


### PR DESCRIPTION
## Summary

- **Root cause**: LiteDB deserializes `DateTime` as `DateTimeKind.Local`. When `.Date` is called in a non-UTC timezone (e.g. India UTC+5:30), the calendar day shifts, producing a different CLTV locktime in the EndOfProject taproot leaf script. This causes a witness program hash mismatch when the founder tries to claim Fund project stage funds.
- **Primary fix**: Register a custom `DateTime` serializer in LiteDB that forces UTC on both serialize and deserialize, ensuring consistent round-trip regardless of system timezone.
- **Secondary fix**: Replace all `DateTime.Now` with `DateTime.UtcNow` in project creation and recovery status flows so dates are stored as UTC from the start.

## Reproduction

- Founder on Pop!_OS (India timezone, UTC+5:30) creates a Fund project
- Investor on Windows (UK timezone, UTC+1) invests
- Founder tries to claim stage funds -> broadcast rejected with "Witness program hash mismatch"

## Files changed (9)

| File | Change |
|------|--------|
| `LiteDbDocumentDatabase.cs` | Register `BsonMapper.Global.RegisterType<DateTime>()` forcing UTC |
| `CreateProjectFlow.cs` | `DateTime.Now` -> `DateTime.UtcNow` (debug defaults) |
| `CreateProjectDtoMapper.cs` (x2) | `DateTime.Now` -> `DateTime.UtcNow` |
| `FundReviewAndDeployViewModel.cs` | `DateTime.Now` -> `DateTime.UtcNow` |
| `PayoutsViewModel.cs` | `DateTime.Now` -> `DateTime.UtcNow` |
| `FundingConfigurationViewModel.cs` | `DateTime.Now` -> `DateTime.UtcNow` |
| `InvestmentProjectConfigBase.cs` | `DateTime.Now` -> `DateTime.UtcNow` (validation) |
| `GetRecoveryStatus.cs` | `DateTime.Now` -> `DateTime.UtcNow` |

## Testing

- All 146 shared tests pass
- All 312 SDK tests pass (14 skipped)
- Manually verified: founder on Pop!_OS (India timezone) can now successfully claim Fund project stage funds
