### PR TITLE
fix: payment status bar layout overlapping on mobile

### DIFF
--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowView.axaml
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowView.axaml
@@ -380,17 +380,19 @@
                         BorderThickness="1"
                         BorderBrush="{DynamicResource DeployFeeBarBorder}"
                         Background="{DynamicResource DeployFeeBarBg}">
-                    <Panel>
-                        <StackPanel Spacing="2" VerticalAlignment="Center"
-                                    HorizontalAlignment="Left">
-                            <TextBlock Text="Amount Required"
+                    <StackPanel Spacing="8">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <TextBlock Grid.Column="0"
+                                       Text="Amount Required"
                                        FontSize="12"
+                                       VerticalAlignment="Center"
                                        Foreground="{DynamicResource DeployFeeLabel}" />
-                            <TextBlock Text="{Binding AmountDisplay}"
+                            <TextBlock Grid.Column="1"
+                                       Text="{Binding AmountDisplay}"
                                        FontSize="20" FontWeight="Bold"
                                        Foreground="{DynamicResource DeployFeeValue}" />
-                        </StackPanel>
-                        <Border HorizontalAlignment="Right" VerticalAlignment="Center"
+                        </Grid>
+                        <Border HorizontalAlignment="Center"
                                 CornerRadius="12" Padding="12,6"
                                 BorderThickness="1"
                                 BorderBrush="{DynamicResource DeployFeePillBorder}"
@@ -406,7 +408,7 @@
                                            VerticalAlignment="Center" />
                             </StackPanel>
                         </Border>
-                    </Panel>
+                    </StackPanel>
                 </Border>
             </StackPanel>
         </Border>


### PR DESCRIPTION
## Summary
- Replaced `Panel` (overlay container) with `Grid` + `StackPanel` layout in the payment flow status bar
- Amount label ("Amount Required") sits left, amount value sits right, vertically centered on the same row
- Status pill is centered horizontally below both on its own row
- Fixes the status pill overlapping the amount text on narrow mobile screens

## Test plan
- [x] Tested on Android emulator (Pixel 9) — layout renders correctly
- [x] Tested on desktop app — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)