### PR TITLE
security: AngorKey type-safety (C3) and mnemonic memory protection (C2)

### DIFF
--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/ApproveInvestmentTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/ApproveInvestmentTests.cs
@@ -110,7 +110,7 @@ public class ApproveInvestmentTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveFounderRecoveryPrivateKey(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .Returns(new Key());
+            .Returns(AngorKey.From(new Key()));
 
         var network = Angor.Shared.Networks.Networks.Bitcoin.Testnet();
         var tx = network.CreateTransaction();
@@ -123,7 +123,7 @@ public class ApproveInvestmentTests
             .Returns(tx);
 
         _mockFounderTransactionActions
-            .Setup(x => x.SignInvestorRecoveryTransactions(It.IsAny<ProjectInfo>(), It.IsAny<string>(), It.IsAny<Blockcore.Consensus.TransactionInfo.Transaction>(), It.IsAny<string>()))
+            .Setup(x => x.SignInvestorRecoveryTransactions(It.IsAny<ProjectInfo>(), It.IsAny<string>(), It.IsAny<Blockcore.Consensus.TransactionInfo.Transaction>(), It.IsAny<AngorKey>()))
             .Returns(new SignatureInfo());
 
         // CheckInvestorRecoverySignatures returns false -> throws InvalidOperationException
@@ -152,11 +152,11 @@ public class ApproveInvestmentTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveFounderRecoveryPrivateKey(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .Returns(new Key());
+            .Returns(AngorKey.From(new Key()));
 
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
 
         var network = Angor.Shared.Networks.Networks.Bitcoin.Testnet();
         var tx = network.CreateTransaction();
@@ -169,7 +169,7 @@ public class ApproveInvestmentTests
             .Returns(tx);
 
         _mockFounderTransactionActions
-            .Setup(x => x.SignInvestorRecoveryTransactions(It.IsAny<ProjectInfo>(), It.IsAny<string>(), It.IsAny<Blockcore.Consensus.TransactionInfo.Transaction>(), It.IsAny<string>()))
+            .Setup(x => x.SignInvestorRecoveryTransactions(It.IsAny<ProjectInfo>(), It.IsAny<string>(), It.IsAny<Blockcore.Consensus.TransactionInfo.Transaction>(), It.IsAny<AngorKey>()))
             .Returns(new SignatureInfo());
 
         _mockInvestorTransactionActions
@@ -255,11 +255,11 @@ public class ApproveInvestmentTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveFounderRecoveryPrivateKey(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .Returns(new Key());
+            .Returns(AngorKey.From(new Key()));
 
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
 
         var network = Angor.Shared.Networks.Networks.Bitcoin.Testnet();
         var tx = network.CreateTransaction();
@@ -272,7 +272,7 @@ public class ApproveInvestmentTests
             .Returns(tx);
 
         _mockFounderTransactionActions
-            .Setup(x => x.SignInvestorRecoveryTransactions(It.IsAny<ProjectInfo>(), It.IsAny<string>(), It.IsAny<Blockcore.Consensus.TransactionInfo.Transaction>(), It.IsAny<string>()))
+            .Setup(x => x.SignInvestorRecoveryTransactions(It.IsAny<ProjectInfo>(), It.IsAny<string>(), It.IsAny<Blockcore.Consensus.TransactionInfo.Transaction>(), It.IsAny<AngorKey>()))
             .Returns(new SignatureInfo());
 
         _mockInvestorTransactionActions

--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/CreateProjectProfileTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/CreateProjectProfileTests.cs
@@ -261,6 +261,6 @@ public class CreateProjectProfileTests
     {
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
     }
 }

--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/FounderAppServiceTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/FounderAppServiceTests.cs
@@ -287,7 +287,7 @@ public class FounderAppServiceTests : IClassFixture<TestNetworkFixture>
 
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), founderKeys.FounderKey))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
 
         var handler = new CreateProjectInfo.CreateProjectInfoHandler(
             _mockSeedwordsProvider.Object,

--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/ReleaseFundsTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/ReleaseFundsTests.cs
@@ -171,7 +171,7 @@ public class ReleaseFundsTests
         _mockFounderTransactionActions
             .Setup(x => x.SignInvestorRecoveryTransactions(
                 It.IsAny<ProjectInfo>(), It.IsAny<string>(),
-                It.IsAny<Blockcore.Consensus.TransactionInfo.Transaction>(), It.IsAny<string>()))
+                It.IsAny<Blockcore.Consensus.TransactionInfo.Transaction>(), It.IsAny<AngorKey>()))
             .Returns(new SignatureInfo());
 
         _mockInvestorTransactionActions
@@ -279,10 +279,10 @@ public class ReleaseFundsTests
     {
         _mockDerivationOperations
             .Setup(x => x.DeriveFounderRecoveryPrivateKey(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .Returns(new Key());
+            .Returns(AngorKey.From(new Key()));
 
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
     }
 }

--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/SpendStageFundsTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/SpendStageFundsTests.cs
@@ -231,7 +231,7 @@ public class SpendStageFundsTests
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<int>(),
                 It.IsAny<Blockcore.Consensus.ScriptInfo.Script>(),
-                It.IsAny<string>(),
+                It.IsAny<AngorKey>(),
                 It.IsAny<FeeEstimation>()))
             .Returns(new Angor.Shared.Models.TransactionInfo
             {
@@ -322,6 +322,6 @@ public class SpendStageFundsTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveFounderPrivateKey(It.IsAny<WalletWords>(), It.IsAny<int>()))
-            .Returns(new Key());
+            .Returns(AngorKey.From(new Key()));
     }
 }

--- a/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/BuildRecoveryTransactionTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/BuildRecoveryTransactionTests.cs
@@ -178,7 +178,7 @@ public class BuildRecoveryTransactionTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveInvestorPrivateKey(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .Returns(new Key());
+            .Returns(AngorKey.From(new Key()));
 
         _mockDerivationOperations
             .Setup(x => x.DeriveNostrPubKey(It.IsAny<WalletWords>(), It.IsAny<string>()))
@@ -186,7 +186,7 @@ public class BuildRecoveryTransactionTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
 
         // LookupSignatureForInvestmentRequest ends without finding signatures
         _mockSignService
@@ -220,7 +220,7 @@ public class BuildRecoveryTransactionTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveInvestorPrivateKey(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .Returns(new Key());
+            .Returns(AngorKey.From(new Key()));
 
         _mockDerivationOperations
             .Setup(x => x.DeriveNostrPubKey(It.IsAny<WalletWords>(), It.IsAny<string>()))
@@ -228,7 +228,7 @@ public class BuildRecoveryTransactionTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
 
         // LookupSignatureForInvestmentRequest finds valid signatures
         var signatureInfo = new SignatureInfo();
@@ -263,7 +263,7 @@ public class BuildRecoveryTransactionTests
                 It.IsAny<ProjectInfo>(),
                 It.IsAny<Blockcore.Consensus.TransactionInfo.Transaction>(),
                 It.IsAny<SignatureInfo>(),
-                It.IsAny<string>()))
+                It.IsAny<AngorKey>()))
             .Returns(network.CreateTransaction());
 
         _mockTransactionService

--- a/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/BuildUnfundedReleaseTransactionTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/BuildUnfundedReleaseTransactionTests.cs
@@ -176,7 +176,7 @@ public class BuildUnfundedReleaseTransactionTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveInvestorPrivateKey(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .Returns(new Key());
+            .Returns(AngorKey.From(new Key()));
 
         // LookupReleaseSigs ends without finding signatures
         _mockSignService
@@ -196,7 +196,7 @@ public class BuildUnfundedReleaseTransactionTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
 
         // Act
         var result = await _sut.Handle(request, CancellationToken.None);

--- a/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/ClaimLightningSwapTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/ClaimLightningSwapTests.cs
@@ -4,6 +4,7 @@ using Angor.Sdk.Funding.Projects.Domain;
 using Angor.Sdk.Funding.Shared;
 using Angor.Shared;
 using Angor.Shared.Integration.Lightning;
+using Blockcore.NBitcoin;
 using Angor.Shared.Integration.Lightning.Models;
 using Angor.Shared.Models;
 using CSharpFunctionalExtensions;
@@ -204,7 +205,7 @@ public class ClaimLightningSwapTests
         SetupSuccessfulKeyDerivation();
 
         _mockBoltzClaimService
-            .Setup(x => x.ClaimSwapAsync(It.IsAny<BoltzSubmarineSwap>(), It.IsAny<string>(), "lockup-hex-abc", 0, 2))
+            .Setup(x => x.ClaimSwapAsync(It.IsAny<BoltzSubmarineSwap>(), It.IsAny<AngorKey>(), "lockup-hex-abc", 0, 2))
             .ReturnsAsync(Result.Failure<BoltzClaimResult>("Claim failed: invalid preimage"));
 
         // Act
@@ -231,7 +232,7 @@ public class ClaimLightningSwapTests
 
         var claimResult = new BoltzClaimResult("claim-tx-id", "claim-tx-hex");
         _mockBoltzClaimService
-            .Setup(x => x.ClaimSwapAsync(It.IsAny<BoltzSubmarineSwap>(), It.IsAny<string>(), "lockup-hex-abc", 0, 2))
+            .Setup(x => x.ClaimSwapAsync(It.IsAny<BoltzSubmarineSwap>(), It.IsAny<AngorKey>(), "lockup-hex-abc", 0, 2))
             .ReturnsAsync(Result.Success(claimResult));
 
         _mockSwapStorageService
@@ -263,7 +264,7 @@ public class ClaimLightningSwapTests
 
         var claimResult = new BoltzClaimResult("claim-tx-id", "claim-tx-hex");
         _mockBoltzClaimService
-            .Setup(x => x.ClaimSwapAsync(It.IsAny<BoltzSubmarineSwap>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<long>()))
+            .Setup(x => x.ClaimSwapAsync(It.IsAny<BoltzSubmarineSwap>(), It.IsAny<AngorKey>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<long>()))
             .ReturnsAsync(Result.Success(claimResult));
 
         _mockSwapStorageService
@@ -296,7 +297,7 @@ public class ClaimLightningSwapTests
 
         var claimResult = new BoltzClaimResult("claim-tx-id", "claim-tx-hex");
         _mockBoltzClaimService
-            .Setup(x => x.ClaimSwapAsync(It.IsAny<BoltzSubmarineSwap>(), It.IsAny<string>(), "doc-lockup-hex", 0, 2))
+            .Setup(x => x.ClaimSwapAsync(It.IsAny<BoltzSubmarineSwap>(), It.IsAny<AngorKey>(), "doc-lockup-hex", 0, 2))
             .ReturnsAsync(Result.Success(claimResult));
 
         _mockSwapStorageService
@@ -328,7 +329,7 @@ public class ClaimLightningSwapTests
 
         _mockHdOperations
             .Setup(x => x.DerivePrivateKey(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string>()))
-            .Returns("derived-private-key-hex");
+            .Returns(AngorKey.From(new Key()));
     }
 
     private static BoltzSwapDocument CreateSwapDocument(string? projectId, string? lockupTxHex = "lockup-hex")

--- a/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/GetInvestorNsecTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/GetInvestorNsecTests.cs
@@ -62,7 +62,7 @@ public class GetInvestorNsecTests
             .ReturnsAsync(Result.Success(sensitiveData));
 
         // Use a real 32-byte key for test
-        var testKey = new Key();
+        var testKey = AngorKey.From(new Key());
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), founderKey))
             .ReturnsAsync(testKey);
@@ -90,7 +90,7 @@ public class GetInvestorNsecTests
             .Setup(x => x.GetSensitiveData(walletId.Value))
             .ReturnsAsync(Result.Success(sensitiveData));
 
-        var testKey = new Key();
+        var testKey = AngorKey.From(new Key());
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), "specific-founder-key"))
             .ReturnsAsync(testKey);

--- a/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/NotifyFounderOfCancellationTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/NotifyFounderOfCancellationTests.cs
@@ -177,7 +177,7 @@ public class NotifyFounderOfCancellationTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), project.FounderKey))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
 
         _mockSerializer
             .Setup(x => x.Serialize(It.IsAny<CancellationNotification>()))
@@ -242,7 +242,7 @@ public class NotifyFounderOfCancellationTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
     }
 
     private static Project CreateTestProject(ProjectId projectId)

--- a/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/NotifyFounderOfInvestmentTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/NotifyFounderOfInvestmentTests.cs
@@ -179,7 +179,7 @@ public class NotifyFounderOfInvestmentTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
 
         _mockSerializer
             .Setup(x => x.Serialize(It.IsAny<InvestmentNotification>()))
@@ -215,7 +215,7 @@ public class NotifyFounderOfInvestmentTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
 
         _mockSerializer
             .Setup(x => x.Serialize(It.IsAny<InvestmentNotification>()))

--- a/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/PublishInvestmentTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/PublishInvestmentTests.cs
@@ -251,6 +251,6 @@ public class PublishInvestmentTests
 
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
     }
 }

