### PR TITLE
fix: Android tab bar positioned at 1/3 from bottom on cold start

### DIFF
--- a/src/design/App/UI/Shell/ShellView.axaml.cs
+++ b/src/design/App/UI/Shell/ShellView.axaml.cs
@@ -606,6 +606,21 @@ public partial class ShellView : UserControl
             ApplySafeAreaInsets(insets.SafeAreaPadding);
             insets.SafeAreaChanged += OnSafeAreaChanged;
         }
+
+        // On Android/iOS, enabling edge-to-edge changes the window bounds
+        // asynchronously. The first layout pass may use stale (pre-edge-to-edge)
+        // dimensions, leaving the tab bar floating above the true screen bottom.
+        // Re-read insets and force the shell Grid to re-measure once the platform
+        // has had a chance to commit the new window geometry.
+        if (OperatingSystem.IsAndroid() || OperatingSystem.IsIOS())
+        {
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                if (insets != null)
+                    ApplySafeAreaInsets(insets.SafeAreaPadding);
+                _shellContent?.InvalidateMeasure();
+            }, Avalonia.Threading.DispatcherPriority.Render);
+        }
     }
 
     private void OnSafeAreaChanged(object? sender, Avalonia.Controls.Platform.SafeAreaChangedArgs e)
@@ -621,6 +636,12 @@ public partial class ShellView : UserControl
             _bottomTabBar.Padding = new Avalonia.Thickness(0, 0, 0, _safeAreaBottom);
         if (_shellContent != null && LayoutModeService.Instance.IsCompact)
             _shellContent.Margin = new Avalonia.Thickness(0, _safeAreaTop, 0, 0);
+
+        // Explicitly invalidate the shell Grid so star-row heights are
+        // recalculated after inset changes. The padding/margin setters above
+        // should cascade, but on Android the cascade can be swallowed when
+        // the change occurs during the initial attachment layout pass.
+        _shellContent?.InvalidateMeasure();
     }
 
     protected override void OnDetachedFromLogicalTree(Avalonia.LogicalTree.LogicalTreeAttachmentEventArgs e)


### PR DESCRIPTION
## Summary

- Fix bottom tab bar rendering at ~1/3 from the screen bottom on Android cold start, with the tab bar background color filling the space below
- The bug self-corrected when toggling the theme in Settings, indicating a stale layout from the initial edge-to-edge window transition

## Root Cause

`DisplayEdgeToEdgePreference = true` is set in `OnAttachedToVisualTree`, which changes Android's window bounds asynchronously. The first layout pass uses the pre-edge-to-edge dimensions, so the shell Grid renders at the smaller size. The theme toggle happened to fix it because `RequestedThemeVariant` forces every `DynamicResource` binding to re-evaluate, triggering a full re-measure from the root with the correct window size.

## Changes

Two targeted changes in `ShellView.axaml.cs`:

1. **Deferred re-layout after edge-to-edge setup** -- post a callback at `Render` priority from `OnAttachedToVisualTree` that re-reads safe area insets and calls `InvalidateMeasure()` on the shell Grid, giving the platform time to commit the new window geometry
2. **Explicit `InvalidateMeasure` in `ApplySafeAreaInsets`** -- ensures the Grid recalculates star-row heights whenever insets change, even if the normal padding/margin cascade is swallowed during the initial attachment layout pass