### PR TITLE
fix: hardcode SupportNpub in App.csproj

### DIFF
--- a/src/design/App/App.csproj
+++ b/src/design/App/App.csproj
@@ -46,7 +46,7 @@
         <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)generated</CompilerGeneratedFilesOutputPath>
     </PropertyGroup>
     <PropertyGroup>
-        <SupportNpub></SupportNpub>
+        <SupportNpub>npub1n2pwqvvuaz9q67vk945l06krlzdcjnxxl4mp7dzrfye5v580x2es5luz4t</SupportNpub>
     </PropertyGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">


### PR DESCRIPTION
## Summary

- Hardcode the support npub directly in `App.csproj` since GitHub Actions variables (`vars.SUPPORT_NPUB`) are not being passed through to the build

## Changes

- Set `SupportNpub` property in `App.csproj` to `npub1n2pwqvvuaz9q67vk945l06krlzdcjnxxl4mp7dzrfye5v580x2es5luz4t` (was empty, relying on `-p:SupportNpub` from CI)
- The value is embedded into assembly metadata via `AssemblyMetadataAttribute` and read at runtime by `LogExportService` for encrypted log export