--- a/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/RequestInvestmentSignaturesTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/RequestInvestmentSignaturesTests.cs
@@ -299,6 +299,6 @@ public class RequestInvestmentSignaturesTests
     {
         _mockDerivationOperations
             .Setup(x => x.DeriveProjectNostrPrivateKeyAsync(It.IsAny<WalletWords>(), It.IsAny<string>()))
-            .ReturnsAsync(new Key());
+            .ReturnsAsync(AngorKey.From(new Key()));
     }
 }

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/ApproveInvestment.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/ApproveInvestment.cs
@@ -63,7 +63,7 @@ public static class ApproveInvestment
             {
                 var key = derivationOperations.DeriveFounderRecoveryPrivateKey(words, projectInfo.FounderKey);
                 
-                var signatureInfo = CreateRecoverySignatures(investmentTransactionHex, projectInfo, Encoders.Hex.EncodeData(key.ToBytes()));
+                var signatureInfo = CreateRecoverySignatures(investmentTransactionHex, projectInfo, key);
 
                 var sigJson = serializer.Serialize(signatureInfo);
 
@@ -77,7 +77,7 @@ public static class ApproveInvestment
             });
         }
 
-        private SignatureInfo CreateRecoverySignatures(string transactionHex, ProjectInfo info, string founderSigningPrivateKey)
+        private SignatureInfo CreateRecoverySignatures(string transactionHex, ProjectInfo info, AngorKey founderSigningPrivateKey)
         {
             var investorTrx = networkConfiguration.GetNetwork().CreateTransaction(transactionHex);
 

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/ReleaseFunds.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/ReleaseFunds.cs
@@ -55,7 +55,7 @@ public static class ReleaseFunds
             
             foreach (var payload in decryptResult.Value)
             {
-                var result = await PerformReleaseSignature(payload, nostrPrivateKeyHex, Encoders.Hex.EncodeData(key.ToBytes()), projectResult.Value.ToProjectInfo());
+                var result = await PerformReleaseSignature(payload, nostrPrivateKeyHex, key, projectResult.Value.ToProjectInfo());
                 
                 if (result.IsFailure)
                     failedSignatures.AppendLine(result.Error);;
@@ -144,12 +144,12 @@ public static class ReleaseFunds
             return Result.Success(list);
         }
 
-        private async Task<Result> PerformReleaseSignature(Payload payload, string nostrFounderPrivateKeyHex, string founderRecoveryPrivateKeyHex, ProjectInfo projectInfo)
+        private async Task<Result> PerformReleaseSignature(Payload payload, string nostrFounderPrivateKeyHex, AngorKey founderRecoveryPrivateKey, ProjectInfo projectInfo)
         {
             try
             {
                 var signatureInfo = CreateReleaseSignatures(payload.SignRecoveryRequest.InvestmentTransactionHex,
-                    projectInfo, founderRecoveryPrivateKeyHex,
+                    projectInfo, founderRecoveryPrivateKey,
                     payload.SignRecoveryRequest.UnfundedReleaseAddress ?? payload.SignRecoveryRequest.UnfundedReleaseKey);
 
                 var sigJson = serializer.Serialize(signatureInfo);
@@ -169,7 +169,7 @@ public static class ReleaseFunds
             }
         }
 
-        private SignatureInfo CreateReleaseSignatures(string transactionHex, ProjectInfo info, string founderSigningPrivateKey, string investorReleaseAddress)
+        private SignatureInfo CreateReleaseSignatures(string transactionHex, ProjectInfo info, AngorKey founderSigningPrivateKey, string investorReleaseAddress)
     {
         var investorTrx = networkConfiguration.GetNetwork().CreateTransaction(transactionHex);
 

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/SpendStageFunds.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/SpendStageFunds.cs
@@ -110,7 +110,7 @@ public static class SpendStageFunds
             return await transactionService.GetTransactionHexByIdAsync(investment.TransactionId) ?? string.Empty;
         }
 
-        private async Task<string?> GetProjectFounderKeyAsync(string walletId, string projectId)
+        private async Task<AngorKey?> GetProjectFounderKeyAsync(string walletId, string projectId)
         {
             // Try to get from storage first
             var storedKeysResult = await derivedProjectKeysCollection.FindByIdAsync(walletId.ToString());
@@ -126,7 +126,7 @@ public static class SpendStageFunds
             // Use the stored index to derive the founder private key
             var words = await seedwordsProvider.GetSensitiveData(walletId);
             var key = derivationOperations.DeriveFounderPrivateKey(words.Value.ToWalletWords(), storedKey.Index);
-            return Encoders.Hex.EncodeData(key.ToBytes());
+            return key;
         }
         
         private async Task<Result<string>> GetUnfundedReleaseAddress(WalletId walletId)

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildEndOfProjectClaim.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildEndOfProjectClaim.cs
@@ -83,7 +83,7 @@ public static class BuildEndOfProjectClaim
             var stageNumber = firstUnspentTaproot.index - 1;
 
             var endOfProjectTransaction = investorTransactionActions.RecoverEndOfProjectFunds(investment.InvestmentTransactionHex, project.Value.ToProjectInfo(), stageNumber,
-                changeAddress, Encoders.Hex.EncodeData(investorPrivateKey.ToBytes()), new FeeEstimation(){FeeRate = request.SelectedFeeRate.SatsPerKilobyte});
+                changeAddress, investorPrivateKey, new FeeEstimation(){FeeRate = request.SelectedFeeRate.SatsPerKilobyte});
             
             return Result.Success(new BuildEndOfProjectClaimResponse(new EndOfProjectTransactionDraft()
                {

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildPenaltyReleaseTransaction.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildPenaltyReleaseTransaction.cs
@@ -100,7 +100,7 @@ public static class BuildPenaltyReleaseTransaction
                 recoveryTransaction,
                 changeAddress,
                 feeEstimation,
-                Encoders.Hex.EncodeData(investorPrivateKey.ToBytes()));
+                investorPrivateKey);
 
             return Result.Success(new BuildPenaltyReleaseTransactionResponse(new ReleaseTransactionDraft
             {

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildRecoveryTransaction.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildRecoveryTransaction.cs
@@ -69,7 +69,7 @@ public static class BuildRecoveryTransaction
             if (signatureLookup.Value is null)
                 return Result.Failure<BuildRecoveryTransactionResponse>("No founder signatures found");
 
-            var unsignedRecoveryTransaction = investorTransactionActions.AddSignaturesToRecoverSeederFundsTransaction(project.Value.ToProjectInfo(), investmentTransaction, signatureLookup.Value, Encoders.Hex.EncodeData(investorPrivateKey.ToBytes()));
+            var unsignedRecoveryTransaction = investorTransactionActions.AddSignaturesToRecoverSeederFundsTransaction(project.Value.ToProjectInfo(), investmentTransaction, signatureLookup.Value, investorPrivateKey);
 
             var transactionInfo = await transactionService.GetTransactionInfoByIdAsync(investmentTransaction.GetHash().ToString());
 

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildUnfundedReleaseTransaction.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildUnfundedReleaseTransaction.cs
@@ -73,7 +73,7 @@ public static class BuildUnfundedReleaseTransaction
             var investorReleaseSigInfo = signatureLookup.Value;
             
             // Sign the release transaction
-            var unsignedReleaseTransaction = investorTransactionActions.AddSignaturesToUnfundedReleaseFundsTransaction(project.Value.ToProjectInfo(), investmentTransaction, investorReleaseSigInfo, Encoders.Hex.EncodeData(investorPrivateKey.ToBytes()), investment.UnfundedReleaseAddress);
+            var unsignedReleaseTransaction = investorTransactionActions.AddSignaturesToUnfundedReleaseFundsTransaction(project.Value.ToProjectInfo(), investmentTransaction, investorReleaseSigInfo, investorPrivateKey, investment.UnfundedReleaseAddress);
 
             // Validate the signatures
             var sigCheckResult = investorTransactionActions.CheckInvestorUnfundedReleaseSignatures(project.Value.ToProjectInfo(), investmentTransaction, investorReleaseSigInfo, investment.UnfundedReleaseAddress);

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/ClaimLightningSwap.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/ClaimLightningSwap.cs
@@ -1,4 +1,4 @@
-﻿using Angor.Sdk.Common;
+using Angor.Sdk.Common;
 using Angor.Sdk.Funding.Services;
 using Angor.Shared;
 using Angor.Shared.Integration.Lightning;
@@ -124,28 +124,28 @@ public static class ClaimLightningSwap
             }
         }
 
-        private async Task<Result<string>> DeriveClaimPrivateKeyFromAddress(WalletId walletId, string address)
+        private async Task<Result<AngorKey>> DeriveClaimPrivateKeyFromAddress(WalletId walletId, string address)
         {
             if (string.IsNullOrEmpty(address))
-                return Result.Failure<string>("Swap has no receive address — cannot derive claim key");
+                return Result.Failure<AngorKey>("Swap has no receive address — cannot derive claim key");
 
             var sensitiveDataResult = await seedwordsProvider.GetSensitiveData(walletId.Value);
             if (sensitiveDataResult.IsFailure)
-                return Result.Failure<string>($"Failed to get wallet data: {sensitiveDataResult.Error}");
+                return Result.Failure<AngorKey>($"Failed to get wallet data: {sensitiveDataResult.Error}");
 
             var accountResult = await walletAccountBalanceService.GetAccountBalanceInfoAsync(walletId);
             if (accountResult.IsFailure)
-                return Result.Failure<string>($"Failed to get account info: {accountResult.Error}");
+                return Result.Failure<AngorKey>($"Failed to get account info: {accountResult.Error}");
 
             var addressInfo = accountResult.Value.AccountInfo.AllAddresses()
                 .FirstOrDefault(a => a.Address == address);
             if (addressInfo == null)
-                return Result.Failure<string>($"Address {address} not found in wallet — cannot derive claim key");
+                return Result.Failure<AngorKey>($"Address {address} not found in wallet — cannot derive claim key");
 
             var (seed, passphrase) = sensitiveDataResult.Value;
-            var privateKeyHex = hdOperations.DerivePrivateKey(seed, passphrase.GetValueOrDefault(), addressInfo.HdPath);
+            var privateKey = hdOperations.DerivePrivateKey(seed, passphrase.GetValueOrDefault(), addressInfo.HdPath);
 
-            return Result.Success(privateKeyHex);
+            return Result.Success(privateKey);
         }
     }
 }

--- a/src/sdk/Angor.Sdk/Wallet/Infrastructure/Impl/SensitiveWalletDataProvider.cs
+++ b/src/sdk/Angor.Sdk/Wallet/Infrastructure/Impl/SensitiveWalletDataProvider.cs
@@ -1,36 +1,75 @@
 using Angor.Sdk.Common;
 using Angor.Sdk.Wallet.Domain;
 using Angor.Sdk.Wallet.Infrastructure.Interfaces;
+using Angor.Shared.Models;
 using CSharpFunctionalExtensions;
 using CSharpFunctionalExtensions.ValueTasks;
 
 namespace Angor.Sdk.Wallet.Infrastructure.Impl;
 
+/// <summary>
+/// Caches wallet sensitive data (mnemonic words, passphrase) using WalletWords
+/// which backs storage with char[] arrays that can be zeroed on disposal.
+/// </summary>
 public class SensitiveWalletDataProvider(IWalletStore walletStore, IWalletSecurityContext walletSecurityContext,
-    IWalletEncryption walletEncryption) : ISensitiveWalletDataProvider
+    IWalletEncryption walletEncryption) : ISensitiveWalletDataProvider, IDisposable
 {
-    private readonly Dictionary<WalletId, (string, Maybe<string>)> cachedSensitiveData = new();
+    private readonly Dictionary<WalletId, WalletWords> cachedWalletWords = new();
 
     public async Task<Result<(string seed, Maybe<string> passphrase)>> RequestSensitiveData(WalletId walletId)
     {
-        var findResult = cachedSensitiveData.TryFind(walletId);
-        if (findResult.HasValue)
+        if (cachedWalletWords.TryGetValue(walletId, out var cached))
         {
-            return findResult.Value;
+            return ToTuple(cached);
         }
 
-        var result = await RequestSensitiveDataCore(walletId).Tap(data => cachedSensitiveData[walletId] = data);
+        var result = await RequestSensitiveDataCore(walletId);
+        if (result.IsSuccess)
+        {
+            var walletWords = new WalletWords
+            {
+                Words = result.Value.seed,
+                Passphrase = result.Value.passphrase.GetValueOrDefault("")
+            };
+            cachedWalletWords[walletId] = walletWords;
+        }
+
         return result;
     }
 
     public void SetSensitiveData(WalletId id, (string seed, Maybe<string> passphrase) data)
     {
-        cachedSensitiveData[id] = data;
+        // Dispose any previously cached data for this wallet
+        if (cachedWalletWords.TryGetValue(id, out var existing))
+            existing.Dispose();
+
+        cachedWalletWords[id] = new WalletWords
+        {
+            Words = data.seed,
+            Passphrase = data.passphrase.GetValueOrDefault("")
+        };
     }
 
     public void RemoveSensitiveData(WalletId id)
     {
-        cachedSensitiveData.Remove(id);
+        if (cachedWalletWords.Remove(id, out var walletWords))
+            walletWords.Dispose();
+    }
+
+    public void Dispose()
+    {
+        foreach (var walletWords in cachedWalletWords.Values)
+            walletWords.Dispose();
+
+        cachedWalletWords.Clear();
+    }
+
+    private static (string seed, Maybe<string> passphrase) ToTuple(WalletWords walletWords)
+    {
+        Maybe<string> passphrase = string.IsNullOrEmpty(walletWords.Passphrase)
+            ? Maybe<string>.None
+            : walletWords.Passphrase;
+        return (walletWords.Words, passphrase);
     }
 
     private async Task<Result<EncryptedWallet>> GetEncryptedWallet(WalletId id)

--- a/src/shared/Angor.Shared.Tests/DerivationOperationsTest.cs
+++ b/src/shared/Angor.Shared.Tests/DerivationOperationsTest.cs
@@ -220,7 +220,7 @@ namespace Angor.Test
 
                 // Assert
                 results.Should().NotBeNull().And.NotContainNulls();
-                results.Should().OnlyContain(r => r is Key);
+                results.Should().OnlyContain(r => r is AngorKey);
             }
             
             [Fact]

--- a/src/shared/Angor.Shared.Tests/Protocol/FounderTransactionActionTest.cs
+++ b/src/shared/Angor.Shared.Tests/Protocol/FounderTransactionActionTest.cs
@@ -112,7 +112,7 @@ public class FounderTransactionActionTest : AngorTestData
             new (Encoders.Hex.DecodeData("a1b81722e2946e2679561f7ec3b475a35f0d3624a20b7366f6fcb94769fb080e"))
         };
         
-        var result = _sut.SignInvestorRecoveryTransactions(projectInvestmentInfo, investmentTrxHex, recoveryTransaction, Encoders.Hex.EncodeData(founderRecoveryPrivateKey.ToBytes()));
+        var result = _sut.SignInvestorRecoveryTransactions(projectInvestmentInfo, investmentTrxHex, recoveryTransaction, founderRecoveryPrivateKey);
 
         Assert.NotEmpty(result.Signatures);
         Assert.Equal(3,result.Signatures.Count);
@@ -158,7 +158,7 @@ public class FounderTransactionActionTest : AngorTestData
     };
 
     var founderTrx = _sut.SpendFounderStage(projectInvestmentInfo, transactionHexList
-        , 1, funderReceiveCoinsKey.PubKey.ScriptPubKey, Encoders.Hex.EncodeData(funderPrivateKey.ToBytes())
+        , 1, funderReceiveCoinsKey.PubKey.ScriptPubKey, funderPrivateKey
         , _expectedFeeEstimation);
         
         TransactionValidation.ThanTheTransactionHasNoErrors(founderTrx.Transaction,
@@ -190,7 +190,7 @@ public class FounderTransactionActionTest : AngorTestData
         
         var founderTrxSpendStageOne = _sut.SpendFounderStage(projectInvestmentInfo,
             transactionList.Select(_ => _.ToHex()), stageNumber,
-            funderReceiveCoinsKey.PubKey.ScriptPubKey, Encoders.Hex.EncodeData(funderPrivateKey.ToBytes())
+            funderReceiveCoinsKey.PubKey.ScriptPubKey, funderPrivateKey
             , _expectedFeeEstimation);
 
         TransactionValidation.ThanTheTransactionHasNoErrors(founderTrxSpendStageOne.Transaction,

--- a/src/shared/Angor.Shared.Tests/Protocol/InvestmentIntegrationsTests.cs
+++ b/src/shared/Angor.Shared.Tests/Protocol/InvestmentIntegrationsTests.cs
@@ -223,7 +223,7 @@ namespace Angor.Test.Protocol
 
             var founderTrxForSeeder1Stage1 = _founderTransactionActions.SpendFounderStage(projectInvestmentInfo,
                 founderContext.InvestmentTrasnactionsHex, 1,
-                funderReceiveCoinsKey.PubKey.ScriptPubKey, Encoders.Hex.EncodeData(funderKey.ToBytes())
+                funderReceiveCoinsKey.PubKey.ScriptPubKey, funderKey
                 , _expectedFeeEstimation);
 
             TransactionValidation.ThanTheTransactionHasNoErrors(founderTrxForSeeder1Stage1.Transaction,
@@ -274,7 +274,7 @@ namespace Angor.Test.Protocol
 
             var seeder1Expierytrx = _seederTransactionActions.RecoverEndOfProjectFunds(seeder1InvTrx.ToHex(), projectInvestmentInfo,
                 1, seeder1ReceiveCoinsKey.PubKey.ScriptPubKey.WitHash.GetAddress(network).ToString(),
-                Encoders.Hex.EncodeData(seeder11Key.ToBytes()), _expectedFeeEstimation);
+                AngorKey.From(seeder11Key), _expectedFeeEstimation);
 
             Assert.NotNull(seeder1Expierytrx);
 
@@ -327,7 +327,7 @@ namespace Angor.Test.Protocol
             var investor1Expierytrx = _investorTransactionActions.RecoverEndOfProjectFunds(investorInvTrx.ToHex(),
                 projectInvestmentInfo,
                 1, seeder1ReceiveCoinsKey.PubKey.ScriptPubKey.WitHash.GetAddress(network).ToString(),
-                Encoders.Hex.EncodeData(seeder11Key.ToBytes()), _expectedFeeEstimation);
+                AngorKey.From(seeder11Key), _expectedFeeEstimation);
 
             Assert.NotNull(investor1Expierytrx);
 
@@ -384,7 +384,7 @@ namespace Angor.Test.Protocol
 
             var investorExpierytrx = _investorTransactionActions.RecoverEndOfProjectFunds(investorInvTrx.ToHex(),
                 projectInvestmentInfo, 1, investorReceiveCoinsKey.PubKey.ScriptPubKey.WitHash.GetAddress(network).ToString(),
-                Encoders.Hex.EncodeData(investorKey.ToBytes()), _expectedFeeEstimation);
+                AngorKey.From(investorKey), _expectedFeeEstimation);
 
             Assert.NotNull(investorExpierytrx);
 
@@ -447,11 +447,11 @@ namespace Angor.Test.Protocol
 
             var founderSignatures = _founderTransactionActions.SignInvestorRecoveryTransactions(investorContext.ProjectInfo,
                 investmentTransaction.ToHex(), recoveryTransaction,
-                Encoders.Hex.EncodeData(founderRecoveryPrivateKey.ToBytes()));
+                founderRecoveryPrivateKey);
 
             var signedRecoveryTransaction = _seederTransactionActions.AddSignaturesToRecoverSeederFundsTransaction(investorContext.ProjectInfo,
                 investmentTransaction, seederFundsRecoveryKey.PubKey.ToHex(),
-                founderSignatures, Encoders.Hex.EncodeData(seederKey.ToBytes()), Encoders.Hex.EncodeData(seederSecret.ToBytes()));
+                founderSignatures, AngorKey.From(seederKey), Encoders.Hex.EncodeData(seederSecret.ToBytes()));
 
             // Adding the input that will be spent as fee 
             signedRecoveryTransaction.Inputs.Add(new Blockcore.Consensus.TransactionInfo.TxIn(new Blockcore.Consensus.TransactionInfo.OutPoint(Blockcore.NBitcoin.uint256.Zero, 0))); //Add fee to the transaction
@@ -515,14 +515,14 @@ namespace Angor.Test.Protocol
 
             var founderSignatures = _founderTransactionActions.SignInvestorRecoveryTransactions(investorContext.ProjectInfo,
                 investmentTransaction.ToHex(), recoveryTransaction,
-                Encoders.Hex.EncodeData(founderRecoveryPrivateKey.ToBytes()));
+                founderRecoveryPrivateKey);
 
             var sigCheckResult = _investorTransactionActions.CheckInvestorRecoverySignatures(investorContext.ProjectInfo, investmentTransaction, founderSignatures);
             Assert.True(sigCheckResult, "failed to validate the founders signatures");
 
             var signedRecoveryTransaction = _investorTransactionActions.AddSignaturesToRecoverSeederFundsTransaction(investorContext.ProjectInfo,
                 investmentTransaction,
-                founderSignatures, Encoders.Hex.EncodeData(investorKey.ToBytes()));
+                founderSignatures, AngorKey.From(investorKey));
 
             List<Coin> coins = new();
             foreach (var indexedTxOut in investmentTransaction.Outputs.AsIndexedOutputs().Where(w => !w.TxOut.ScriptPubKey.IsUnspendable))
@@ -540,7 +540,7 @@ namespace Angor.Test.Protocol
 
             // recover the coins after the penalty
             var releaseTransaction = _investorTransactionActions.BuildAndSignRecoverReleaseFundsTransaction(investorContext.ProjectInfo, investmentTransaction, signedRecoveryTransaction,
-                investorContext.ChangeAddress, _expectedFeeEstimation, Encoders.Hex.EncodeData(investorKey.ToBytes()));
+                investorContext.ChangeAddress, _expectedFeeEstimation, AngorKey.From(investorKey));
 
             coins = new();
             foreach (var indexedTxOut in signedRecoveryTransaction.Outputs.AsIndexedOutputs())
@@ -618,7 +618,7 @@ namespace Angor.Test.Protocol
                 var investorRecoverFundsNoPenalty = _investorTransactionActions.RecoverRemainingFundsWithOutPenalty(
                     investorInvTrx.ToHex(), projectInvestmentInfo, startStageNumber,
                     investorReceiveCoinsKey.PubKey.ScriptPubKey.WitHash.GetAddress(Networks.Bitcoin.Testnet()).ToString(),
-                    Encoders.Hex.EncodeData(investorKey.ToBytes()), _expectedFeeEstimation, partSecrets
+                    AngorKey.From(investorKey), _expectedFeeEstimation, partSecrets
                 );
 
                 Assert.NotNull(investorRecoverFundsNoPenalty);
@@ -683,10 +683,10 @@ namespace Angor.Test.Protocol
             // Sign the release transaction
             var founderSignatures = _founderTransactionActions.SignInvestorRecoveryTransactions(investorContext.ProjectInfo,
                 investmentTransaction.ToHex(), releaseTransaction,
-                Encoders.Hex.EncodeData(founderRecoveryPrivateKey.ToBytes()));
+                founderRecoveryPrivateKey);
 
             var signedReleaseTransaction = _investorTransactionActions.AddSignaturesToUnfundedReleaseFundsTransaction(investorContext.ProjectInfo,
-                investmentTransaction, founderSignatures, Encoders.Hex.EncodeData(investorKey.ToBytes()), investorReleasePubKey);
+                investmentTransaction, founderSignatures, AngorKey.From(investorKey), investorReleasePubKey);
 
             // Validate the signatures
             var sigCheckResult = _investorTransactionActions.CheckInvestorUnfundedReleaseSignatures(investorContext.ProjectInfo, investmentTransaction, founderSignatures, investorReleasePubKey);
@@ -772,7 +772,7 @@ namespace Angor.Test.Protocol
                 projectInvestmentInfo,
                 1,
                 investorReceiveCoinsKey.PubKey.ScriptPubKey.WitHash.GetAddress(network).ToString(),
-                Encoders.Hex.EncodeData(investorKey.ToBytes()), _expectedFeeEstimation);
+                AngorKey.From(investorKey), _expectedFeeEstimation);
 
             Assert.NotNull(investor1Expierytrx);
 
@@ -844,7 +844,7 @@ namespace Angor.Test.Protocol
             var investor1Expierytrx = _investorTransactionActions.RecoverEndOfProjectFunds(investorInvTrx.ToHex(),
            projectInvestmentInfo,
              1, investorReceiveCoinsKey.PubKey.ScriptPubKey.WitHash.GetAddress(network).ToString(),
-             Encoders.Hex.EncodeData(investorKey.ToBytes()), _expectedFeeEstimation);
+              AngorKey.From(investorKey), _expectedFeeEstimation);
 
             Assert.NotNull(investor1Expierytrx);
 
@@ -947,7 +947,7 @@ namespace Angor.Test.Protocol
                 projectInfo,
                 2, // Stage 1
                 investor1ReceiveAddress,
-                Encoders.Hex.EncodeData(investor1PrivateKey),
+                AngorKey.FromHex(Encoders.Hex.EncodeData(investor1PrivateKey)),
                 _expectedFeeEstimation);
 
             Assert.NotNull(investor1RecoverStage1);
@@ -967,7 +967,7 @@ namespace Angor.Test.Protocol
                     projectInfo,
                     investor2Trx.ToHex(),
                     investor2RecoveryTrx,
-                    Encoders.Hex.EncodeData(founderRecoveryPrivateKey.ToBytes()));
+                    founderRecoveryPrivateKey);
 
             Assert.NotNull(founderSignatures);
             Assert.NotEmpty(founderSignatures.Signatures);
@@ -981,7 +981,7 @@ namespace Angor.Test.Protocol
                 projectInfo,
                 investor2Trx,
                 founderSignatures,
-                Encoders.Hex.EncodeData(investor2PrivateKey));
+                AngorKey.FromHex(Encoders.Hex.EncodeData(investor2PrivateKey)));
 
             Assert.NotNull(investor2SignedRecoveryTrx);
 
@@ -1005,7 +1005,7 @@ namespace Angor.Test.Protocol
                     investor2SignedRecoveryTrx,
                     investor2ReceiveAddress,
                     _expectedFeeEstimation,
-                    Encoders.Hex.EncodeData(investor2PrivateKey));
+                    AngorKey.FromHex(Encoders.Hex.EncodeData(investor2PrivateKey)));
 
             Assert.NotNull(investor2RecoverStage1);
             Assert.NotNull(investor2RecoverStage1.Transaction);
@@ -1020,7 +1020,7 @@ namespace Angor.Test.Protocol
                     projectInfo,
                     allInvestmentHexes,
                     founderReceiveAddress,
-                    Encoders.Hex.EncodeData(founderKey.ToBytes()),
+                    founderKey,
                     _expectedFeeEstimation);
 
             Assert.NotNull(founderSpendStage2);
@@ -1098,7 +1098,7 @@ namespace Angor.Test.Protocol
                 new[] { investorInvTrx.ToHex() },
                 1,
                 founderReceiveAddress,
-                Encoders.Hex.EncodeData(founderKey.ToBytes()),
+                founderKey,
                 _expectedFeeEstimation);
 
             Assert.NotNull(founderSpendStage1);
@@ -1112,7 +1112,7 @@ namespace Angor.Test.Protocol
                           projectInvestmentInfo,
                        2,
              investorReceiveCoinsKey.PubKey.ScriptPubKey.WitHash.GetAddress(network).ToString(),
-                Encoders.Hex.EncodeData(investorKey.ToBytes()),
+                AngorKey.From(investorKey),
                  _expectedFeeEstimation);
 
             Assert.NotNull(investor1RecoverStage2);

--- a/src/shared/Angor.Shared.Tests/Protocol/TransactionBuilders/SpendingTransactionBuilderTest.cs
+++ b/src/shared/Angor.Shared.Tests/Protocol/TransactionBuilders/SpendingTransactionBuilderTest.cs
@@ -1,3 +1,4 @@
+using Angor.Shared;
 using Angor.Shared.Models;
 using Angor.Shared.Networks;
 using Angor.Shared.Protocol.Scripts;
@@ -44,7 +45,7 @@ public class SpendingTransactionBuilderTest : AngorTestData
             projectInfo,
             1,
             changeAddress.ScriptPubKey.WitHash.GetAddress(Networks.Bitcoin.Testnet()).ToString(),
-            Encoders.Hex.EncodeData(new Key().ToBytes()),
+            AngorKey.From(new Key()),
             new NBitcoin.FeeRate(NBitcoin.Money.Satoshis(1000)), // 1 sat/vB - realistic fee rate
             _ => { return GetRandomDataWitScript(3); },
             (_, s) => { return GetRandomDataWitScript(3); }
@@ -70,7 +71,7 @@ public class SpendingTransactionBuilderTest : AngorTestData
             projectInfo,
             1,
             changeAddress.ScriptPubKey.WitHash.GetAddress(Networks.Bitcoin.Testnet()).ToString(),
-            Encoders.Hex.EncodeData(new Key().ToBytes()),
+            AngorKey.From(new Key()),
             new NBitcoin.FeeRate(NBitcoin.Money.Satoshis(1000)), // 1 sat/vB - realistic fee rate
             _ => { return expectedWitSigWithFakeSig; },
             (_, s) =>
@@ -115,7 +116,7 @@ public class SpendingTransactionBuilderTest : AngorTestData
             projectInfo,
             1,
             changeAddress.ScriptPubKey.WitHash.GetAddress(Networks.Bitcoin.Testnet()).ToString(),
-            Encoders.Hex.EncodeData(new Key().ToBytes()),
+            AngorKey.From(new Key()),
             new NBitcoin.FeeRate(NBitcoin.Money.Satoshis(1000)), // 1 sat/vB - realistic fee rate
             _ =>
             {

--- a/src/shared/Angor.Shared.Tests/PsbtOperationsTests.cs
+++ b/src/shared/Angor.Shared.Tests/PsbtOperationsTests.cs
@@ -177,12 +177,12 @@ public class PsbtOperationsTests : AngorTestData
         Assert.Equal(signedInvestmentTransaction.Transaction.GetHash(), strippedInvestmentTransaction.GetHash());
 
         var unsignedRecoveryTransaction = _investorTransactionActions.BuildRecoverInvestorFundsTransaction(projectInfo, strippedInvestmentTransaction);
-        var recoverySigs = _founderTransactionActions.SignInvestorRecoveryTransactions(projectInfo, strippedInvestmentTransaction.ToHex(), unsignedRecoveryTransaction, Encoders.Hex.EncodeData(founderRecoveryPrivateKey.ToBytes()));
+        var recoverySigs = _founderTransactionActions.SignInvestorRecoveryTransactions(projectInfo, strippedInvestmentTransaction.ToHex(), unsignedRecoveryTransaction, founderRecoveryPrivateKey);
 
         var sigCheckResult = _investorTransactionActions.CheckInvestorRecoverySignatures(projectInfo, signedInvestmentTransaction.Transaction, recoverySigs);
         Assert.True(sigCheckResult, "failed to validate the founders signatures");
 
-        var recoveryTransaction = _investorTransactionActions.AddSignaturesToRecoverSeederFundsTransaction(projectInfo, signedInvestmentTransaction.Transaction, recoverySigs, Encoders.Hex.EncodeData(investorPrivateKey.ToBytes()));
+        var recoveryTransaction = _investorTransactionActions.AddSignaturesToRecoverSeederFundsTransaction(projectInfo, signedInvestmentTransaction.Transaction, recoverySigs, investorPrivateKey);
 
         // remove the first stage to simulate that is was spent
         recoveryTransaction.Outputs.RemoveAt(0);

--- a/src/shared/Angor.Shared.Tests/WalletOperationsTest.cs
+++ b/src/shared/Angor.Shared.Tests/WalletOperationsTest.cs
@@ -187,12 +187,12 @@ public class WalletOperationsTest : AngorTestData
         Assert.Equal(signedInvestmentTransaction.Transaction.GetHash(), strippedInvestmentTransaction.GetHash());
 
         var unsignedRecoveryTransaction = _investorTransactionActions.BuildRecoverInvestorFundsTransaction(projectInfo, strippedInvestmentTransaction);
-        var recoverySigs = _founderTransactionActions.SignInvestorRecoveryTransactions(projectInfo, strippedInvestmentTransaction.ToHex(), unsignedRecoveryTransaction, Encoders.Hex.EncodeData(founderRecoveryPrivateKey.ToBytes()));
+        var recoverySigs = _founderTransactionActions.SignInvestorRecoveryTransactions(projectInfo, strippedInvestmentTransaction.ToHex(), unsignedRecoveryTransaction, founderRecoveryPrivateKey);
 
         var sigCheckResult  = _investorTransactionActions.CheckInvestorRecoverySignatures(projectInfo, signedInvestmentTransaction.Transaction, recoverySigs);
         Assert.True(sigCheckResult, "failed to validate the founders signatures");
 
-        var recoveryTransaction = _investorTransactionActions.AddSignaturesToRecoverSeederFundsTransaction(projectInfo, signedInvestmentTransaction.Transaction, recoverySigs, Encoders.Hex.EncodeData(investorPrivateKey.ToBytes()));
+        var recoveryTransaction = _investorTransactionActions.AddSignaturesToRecoverSeederFundsTransaction(projectInfo, signedInvestmentTransaction.Transaction, recoverySigs, investorPrivateKey);
 
         // remove the first stage to simulate that is was spent
         recoveryTransaction.Outputs.RemoveAt(0);

--- a/src/shared/Angor.Shared/AngorKey.cs
+++ b/src/shared/Angor.Shared/AngorKey.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+using Blockcore.NBitcoin;
+using Blockcore.NBitcoin.DataEncoders;
+using BlockcoreKey = Blockcore.NBitcoin.Key;
+
+namespace Angor.Shared;
+
+/// <summary>
+/// Strongly-typed private key that inherits from NBitcoin.Key.
+/// Replaces raw hex-string passing across protocol signing APIs,
+/// preventing private key material from lingering as interned strings
+/// on the managed heap. Dispose when done to zero backing memory.
+/// </summary>
+public class AngorKey : NBitcoin.Key
+{
+    public AngorKey() : base() { }
+
+    public AngorKey(byte[] data, int count = -1, bool fCompressedIn = true)
+        : base(data, count, fCompressedIn) { }
+
+    /// <summary>
+    /// Creates an AngorKey from a hex-encoded private key string.
+    /// The intermediate byte array is zeroed immediately after construction.
+    /// </summary>
+    public static AngorKey FromHex(string hex)
+    {
+        var bytes = Encoders.Hex.DecodeData(hex);
+        try
+        {
+            return new AngorKey(bytes);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(bytes);
+        }
+    }
+
+    /// <summary>
+    /// Bridge factory: converts a Blockcore.NBitcoin.Key to AngorKey.
+    /// Temporary shim until the Blockcore dependency is removed.
+    /// </summary>
+    public static AngorKey From(BlockcoreKey blockcoreKey)
+    {
+        var bytes = blockcoreKey.ToBytes();
+        try
+        {
+            return new AngorKey(bytes);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(bytes);
+        }
+    }
+}

--- a/src/shared/Angor.Shared/DerivationOperations.cs
+++ b/src/shared/Angor.Shared/DerivationOperations.cs
@@ -26,10 +26,9 @@ public class DerivationOperations : IDerivationOperations
     
     private ExtKey GetExtendedKey(WalletWords walletWords)
     {
-        ExtKey extendedKey;
         try
         {
-            extendedKey = _hdOperations.GetExtendedKey(walletWords.Words, walletWords.Passphrase);
+            return walletWords.GetOrDeriveExtKey(_hdOperations);
         }
         catch (NotSupportedException ex)
         {
@@ -40,8 +39,6 @@ public class DerivationOperations : IDerivationOperations
 
             throw;
         }
-
-        return extendedKey;
     }
 
     public FounderKeyCollection DeriveProjectKeys(WalletWords walletWords, string angorTestKey)
@@ -112,7 +109,7 @@ public class DerivationOperations : IDerivationOperations
         return extPubKey.PubKey.ToHex();
     }
 
-    public Key DeriveInvestorPrivateKey(WalletWords walletWords, string founderKey)
+    public AngorKey DeriveInvestorPrivateKey(WalletWords walletWords, string founderKey)
     {
         ExtKey extendedKey = GetExtendedKey(walletWords);
 
@@ -124,7 +121,7 @@ public class DerivationOperations : IDerivationOperations
 
         ExtKey extKey = extendedKey.Derive(new KeyPath(path));
 
-        return extKey.PrivateKey;
+        return AngorKey.From(extKey.PrivateKey);
     }
 
     public string DeriveFounderKey(WalletWords walletWords, int index)
@@ -164,7 +161,7 @@ public class DerivationOperations : IDerivationOperations
         return extPubKey.PubKey.ToHex();
     }
 
-    public Key DeriveFounderPrivateKey(WalletWords walletWords, int index)
+    public AngorKey DeriveFounderPrivateKey(WalletWords walletWords, int index)
     {
         ExtKey extendedKey = GetExtendedKey(walletWords);
 
@@ -172,26 +169,12 @@ public class DerivationOperations : IDerivationOperations
 
         ExtKey extKey = extendedKey.Derive(new KeyPath(path));
 
-        return extKey.PrivateKey;
+        return AngorKey.From(extKey.PrivateKey);
     }
 
-    public Key DeriveFounderRecoveryPrivateKey(WalletWords walletWords, string founderKey)
+    public AngorKey DeriveFounderRecoveryPrivateKey(WalletWords walletWords, string founderKey)
     {
-        ExtKey extendedKey;
-
-        try
-        {
-            extendedKey = _hdOperations.GetExtendedKey(walletWords.Words, walletWords.Passphrase);
-        }
-        catch (NotSupportedException ex)
-        {
-            _logger.LogError("Exception occurred: {0}", ex.ToString());
-
-            if (ex.Message == "Unknown")
-                throw new Exception("Please make sure you enter valid mnemonic words.");
-
-            throw;
-        }
+        ExtKey extendedKey = GetExtendedKey(walletWords);
 
         var upi = this.DeriveUniqueProjectIdentifier(founderKey);
 
@@ -199,10 +182,10 @@ public class DerivationOperations : IDerivationOperations
 
         ExtKey extKey = extendedKey.Derive(new KeyPath(path));
 
-        return extKey.PrivateKey;
+        return AngorKey.From(extKey.PrivateKey);
     }
 
-    public Key DeriveProjectNostrPrivateKey(WalletWords walletWords, string founderKey)
+    public AngorKey DeriveProjectNostrPrivateKey(WalletWords walletWords, string founderKey)
     {
         ExtKey extendedKey = GetExtendedKey(walletWords);
 
@@ -212,10 +195,10 @@ public class DerivationOperations : IDerivationOperations
 
         ExtKey extKey = extendedKey.Derive(new KeyPath(path));
 
-        return extKey.PrivateKey;
+        return AngorKey.From(extKey.PrivateKey);
     }
     
-    public async Task<Key> DeriveProjectNostrPrivateKeyAsync(WalletWords walletWords, string founderKey)
+    public async Task<AngorKey> DeriveProjectNostrPrivateKeyAsync(WalletWords walletWords, string founderKey)
     {
         ExtKey extendedKey = GetExtendedKey(walletWords);
        
@@ -225,7 +208,7 @@ public class DerivationOperations : IDerivationOperations
 
         var extKey = await Task.Run(() => extendedKey.Derive(new KeyPath(path)));
         
-        return extKey.PrivateKey;
+        return AngorKey.From(extKey.PrivateKey);
     }
 
     public uint DeriveUniqueProjectIdentifier(string founderKey)
@@ -254,7 +237,7 @@ public class DerivationOperations : IDerivationOperations
         return key.PubKey.ToHex()[2..]; //Need the pub key without prefix
     }
 
-    public Key DeriveNostrStorageKey(WalletWords walletWords)
+    public AngorKey DeriveNostrStorageKey(WalletWords walletWords)
     {
         ExtKey extendedKey = GetExtendedKey(walletWords);
 
@@ -263,7 +246,7 @@ public class DerivationOperations : IDerivationOperations
 
         ExtKey extKey = extendedKey.Derive(new KeyPath(path));
 
-        return extKey.PrivateKey;
+        return AngorKey.From(extKey.PrivateKey);
     }
 
     /// <summary>
@@ -282,12 +265,12 @@ public class DerivationOperations : IDerivationOperations
         };
     }
 
-    public Key DeriveSupportDmKey(WalletWords walletWords)
+    public AngorKey DeriveSupportDmKey(WalletWords walletWords)
     {
         ExtKey extendedKey = GetExtendedKey(walletWords);
         var networkIndex = GetNetworkStorageIndex();
         var path = $"m/44'/1237'/2'/{networkIndex}/0";
-        return extendedKey.Derive(new KeyPath(path)).PrivateKey;
+        return AngorKey.From(extendedKey.Derive(new KeyPath(path)).PrivateKey);
     }
 
     public string DeriveSupportDmPubKeyHex(WalletWords walletWords)

--- a/src/shared/Angor.Shared/HdOperations.cs
+++ b/src/shared/Angor.Shared/HdOperations.cs
@@ -16,7 +16,9 @@ public interface IHdOperations
     PubKey GeneratePublicKey(ExtPubKey accountExtPubKey, int index, bool isChange);
     string CreateHdPath(int purpose, int coinType, int accountIndex, bool isChange, int addressIndex);
     string DerivePublicKey(string mnemonic, string? passphrase, string hdPath);
-    string DerivePrivateKey(string mnemonic, string? passphrase, string hdPath);
+    AngorKey DerivePrivateKey(string mnemonic, string? passphrase, string hdPath);
+    string DerivePublicKey(ExtKey extKey, string hdPath);
+    AngorKey DerivePrivateKey(ExtKey extKey, string hdPath);
 }
 
 public class HdOperations : IHdOperations
@@ -290,13 +292,25 @@ public class HdOperations : IHdOperations
             return derivedKey.PrivateKey.PubKey.ToHex();
         }
 
-        public string DerivePrivateKey(string mnemonic, string? passphrase, string hdPath)
+        public AngorKey DerivePrivateKey(string mnemonic, string? passphrase, string hdPath)
         {
             ExtKey.UseBCForHMACSHA512 = true;
             Blockcore.NBitcoin.Crypto.Hashes.UseBCForHMACSHA512 = true;
 
             var extendedKey = GetExtendedKey(mnemonic, passphrase);
             var derivedKey = extendedKey.Derive(new KeyPath(hdPath));
-            return Blockcore.NBitcoin.DataEncoders.Encoders.Hex.EncodeData(derivedKey.PrivateKey.ToBytes());
+            return AngorKey.From(derivedKey.PrivateKey);
+        }
+
+        public string DerivePublicKey(ExtKey extKey, string hdPath)
+        {
+            var derivedKey = extKey.Derive(new KeyPath(hdPath));
+            return derivedKey.PrivateKey.PubKey.ToHex();
+        }
+
+        public AngorKey DerivePrivateKey(ExtKey extKey, string hdPath)
+        {
+            var derivedKey = extKey.Derive(new KeyPath(hdPath));
+            return AngorKey.From(derivedKey.PrivateKey);
         }
     }

--- a/src/shared/Angor.Shared/IDerivationOperations.cs
+++ b/src/shared/Angor.Shared/IDerivationOperations.cs
@@ -1,6 +1,5 @@
 using Angor.Shared.Models;
 using Blockcore.Consensus.ScriptInfo;
-using Blockcore.NBitcoin;
 
 namespace Angor.Shared;
 
@@ -14,17 +13,17 @@ public interface IDerivationOperations
     string DeriveAngorKey(string angorRootKey, string founderKey);
     Script AngorKeyToScript(string angorKey);
     string DeriveInvestorKey(WalletWords walletWords, string founderKey);
-    Key DeriveInvestorPrivateKey(WalletWords walletWords, string founderKey);
+    AngorKey DeriveInvestorPrivateKey(WalletWords walletWords, string founderKey);
     string DeriveLeadInvestorSecretHash(WalletWords walletWords, string founderKey);
-    Key DeriveFounderPrivateKey(WalletWords walletWords, int index);
-    Key DeriveFounderRecoveryPrivateKey(WalletWords walletWords, string founderKey);
-    Key DeriveProjectNostrPrivateKey(WalletWords walletWords, string founderKey);
+    AngorKey DeriveFounderPrivateKey(WalletWords walletWords, int index);
+    AngorKey DeriveFounderRecoveryPrivateKey(WalletWords walletWords, string founderKey);
+    AngorKey DeriveProjectNostrPrivateKey(WalletWords walletWords, string founderKey);
     string DeriveNostrPubKey(WalletWords walletWords, string founderKey);
-    Task<Key> DeriveProjectNostrPrivateKeyAsync(WalletWords walletWords, string founderKey);
+    Task<AngorKey> DeriveProjectNostrPrivateKeyAsync(WalletWords walletWords, string founderKey);
     string DeriveNostrStoragePassword(WalletWords walletWords);
-    Key DeriveNostrStorageKey(WalletWords walletWords);
+    AngorKey DeriveNostrStorageKey(WalletWords walletWords);
     string DeriveNostrStoragePubKeyHex(WalletWords walletWords);
     string ConvertAngorKeyToBitcoinAddress(string projectId);
-    Key DeriveSupportDmKey(WalletWords walletWords);
+    AngorKey DeriveSupportDmKey(WalletWords walletWords);
     string DeriveSupportDmPubKeyHex(WalletWords walletWords);
 }

--- a/src/shared/Angor.Shared/IWalletOperations.cs
+++ b/src/shared/Angor.Shared/IWalletOperations.cs
@@ -31,6 +31,6 @@ public interface IWalletOperations
     /// <summary>Derive the compressed public key hex for a given HD path from wallet words.</summary>
     string DerivePublicKey(WalletWords walletWords, string hdPath);
 
-    /// <summary>Derive the private key hex for a given HD path from wallet words.</summary>
-    string DerivePrivateKey(WalletWords walletWords, string hdPath);
+    /// <summary>Derive the private key for a given HD path from wallet words.</summary>
+    AngorKey DerivePrivateKey(WalletWords walletWords, string hdPath);
 }

--- a/src/shared/Angor.Shared/Integration/Lightning/BoltzClaimService.cs
+++ b/src/shared/Angor.Shared/Integration/Lightning/BoltzClaimService.cs
@@ -33,7 +33,7 @@ public class BoltzClaimService : IBoltzClaimService
     /// <inheritdoc />
     public async Task<Result<BoltzClaimResult>> ClaimSwapAsync(
         BoltzSubmarineSwap swap,
-        string claimPrivateKeyHex,
+        AngorKey claimPrivateKey,
         string lockupTransactionHex,
         int lockupOutputIndex = 0,
         long feeRate = 2)
@@ -69,7 +69,7 @@ public class BoltzClaimService : IBoltzClaimService
             try
             {
                 var cooperativeResult = await CooperativeMusig2Claim(
-                    swap, claimPrivateKeyHex, lockupTransactionHex, lockupOutputIndex, feeRate, preimageBytes);
+                    swap, claimPrivateKey, lockupTransactionHex, lockupOutputIndex, feeRate, preimageBytes);
                 
                 if (cooperativeResult.IsSuccess)
                 {
@@ -91,7 +91,7 @@ public class BoltzClaimService : IBoltzClaimService
             _logger.LogInformation("Proceeding with manual claim transaction (Taproot script path spend)...");
             
             var scriptPathResult = await BuildAndBroadcastClaimTransaction(
-                swap, claimPrivateKeyHex, lockupTransactionHex, lockupOutputIndex, feeRate, preimageBytes);
+                swap, claimPrivateKey, lockupTransactionHex, lockupOutputIndex, feeRate, preimageBytes);
             
             if (scriptPathResult.IsFailure && cooperativeError != null)
             {
@@ -113,7 +113,7 @@ public class BoltzClaimService : IBoltzClaimService
     /// </summary>
     private async Task<Result<BoltzClaimResult>> CooperativeMusig2Claim(
         BoltzSubmarineSwap swap,
-        string claimPrivateKeyHex,
+        AngorKey claimPrivateKey,
         string lockupTransactionHex,
         int lockupOutputIndex,
         long feeRate,
@@ -158,7 +158,7 @@ public class BoltzClaimService : IBoltzClaimService
         var lockupOutpoint = new NBitcoin.OutPoint(lockupTx.GetHash(), foundOutputIndex);
         
         // Initialize MuSig2 session
-        var claimPrivateKeyBytes = Convert.FromHexString(claimPrivateKeyHex);
+        var claimPrivateKeyBytes = claimPrivateKey.ToBytes();
         var boltzRefundKeyBytes = Convert.FromHexString(swap.RefundPublicKey);
         
         // Verify the derived claim key matches what was registered with Boltz
@@ -339,7 +339,7 @@ public class BoltzClaimService : IBoltzClaimService
     /// </summary>
     private async Task<Result<BoltzClaimResult>> BuildAndBroadcastClaimTransaction(
         BoltzSubmarineSwap swap,
-        string claimPrivateKeyHex,
+        AngorKey claimPrivateKey,
         string lockupTransactionHex,
         int lockupOutputIndex,
         long feeRate,
@@ -363,7 +363,7 @@ public class BoltzClaimService : IBoltzClaimService
                 }
             }
 
-            if (string.IsNullOrEmpty(claimPrivateKeyHex))
+            if (claimPrivateKey == null)
             {
                 return Result.Failure<BoltzClaimResult>("Claim private key is required");
             }
@@ -435,7 +435,7 @@ public class BoltzClaimService : IBoltzClaimService
             var claimTx = BuildClaimTransaction(lockupOutpoint, lockupOutput, swap.Address, feeRate, network);
 
             // Sign the transaction
-            var claimKey = new NBitcoin.Key(Convert.FromHexString(claimPrivateKeyHex));
+            var claimKey = claimPrivateKey;
             var tapScript = claimScript.ToTapScript(NBitcoin.TapLeafVersion.C0);
             var leafHash = tapScript.LeafHash;
 

--- a/src/shared/Angor.Shared/Integration/Lightning/IBoltzClaimService.cs
+++ b/src/shared/Angor.Shared/Integration/Lightning/IBoltzClaimService.cs
@@ -15,7 +15,7 @@ public interface IBoltzClaimService
     /// </summary>
     Task<Result<BoltzClaimResult>> ClaimSwapAsync(
         BoltzSubmarineSwap swap,
-        string claimPrivateKeyHex,
+        AngorKey claimPrivateKey,
         string lockupTransactionHex,
         int lockupOutputIndex = 0,
         long feeRate = 2);

--- a/src/shared/Angor.Shared/Models/WalletWords.cs
+++ b/src/shared/Angor.Shared/Models/WalletWords.cs
@@ -1,11 +1,66 @@
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using Blockcore.NBitcoin.BIP32;
 
 namespace Angor.Shared.Models;
 
-public class WalletWords
+/// <summary>
+/// Holds BIP-39 mnemonic words and optional passphrase.
+/// Backed by char[] so the raw material can be zeroed on disposal.
+/// Caches the derived ExtKey to avoid repeated PBKDF2 derivations.
+/// </summary>
+public class WalletWords : IDisposable
 {
-    public string Words { get; set; }
-    public string? Passphrase { get; set; }
+    private char[] wordsChars = Array.Empty<char>();
+    private char[]? passphraseChars;
+    private ExtKey? cachedExtKey;
+    private bool disposed;
+
+    /// <summary>The BIP-39 mnemonic words (space-separated).</summary>
+    public string Words
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            return new string(wordsChars);
+        }
+        set => wordsChars = value?.ToCharArray() ?? Array.Empty<char>();
+    }
+
+    /// <summary>Optional BIP-39 passphrase.</summary>
+    public string? Passphrase
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            return passphraseChars != null ? new string(passphraseChars) : null;
+        }
+        set => passphraseChars = value?.ToCharArray();
+    }
+
+    /// <summary>
+    /// Gets or derives the master extended key, caching it for subsequent calls.
+    /// Avoids repeated PBKDF2 derivation from the mnemonic on every signing operation.
+    /// </summary>
+    [JsonIgnore]
+    public ExtKey? CachedExtKey => cachedExtKey;
+
+    /// <summary>
+    /// Derives and caches the master ExtKey from the mnemonic.
+    /// Subsequent calls return the cached key without touching the mnemonic.
+    /// </summary>
+    public ExtKey GetOrDeriveExtKey(IHdOperations hdOperations)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        if (cachedExtKey != null)
+            return cachedExtKey;
+
+        cachedExtKey = hdOperations.GetExtendedKey(Words, Passphrase);
+        return cachedExtKey;
+    }
 
     public string ConvertToString()
     {
@@ -18,5 +73,18 @@ public class WalletWords
             throw new InvalidOperationException();
 
         return JsonSerializer.Deserialize<WalletWords>(data) ?? throw new InvalidOperationException();
+    }
+
+    public void Dispose()
+    {
+        if (disposed) return;
+        disposed = true;
+
+        CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(wordsChars.AsSpan()));
+
+        if (passphraseChars != null)
+            CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(passphraseChars.AsSpan()));
+
+        cachedExtKey = null;
     }
 }

--- a/src/shared/Angor.Shared/Models/WalletWords.cs
+++ b/src/shared/Angor.Shared/Models/WalletWords.cs
@@ -26,7 +26,12 @@ public class WalletWords : IDisposable
             ObjectDisposedException.ThrowIf(disposed, this);
             return new string(wordsChars);
         }
-        set => wordsChars = value?.ToCharArray() ?? Array.Empty<char>();
+        set
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            ArgumentNullException.ThrowIfNull(value);
+            wordsChars = value.ToCharArray();
+        }
     }
 
     /// <summary>Optional BIP-39 passphrase.</summary>

--- a/src/shared/Angor.Shared/Protocol/FounderTransactionActions.cs
+++ b/src/shared/Angor.Shared/Protocol/FounderTransactionActions.cs
@@ -37,14 +37,14 @@ public class FounderTransactionActions : IFounderTransactionActions
     }
 
     public SignatureInfo SignInvestorRecoveryTransactions(ProjectInfo projectInfo, string investmentTrxHex,
-        Transaction recoveryTransaction, string founderPrivateKey)
+        Transaction recoveryTransaction, AngorKey founderPrivateKey)
     {
         var network = _networkConfiguration.GetNetwork();
         var nbitcoinNetwork = NetworkMapper.Map(network);
         var nbitcoinRecoveryTransaction = NBitcoin.Transaction.Parse(recoveryTransaction.ToHex(), nbitcoinNetwork);
         var nbitcoinInvestmentTransaction = NBitcoin.Transaction.Parse(investmentTrxHex, nbitcoinNetwork);
 
-        var key = new Key(Encoders.Hex.DecodeData(founderPrivateKey));
+        var key = founderPrivateKey;
         const TaprootSigHash sigHash = TaprootSigHash.Single | TaprootSigHash.AnyoneCanPay;
 
         var fundingParameters = FundingParameters.CreateFromTransaction(projectInfo, network.CreateTransaction(investmentTrxHex));
@@ -84,14 +84,14 @@ public class FounderTransactionActions : IFounderTransactionActions
         return info;
     }
 
-    public TransactionInfo SpendFounderStage(ProjectInfo projectInfo, IEnumerable<string> investmentTransactionsHex, int stageNumber, Script founderRecieveAddress, string founderPrivateKey, FeeEstimation fee)
+    public TransactionInfo SpendFounderStage(ProjectInfo projectInfo, IEnumerable<string> investmentTransactionsHex, int stageNumber, Script founderRecieveAddress, AngorKey founderPrivateKey, FeeEstimation fee)
     {
         // For Invest projects, all transactions use the same stage number
         var stageTransactionInputs = investmentTransactionsHex.Select(trx => new StageTransactionInput(trx, stageNumber)).ToList();
         return SpendFounderStage(projectInfo, stageTransactionInputs, founderRecieveAddress, founderPrivateKey, fee);
     }
 
-    public TransactionInfo SpendFounderStage(ProjectInfo projectInfo, IEnumerable<StageTransactionInput> stageTransactionInput, Script founderRecieveAddress, string founderPrivateKey, FeeEstimation fee)
+    public TransactionInfo SpendFounderStage(ProjectInfo projectInfo, IEnumerable<StageTransactionInput> stageTransactionInput, Script founderRecieveAddress, AngorKey founderPrivateKey, FeeEstimation fee)
     {
         // H4: Reject fee rates below the protocol minimum — a sub-minimum rate
         // indicates a bug in fee estimation or a unit mismatch. FeeRate must be in sat/kB.
@@ -161,7 +161,7 @@ public class FounderTransactionActions : IFounderTransactionActions
         // Step 4 - sign the taproot inputs
         var trxData = spendingTransaction.PrecomputeTransactionData(stageOutputs.Select(_ => _.TxOut).ToArray());
         const TaprootSigHash sigHash = TaprootSigHash.All;
-        var key = new Key(Encoders.Hex.DecodeData(founderPrivateKey));
+        var key = founderPrivateKey;
 
         var inputIndex = 0;
         foreach (var input in spendingTransaction.Inputs)

--- a/src/shared/Angor.Shared/Protocol/IFounderTransactionActions.cs
+++ b/src/shared/Angor.Shared/Protocol/IFounderTransactionActions.cs
@@ -6,11 +6,11 @@ namespace Angor.Shared.Protocol;
 
 public interface IFounderTransactionActions
 {
-    SignatureInfo SignInvestorRecoveryTransactions(ProjectInfo projectInfo, string investmentTrxHex, Transaction recoveryTransaction, string founderPrivateKey);
+    SignatureInfo SignInvestorRecoveryTransactions(ProjectInfo projectInfo, string investmentTrxHex, Transaction recoveryTransaction, AngorKey founderPrivateKey);
 
-    TransactionInfo SpendFounderStage(ProjectInfo projectInfo, IEnumerable<string> investmentTransactionsHex, int stageNumber, Script founderRecieveAddress, string founderPrivateKey, FeeEstimation fee);
+    TransactionInfo SpendFounderStage(ProjectInfo projectInfo, IEnumerable<string> investmentTransactionsHex, int stageNumber, Script founderRecieveAddress, AngorKey founderPrivateKey, FeeEstimation fee);
 
-    TransactionInfo SpendFounderStage(ProjectInfo projectInfo, IEnumerable<StageTransactionInput> stageTransactionInput, Script founderRecieveAddress, string founderPrivateKey, FeeEstimation fee);
+    TransactionInfo SpendFounderStage(ProjectInfo projectInfo, IEnumerable<StageTransactionInput> stageTransactionInput, Script founderRecieveAddress, AngorKey founderPrivateKey, FeeEstimation fee);
 
     Transaction CreateNewProjectTransaction(string founderKey, Script angorKey, long angorFeeSatoshis, short keyType, string nostrEventId);
 }

--- a/src/shared/Angor.Shared/Protocol/IInvestorTransactionActions.cs
+++ b/src/shared/Angor.Shared/Protocol/IInvestorTransactionActions.cs
@@ -15,15 +15,15 @@ public interface IInvestorTransactionActions
 
     Transaction BuildUnfundedReleaseInvestorFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, string investorReleaseKey);
 
-    TransactionInfo BuildAndSignRecoverReleaseFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, Transaction recoveryTransaction, string investorReceiveAddress, FeeEstimation feeEstimation, string investorPrivateKey);
+    TransactionInfo BuildAndSignRecoverReleaseFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, Transaction recoveryTransaction, string investorReceiveAddress, FeeEstimation feeEstimation, AngorKey investorPrivateKey);
 
-    TransactionInfo RecoverEndOfProjectFunds(string transactionHex, ProjectInfo projectInfo, int startStageNumber, string investorReceiveAddress, string investorPrivateKey, FeeEstimation feeEstimation);
+    TransactionInfo RecoverEndOfProjectFunds(string transactionHex, ProjectInfo projectInfo, int startStageNumber, string investorReceiveAddress, AngorKey investorPrivateKey, FeeEstimation feeEstimation);
 
-    TransactionInfo RecoverRemainingFundsWithOutPenalty(string transactionHex, ProjectInfo projectInfo, int startStageNumber, string investorReceiveAddress, string investorPrivateKey, FeeEstimation feeEstimation, IEnumerable<byte[]> seederSecrets);
+    TransactionInfo RecoverRemainingFundsWithOutPenalty(string transactionHex, ProjectInfo projectInfo, int startStageNumber, string investorReceiveAddress, AngorKey investorPrivateKey, FeeEstimation feeEstimation, IEnumerable<byte[]> seederSecrets);
 
-    Transaction AddSignaturesToRecoverSeederFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, SignatureInfo founderSignatures, string investorPrivateKey);
+    Transaction AddSignaturesToRecoverSeederFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, SignatureInfo founderSignatures, AngorKey investorPrivateKey);
 
-    Transaction AddSignaturesToUnfundedReleaseFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, SignatureInfo founderSignatures, string investorPrivateKey, string investorReleaseKey);
+    Transaction AddSignaturesToUnfundedReleaseFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, SignatureInfo founderSignatures, AngorKey investorPrivateKey, string investorReleaseKey);
 
     bool CheckInvestorRecoverySignatures(ProjectInfo projectInfo, Transaction investmentTransaction, SignatureInfo founderSignatures);
 

--- a/src/shared/Angor.Shared/Protocol/ISeederTransactionActions.cs
+++ b/src/shared/Angor.Shared/Protocol/ISeederTransactionActions.cs
@@ -11,8 +11,8 @@ public interface ISeederTransactionActions
     [Obsolete("Use CreateInvestmentTransaction(ProjectInfo projectInfo, FundingParameters parameters) instead")]
     Transaction CreateInvestmentTransaction(ProjectInfo projectInfo, string investorKey, uint256 investorSecretHash, long totalInvestmentAmount);
     Transaction BuildRecoverSeederFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, int penaltyDays, string investorKey);
-    TransactionInfo RecoverEndOfProjectFunds(string investmentTransactionHex, ProjectInfo projectInfo, int stageIndex, string investorReceiveAddress, string investorPrivateKey, FeeEstimation feeEstimation);
+    TransactionInfo RecoverEndOfProjectFunds(string investmentTransactionHex, ProjectInfo projectInfo, int stageIndex, string investorReceiveAddress, AngorKey investorPrivateKey, FeeEstimation feeEstimation);
 
     Transaction AddSignaturesToRecoverSeederFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction,
-        string receiveAddress, SignatureInfo founderSignatures, string privateKey, string? secret);
+        string receiveAddress, SignatureInfo founderSignatures, AngorKey privateKey, string? secret);
 }

--- a/src/shared/Angor.Shared/Protocol/InvestorTransactionActions.cs
+++ b/src/shared/Angor.Shared/Protocol/InvestorTransactionActions.cs
@@ -96,7 +96,7 @@ public class InvestorTransactionActions : IInvestorTransactionActions
     }
 
     public TransactionInfo BuildAndSignRecoverReleaseFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction,
-        Transaction recoveryTransaction, string investorReceiveAddress, FeeEstimation feeEstimation, string investorPrivateKey)
+        Transaction recoveryTransaction, string investorReceiveAddress, FeeEstimation feeEstimation, AngorKey investorPrivateKey)
     {
         // H4: Reject fee rates below the protocol minimum — FeeRate must be in sat/kB.
         if (feeEstimation.FeeRate < ProtocolConstants.MinFeeRateSatsPerKb)
@@ -141,7 +141,8 @@ public class InvestorTransactionActions : IInvestorTransactionActions
         transaction.Outputs[0].Value -= new Blockcore.NBitcoin.Money(fee);
 
         // sign the inputs (replace fake WitScript with real one)
-        var key = new Key(Encoders.Hex.DecodeData(investorPrivateKey));
+        // Convert AngorKey (NBitcoin.Key) to Blockcore Key for P2WSH signing
+        var key = new Key(investorPrivateKey.ToBytes());
 
         foreach (var intput in transaction.Inputs)
         {
@@ -160,7 +161,7 @@ public class InvestorTransactionActions : IInvestorTransactionActions
     }
 
     public TransactionInfo RecoverEndOfProjectFunds(string transactionHex, ProjectInfo projectInfo, int startStageNumber,
-        string investorReceiveAddress, string investorPrivateKey, FeeEstimation feeEstimation)
+        string investorReceiveAddress, AngorKey investorPrivateKey, FeeEstimation feeEstimation)
     {
         // H4: Reject fee rates below the protocol minimum
         if (feeEstimation.FeeRate < ProtocolConstants.MinFeeRateSatsPerKb)
@@ -188,7 +189,7 @@ public class InvestorTransactionActions : IInvestorTransactionActions
     }
 
     public TransactionInfo RecoverRemainingFundsWithOutPenalty(string transactionHex, ProjectInfo projectInfo, int startStageNumber,
-        string investorReceiveAddress, string investorPrivateKey, FeeEstimation feeEstimation,
+        string investorReceiveAddress, AngorKey investorPrivateKey, FeeEstimation feeEstimation,
         IEnumerable<byte[]> seederSecrets)
     {
         // H4: Reject fee rates below the protocol minimum
@@ -249,7 +250,7 @@ public class InvestorTransactionActions : IInvestorTransactionActions
             });
     }
 
-    public Transaction AddSignaturesToRecoverSeederFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, SignatureInfo founderSignatures, string investorPrivateKey)
+    public Transaction AddSignaturesToRecoverSeederFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, SignatureInfo founderSignatures, AngorKey investorPrivateKey)
     {
         var (investorKey, secretHash) = _projectScriptsBuilder.GetInvestmentDataFromOpReturnScript(investmentTransaction.Outputs.First(_ => _.ScriptPubKey.IsUnspendable).ScriptPubKey);
 
@@ -260,7 +261,7 @@ public class InvestorTransactionActions : IInvestorTransactionActions
         return recoverTransaction;
     }
 
-    public Transaction AddSignaturesToUnfundedReleaseFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, SignatureInfo founderSignatures, string investorPrivateKey, string investorReleaseKey)
+    public Transaction AddSignaturesToUnfundedReleaseFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, SignatureInfo founderSignatures, AngorKey investorPrivateKey, string investorReleaseKey)
     {
         var unsignedUnfundedReleaseTransaction = _investmentTransactionBuilder.BuildUpfrontUnfundedReleaseFundsTransaction(projectInfo, investmentTransaction, investorReleaseKey);
 
@@ -300,7 +301,7 @@ public class InvestorTransactionActions : IInvestorTransactionActions
         return PenaltyThresholdHelper.GetExpiryDateOverride(projectInfo, investmentAmount);
     }
 
-    private Transaction AddSignaturesToRecoveryPathTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, Transaction recoveryTransaction, SignatureInfo founderSignatures, string investorPrivateKey)
+    private Transaction AddSignaturesToRecoveryPathTransaction(ProjectInfo projectInfo, Transaction investmentTransaction, Transaction recoveryTransaction, SignatureInfo founderSignatures, AngorKey investorPrivateKey)
     {
         // Verify founder signatures before incorporating them
         if (!CheckRecoverySignatures(projectInfo, investmentTransaction, recoveryTransaction, founderSignatures))
@@ -312,7 +313,7 @@ public class InvestorTransactionActions : IInvestorTransactionActions
         var nbitcoinRecoveryTransaction = NBitcoin.Transaction.Parse(recoveryTransaction.ToHex(), nbitcoinNetwork);
         var nbitcoinInvestmentTransaction = NBitcoin.Transaction.Parse(investmentTransaction.ToHex(), nbitcoinNetwork);
 
-        var key = new NBitcoin.Key(Encoders.Hex.DecodeData(investorPrivateKey));
+        var key = new NBitcoin.Key(investorPrivateKey.ToBytes());
         var sigHash = TaprootSigHash.Single | TaprootSigHash.AnyoneCanPay;
 
         var fundingParameters = FundingParameters.CreateFromTransaction(projectInfo, investmentTransaction);

--- a/src/shared/Angor.Shared/Protocol/SeederTransactionActions.cs
+++ b/src/shared/Angor.Shared/Protocol/SeederTransactionActions.cs
@@ -60,7 +60,7 @@ public class SeederTransactionActions : ISeederTransactionActions
     }
 
     public Transaction AddSignaturesToRecoverSeederFundsTransaction(ProjectInfo projectInfo, Transaction investmentTransaction,
-        string receiveAddress, SignatureInfo founderSignatures, string privateKey, string? secret)
+        string receiveAddress, SignatureInfo founderSignatures, AngorKey privateKey, string? secret)
     {
         var recoveryTransaction = _investmentTransactionBuilder.BuildUpfrontRecoverFundsTransaction(projectInfo, investmentTransaction, projectInfo.PenaltyDays, receiveAddress);
 
@@ -77,7 +77,7 @@ public class SeederTransactionActions : ISeederTransactionActions
             .Select(_ => _.TxOut)
             .ToArray();
 
-        var key = new Key(Encoders.Hex.DecodeData(privateKey));
+        var key = new Key(privateKey.ToBytes());
         var sigHash = TaprootSigHash.Single | TaprootSigHash.AnyoneCanPay;
 
         for (var stageIndex = 0; stageIndex < projectInfo.Stages.Count; stageIndex++)
@@ -106,7 +106,7 @@ public class SeederTransactionActions : ISeederTransactionActions
     }
 
     public TransactionInfo RecoverEndOfProjectFunds(string investmentTransactionHex, ProjectInfo projectInfo, int stageIndex, string investorReceiveAddress,
-        string investorPrivateKey, FeeEstimation feeEstimation)
+        AngorKey investorPrivateKey, FeeEstimation feeEstimation)
     {
         // H4: Reject fee rates below the protocol minimum
         if (feeEstimation.FeeRate < ProtocolConstants.MinFeeRateSatsPerKb)

--- a/src/shared/Angor.Shared/Protocol/TransactionBuilders/ISpendingTransactionBuilder.cs
+++ b/src/shared/Angor.Shared/Protocol/TransactionBuilders/ISpendingTransactionBuilder.cs
@@ -6,7 +6,7 @@ namespace Angor.Shared.Protocol.TransactionBuilders;
 public interface ISpendingTransactionBuilder
 {
     TransactionInfo BuildRecoverInvestorRemainingFundsInProject(string investmentTransactionHex, ProjectInfo projectInfo, int startStageIndex,
-        string receiveAddress, string privateKey, FeeRate feeRate,
+        string receiveAddress, AngorKey privateKey, FeeRate feeRate,
         Func<ProjectScripts, WitScript> buildWitScriptWithSigPlaceholder,
         Func<WitScript, TaprootSignature, WitScript> addSignatureToWitScript);
 }

--- a/src/shared/Angor.Shared/Protocol/TransactionBuilders/SpendingTransactionBuilder.cs
+++ b/src/shared/Angor.Shared/Protocol/TransactionBuilders/SpendingTransactionBuilder.cs
@@ -21,7 +21,7 @@ public class SpendingTransactionBuilder : ISpendingTransactionBuilder
     }
 
     public TransactionInfo BuildRecoverInvestorRemainingFundsInProject(string investmentTransactionHex, ProjectInfo projectInfo,
-        int startStageNumber, string receiveAddress, string privateKey, FeeRate feeRate,
+        int startStageNumber, string receiveAddress, AngorKey privateKey, FeeRate feeRate,
         Func<ProjectScripts, WitScript> buildWitScriptWithSigPlaceholder,
         Func<WitScript, TaprootSignature, WitScript> addSignatureToWitScript)
     {
@@ -32,8 +32,8 @@ public class SpendingTransactionBuilder : ISpendingTransactionBuilder
         if (string.IsNullOrWhiteSpace(receiveAddress))
             throw new ArgumentException("Receive address cannot be null or empty.", nameof(receiveAddress));
 
-        if (string.IsNullOrWhiteSpace(privateKey))
-            throw new ArgumentException("Private key cannot be null or empty.", nameof(privateKey));
+        if (privateKey is null)
+            throw new ArgumentNullException(nameof(privateKey), "Private key cannot be null.");
 
         if (startStageNumber < 1)
             throw new ArgumentOutOfRangeException(nameof(startStageNumber), "Stage number must be at least 1.");
@@ -118,7 +118,7 @@ public class SpendingTransactionBuilder : ISpendingTransactionBuilder
 
         // Step 4 - sign the taproot inputs
         var trxData = spendingTrx.PrecomputeTransactionData(investmentTrxOutputs.Select(s => s.TxOut).ToArray());
-        var key = new Key(Encoders.Hex.DecodeData(privateKey));
+        var key = new Key(privateKey.ToBytes());
 
         const TaprootSigHash sigHash = TaprootSigHash.All;
         var inputIndex = 0;

--- a/src/shared/Angor.Shared/WalletOperations.cs
+++ b/src/shared/Angor.Shared/WalletOperations.cs
@@ -412,7 +412,7 @@ public class WalletOperations : IWalletOperations
         ExtKey extendedKey;
         try
         {
-            extendedKey = _hdOperations.GetExtendedKey(walletWords.Words, walletWords.Passphrase); //TODO change this to be the extended key 
+            extendedKey = walletWords.GetOrDeriveExtKey(_hdOperations);
         }
         catch (NotSupportedException ex)
         {
@@ -445,10 +445,10 @@ public class WalletOperations : IWalletOperations
 
 
     public string DerivePublicKey(WalletWords walletWords, string hdPath)
-        => _hdOperations.DerivePublicKey(walletWords.Words, walletWords.Passphrase, hdPath);
+        => _hdOperations.DerivePublicKey(walletWords.GetOrDeriveExtKey(_hdOperations), hdPath);
 
-    public string DerivePrivateKey(WalletWords walletWords, string hdPath)
-        => _hdOperations.DerivePrivateKey(walletWords.Words, walletWords.Passphrase, hdPath);
+    public AngorKey DerivePrivateKey(WalletWords walletWords, string hdPath)
+        => _hdOperations.DerivePrivateKey(walletWords.GetOrDeriveExtKey(_hdOperations), hdPath);
 
     public AccountInfo BuildAccountInfoForWalletWords(WalletWords walletWords)
     {
@@ -461,7 +461,7 @@ public class WalletOperations : IWalletOperations
         ExtKey extendedKey;
         try
         {
-            extendedKey = _hdOperations.GetExtendedKey(walletWords.Words, walletWords.Passphrase);
+            extendedKey = walletWords.GetOrDeriveExtKey(_hdOperations);
         }
         catch (NotSupportedException ex)
         {

--- a/src/webapp/Angor.Client/Pages/CheckTransactionCode.razor
+++ b/src/webapp/Angor.Client/Pages/CheckTransactionCode.razor
@@ -192,7 +192,7 @@ else
 
         recoveryTransaction = SeederTransactionActions.BuildRecoverSeederFundsTransaction(context.ProjectInfo, transactionInfo.Transaction, context.ProjectInfo.PenaltyDays, testAddress.PubKey.ToHex());
 
-        var signatures = FounderTransactionActions.SignInvestorRecoveryTransactions(context.ProjectInfo, context.TransactionHex, recoveryTransaction, Encoders.Hex.EncodeData(privateFounderKey.PrivateKey.ToBytes()));
+        var signatures = FounderTransactionActions.SignInvestorRecoveryTransactions(context.ProjectInfo, context.TransactionHex, recoveryTransaction, AngorKey.From(privateFounderKey.PrivateKey));
 
         var sendInfo = new SendInfo
         {
@@ -205,11 +205,11 @@ else
 
         var fee = await _walletOperations.GetFeeEstimationAsync();
 
-        recoveryTransaction = SeederTransactionActions.AddSignaturesToRecoverSeederFundsTransaction(context.ProjectInfo, transactionInfo.Transaction, testAddress.PubKey.ToHex(), signatures, Encoders.Hex.EncodeData(privateFounderKey.PrivateKey.ToBytes()),
+        recoveryTransaction = SeederTransactionActions.AddSignaturesToRecoverSeederFundsTransaction(context.ProjectInfo, transactionInfo.Transaction, testAddress.PubKey.ToHex(), signatures, AngorKey.From(privateFounderKey.PrivateKey),
             Encoders.Hex.EncodeData(secret.ToBytes()));
 
         var founderTransactionRes = FounderTransactionActions.SpendFounderStage(context.ProjectInfo, new List<string>() { transactionInfo.Transaction.ToHex() }, 1,
-            testAddress.ScriptPubKey , privateFounderKey.PrivateKey.ToHex(network.Consensus.ConsensusFactory), fee.First());
+            testAddress.ScriptPubKey , AngorKey.From(privateFounderKey.PrivateKey), fee.First());
 
         founderTransaction = founderTransactionRes.Transaction;
 

--- a/src/webapp/Angor.Client/Pages/InvestView.razor
+++ b/src/webapp/Angor.Client/Pages/InvestView.razor
@@ -1847,7 +1847,6 @@
                 // Derive claim private key (same path as the public key used at swap creation)
                 var words = await passwordComponent.GetWalletAsync();
                 var claimPrivateKey = _derivationOperations.DeriveInvestorPrivateKey(words, project!.ProjectInfo.FounderKey);
-                var claimPrivateKeyHex = Encoders.Hex.EncodeData(claimPrivateKey.ToBytes());
 
                 _Logger.LogInformation("Claiming swap {SwapId} from lockup {LockupAddress}",
                     lightningSwapId, currentSwap!.LockupAddress);
@@ -1856,7 +1855,7 @@
                 StateHasChanged();
 
                 var claimResult = await _boltzClaimService.ClaimSwapAsync(
-                    currentSwap, claimPrivateKeyHex, lockupTxHex);
+                    currentSwap, claimPrivateKey, lockupTxHex);
 
                 if (claimResult.IsFailure)
                 {

--- a/src/webapp/Angor.Client/Pages/Recover.razor
+++ b/src/webapp/Angor.Client/Pages/Recover.razor
@@ -1,4 +1,4 @@
-﻿@page "/recover/{ProjectIdentifier}"
+@page "/recover/{ProjectIdentifier}"
 
 @using Angor.Shared
 @using Angor.Client.Storage
@@ -897,7 +897,7 @@
 
             var investorPrivateKey = _derivationOperations.DeriveInvestorPrivateKey(words, project.ProjectInfo.FounderKey);
 
-            unsignedRecoveryTransaction = _InvestorTransactionActions.AddSignaturesToRecoverSeederFundsTransaction(project.ProjectInfo, investmentTransaction, project.SignaturesInfo, Encoders.Hex.EncodeData(investorPrivateKey.ToBytes()));
+            unsignedRecoveryTransaction = _InvestorTransactionActions.AddSignaturesToRecoverSeederFundsTransaction(project.ProjectInfo, investmentTransaction, project.SignaturesInfo, investorPrivateKey);
 
             // remove outputs that have been spent
             List<TxOut> removeTxout = new();
@@ -1063,7 +1063,7 @@
             }
 
             releaseRecoveryTransaction = _InvestorTransactionActions.BuildAndSignRecoverReleaseFundsTransaction(project.ProjectInfo, investmentTransaction, recoveryTransaction.Transaction,
-                accountInfo.GetNextChangeReceiveAddress(), feeData.SelectedFeeEstimation, Encoders.Hex.EncodeData(investorPrivateKey.ToBytes()));
+                accountInfo.GetNextChangeReceiveAddress(), feeData.SelectedFeeEstimation, investorPrivateKey);
 
             Logger.LogInformation($"recoveryReleaseTransactionId={releaseRecoveryTransaction.Transaction.GetHash().ToString()}");
 
@@ -1111,7 +1111,7 @@
                 recoveryTransaction.Transaction,
                 accountInfo.GetNextChangeReceiveAddress(),
                 feeData.SelectedFeeEstimation,
-                Encoders.Hex.EncodeData(investorPrivateKey.ToBytes()));
+                investorPrivateKey);
 
             StateHasChanged();
         }
@@ -1200,7 +1200,7 @@
             var fromStage = StageInfo.Items.First(f => f.IsSpent == false);
 
             endOfProjectTransaction = _InvestorTransactionActions.RecoverEndOfProjectFunds(investmentTransaction.ToHex(network.Consensus.ConsensusFactory), project.ProjectInfo, fromStage.StageIndex,
-                accountInfo.GetNextChangeReceiveAddress(), Encoders.Hex.EncodeData(investorPrivateKey.ToBytes()), feeData.SelectedFeeEstimation);
+                accountInfo.GetNextChangeReceiveAddress(), investorPrivateKey, feeData.SelectedFeeEstimation);
 
             Logger.LogInformation($"EndOfProjectTransactionId={endOfProjectTransaction.Transaction.GetHash().ToString()}");
 
@@ -1248,7 +1248,7 @@
                 project.ProjectInfo,
                 fromStage.StageIndex,
                 accountInfo.GetNextChangeReceiveAddress(),
-                Encoders.Hex.EncodeData(investorPrivateKey.ToBytes()),
+                investorPrivateKey,
                 feeData.SelectedFeeEstimation);
 
             StateHasChanged();

--- a/src/webapp/Angor.Client/Pages/Release.razor
+++ b/src/webapp/Angor.Client/Pages/Release.razor
@@ -1,4 +1,4 @@
-﻿@page "/release/{ProjectIdentifier}"
+@page "/release/{ProjectIdentifier}"
 @using Angor.Shared
 @using Angor.Client.Storage
 @using Angor.Shared.Models
@@ -406,7 +406,7 @@
             var investmentTransaction = _networkConfiguration.GetNetwork().CreateTransaction(signedTransactionHex);
 
             // Sign the release transaction
-            unsignedReleaseTransaction = InvestorTransactionActions.AddSignaturesToUnfundedReleaseFundsTransaction(InvestorProject.ProjectInfo, investmentTransaction, InvestorReleaseSigInfo, Encoders.Hex.EncodeData(investorPrivateKey.ToBytes()), InvestorProject.UnfundedReleaseAddress);
+            unsignedReleaseTransaction = InvestorTransactionActions.AddSignaturesToUnfundedReleaseFundsTransaction(InvestorProject.ProjectInfo, investmentTransaction, InvestorReleaseSigInfo, investorPrivateKey, InvestorProject.UnfundedReleaseAddress);
 
             // Validate the signatures
             var sigCheckResult = InvestorTransactionActions.CheckInvestorUnfundedReleaseSignatures(InvestorProject.ProjectInfo, investmentTransaction, InvestorReleaseSigInfo, InvestorProject.UnfundedReleaseAddress);

--- a/src/webapp/Angor.Client/Pages/Signatures.razor
+++ b/src/webapp/Angor.Client/Pages/Signatures.razor
@@ -1,4 +1,4 @@
-﻿@page "/signatures/{ProjectIdentifier}"
+@page "/signatures/{ProjectIdentifier}"
 @using Angor.Shared
 @using Angor.Client.Storage
 @using Angor.Shared.Models
@@ -700,7 +700,7 @@
         try
         {
             var key = DerivationOperations.DeriveFounderRecoveryPrivateKey(words, FounderProject.ProjectInfo.FounderKey);
-            var signatureInfo = CreateRecoverySignatures(signature.SignRecoveryRequest.InvestmentTransactionHex, FounderProject.ProjectInfo, Encoders.Hex.EncodeData(key.ToBytes()));
+            var signatureInfo = CreateRecoverySignatures(signature.SignRecoveryRequest.InvestmentTransactionHex, FounderProject.ProjectInfo, key);
 
             var sigJson = serializer.Serialize(signatureInfo);
 
@@ -724,7 +724,7 @@
         }
     }
 
-    private SignatureInfo CreateRecoverySignatures(string transactionHex, ProjectInfo info, string founderSigningPrivateKey)
+    private SignatureInfo CreateRecoverySignatures(string transactionHex, ProjectInfo info, AngorKey founderSigningPrivateKey)
     {
         var investorTrx = _networkConfiguration.GetNetwork().CreateTransaction(transactionHex);
 

--- a/src/webapp/Angor.Client/Pages/Spend.razor
+++ b/src/webapp/Angor.Client/Pages/Spend.razor
@@ -1,4 +1,4 @@
-﻿@page "/spend/{ProjectId}"
+@page "/spend/{ProjectId}"
 @using Angor.Shared
 @using Angor.Client.Storage
 @using Angor.Client.Services
@@ -905,7 +905,7 @@
 
             var key = _derivationOperations.DeriveFounderPrivateKey(words, keys.Index);
 
-            signedTransaction = _founderTransactionActions.SpendFounderStage(founderContext.ProjectInfo, founderContext.InvestmentTrasnactionsHex, selectedStageId, addressScript, Encoders.Hex.EncodeData(key.ToBytes()), feeData.SelectedFeeEstimation);
+            signedTransaction = _founderTransactionActions.SpendFounderStage(founderContext.ProjectInfo, founderContext.InvestmentTrasnactionsHex, selectedStageId, addressScript, key, feeData.SelectedFeeEstimation);
 
             showCreateModal = true;
         }
@@ -955,7 +955,7 @@
                 founderContext.InvestmentTrasnactionsHex,
                 selectedStageId,
                 addressScript,
-                Encoders.Hex.EncodeData(key.ToBytes()),
+                key,
                 feeData.SelectedFeeEstimation);
 
             StateHasChanged();

--- a/src/webapp/Angor.Client/Pages/Unfunded.razor
+++ b/src/webapp/Angor.Client/Pages/Unfunded.razor
@@ -1,4 +1,4 @@
-﻿@page "/unfunded/{ProjectIdentifier}"
+@page "/unfunded/{ProjectIdentifier}"
 @using Angor.Shared
 @using Angor.Client.Storage
 @using Angor.Shared.Models
@@ -619,7 +619,7 @@
         try
         {
             var key = DerivationOperations.DeriveFounderRecoveryPrivateKey(words, FounderProject.ProjectInfo.FounderKey);
-            var signatureInfo = CreateReleaseSignatures(signature.SignRecoveryRequest?.InvestmentTransactionHex, FounderProject.ProjectInfo, Encoders.Hex.EncodeData(key.ToBytes()), signature.SignRecoveryRequest?.UnfundedReleaseAddress ?? signature.SignRecoveryRequest.UnfundedReleaseKey);
+            var signatureInfo = CreateReleaseSignatures(signature.SignRecoveryRequest?.InvestmentTransactionHex, FounderProject.ProjectInfo, key, signature.SignRecoveryRequest?.UnfundedReleaseAddress ?? signature.SignRecoveryRequest.UnfundedReleaseKey);
 
             var sigJson = serializer.Serialize(signatureInfo);
 
@@ -639,7 +639,7 @@
         }
     }
 
-    private SignatureInfo CreateReleaseSignatures(string transactionHex, ProjectInfo info, string founderSigningPrivateKey, string investorReleaseAddress)
+    private SignatureInfo CreateReleaseSignatures(string transactionHex, ProjectInfo info, AngorKey founderSigningPrivateKey, string investorReleaseAddress)
     {
         var investorTrx = _networkConfiguration.GetNetwork().CreateTransaction(transactionHex);
 


### PR DESCRIPTION
## Summary

Implements two critical security findings from the security audit:

- **C3 (Private key type-safety)**: Introduces `AngorKey : NBitcoin.Key` to replace raw hex string private key parameters across all protocol interfaces, eliminating accidental logging/serialization of key material
- **C2 (Mnemonic memory protection)**: Refactors `WalletWords` to use `char[]` backing with `IDisposable` zeroing via `CryptographicOperations.ZeroMemory`, caches the derived `ExtKey` to avoid repeated PBKDF2 derivation, and updates `SensitiveWalletDataProvider` to deterministically zero cached mnemonics on removal

## Changes

### C3 - AngorKey type-safety
- New `AngorKey : NBitcoin.Key` class with `FromHex(string)` and `From(Blockcore.NBitcoin.Key)` bridge factories
- Updated 7 protocol interfaces + implementations to accept `AngorKey` instead of `string`
- Updated 8 SDK operation handlers and 7 webapp Razor pages
- Updated all test files (Shared + SDK)

### C2 - Mnemonic memory protection
- `WalletWords` rewritten with `char[]` backing, `IDisposable` zeroing, and lazy `ExtKey` caching
- `DerivationOperations` routes all 12+ derivation sites through `walletWords.GetOrDeriveExtKey()`
- `WalletOperations.DerivePublicKey/DerivePrivateKey` now use cached `ExtKey` overloads
- `IHdOperations` extended with `DerivePublicKey(ExtKey, string)` and `DerivePrivateKey(ExtKey, string)` overloads
- `SensitiveWalletDataProvider` caches `WalletWords` (zeroable) instead of raw `(string, Maybe<string>)` tuples, with `Dispose()` zeroing on removal

## Test Results

- Shared tests: **146/146 passed**
- SDK tests: **312/312 passed** (7 skipped - pre-existing)
- Builds clean (only pre-existing iOS workload error on Windows)