### PR TITLE
fix: prevent wallet loss on Android swipe-kill

### DIFF
--- a/src/design/App.Android/MainActivity.cs
+++ b/src/design/App.Android/MainActivity.cs
@@ -1,10 +1,15 @@
+using System;
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
 using Android.Views;
+using Angor.Data.Documents.Interfaces;
 using App.UI.Shared.Helpers;
+using App.UI.Shell;
 using Avalonia.Android;
 using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace App.Android;
 
@@ -36,6 +41,44 @@ public class MainActivity : AvaloniaMainActivity
         {
             UnregisterReceiver(_perfReceiver);
             _perfReceiver = null;
+        }
+    }
+
+    protected override void OnStop()
+    {
+        base.OnStop();
+
+        // Flush all pending state to disk before the process may be killed.
+        // Android can terminate the process at any point after OnStop returns.
+        try
+        {
+            var services = global::App.App.Services;
+            if (services == null) return;
+
+            // Checkpoint LiteDB to flush the WAL into the main data file
+            var db = services.GetService<IAngorDocumentDatabase>();
+            if (db != null)
+            {
+                db.CheckpointAsync().GetAwaiter().GetResult();
+            }
+
+            // Flush prototype settings (selected wallet ID, theme, etc.)
+            var settings = services.GetService<PrototypeSettings>();
+            settings?.FlushAsync().GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                var logger = global::App.App.Services?
+                    .GetService<ILoggerFactory>()?
+                    .CreateLogger<MainActivity>();
+                logger?.LogError(ex, "Failed to flush data in OnStop");
+            }
+            catch
+            {
+                // Swallow — logging infrastructure may already be disposed
+            }
         }
     }
 

--- a/src/design/App/UI/Shell/ShellViewModel.cs
+++ b/src/design/App/UI/Shell/ShellViewModel.cs
@@ -163,6 +163,7 @@ public class SignatureStore
 public partial class PrototypeSettings : ReactiveObject
 {
     private readonly IStore _store;
+    private readonly ILogger _logger;
     private const string SettingsKey = "prototype_settings.json";
     private CancellationTokenSource? saveSettingsCts;
 
@@ -192,9 +193,10 @@ public partial class PrototypeSettings : ReactiveObject
     /// </summary>
     [Reactive] private string? selectedWalletId;
 
-    public PrototypeSettings(IStore store)
+    public PrototypeSettings(IStore store, ILogger<PrototypeSettings> logger)
     {
         _store = store;
+        _logger = logger;
 
         // Load persisted values asynchronously to avoid blocking the UI thread.
         // Default field values are used until loading completes.
@@ -274,8 +276,7 @@ public partial class PrototypeSettings : ReactiveObject
 
             if (!token.IsCancellationRequested && saveResult.IsFailure)
             {
-                var logger = App.Services.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(PrototypeSettings));
-                logger.LogWarning("Failed to save settings: {Error}", saveResult.Error);
+                _logger.LogWarning("Failed to save settings: {Error}", saveResult.Error);
             }
         }, token);
     }
@@ -301,8 +302,7 @@ public partial class PrototypeSettings : ReactiveObject
 
         if (saveResult.IsFailure)
         {
-            var logger = App.Services.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(PrototypeSettings));
-            logger.LogWarning("FlushAsync: Failed to save settings: {Error}", saveResult.Error);
+            _logger.LogWarning("FlushAsync: Failed to save settings: {Error}", saveResult.Error);
         }
     }
 

--- a/src/design/App/UI/Shell/ShellViewModel.cs
+++ b/src/design/App/UI/Shell/ShellViewModel.cs
@@ -280,6 +280,32 @@ public partial class PrototypeSettings : ReactiveObject
         }, token);
     }
 
+    /// <summary>
+    /// Immediately persists the current settings to disk, bypassing the throttle.
+    /// Called from Android lifecycle handlers (OnStop) to ensure the selected wallet ID
+    /// is saved before the process is killed.
+    /// </summary>
+    public async Task FlushAsync()
+    {
+        // Cancel any pending throttled save to avoid a race
+        saveSettingsCts?.Cancel();
+        saveSettingsCts?.Dispose();
+        saveSettingsCts = null;
+
+        Result saveResult = await _store.Save(SettingsKey, new PrototypeSettingsData
+        {
+            IsDebugMode = IsDebugMode,
+            IsDarkTheme = IsDarkTheme,
+            SelectedWalletId = SelectedWalletId,
+        });
+
+        if (saveResult.IsFailure)
+        {
+            var logger = App.Services.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(PrototypeSettings));
+            logger.LogWarning("FlushAsync: Failed to save settings: {Error}", saveResult.Error);
+        }
+    }
+
     private class PrototypeSettingsData
     {
         public bool IsDebugMode { get; set; }

--- a/src/sdk/Angor.Data.Documents.LiteDb/LiteDbDocumentDatabase.cs
+++ b/src/sdk/Angor.Data.Documents.LiteDb/LiteDbDocumentDatabase.cs
@@ -18,29 +18,20 @@ public class LiteDbDocumentDatabase : IAngorDocumentDatabase
         _logger = logger;
         _databasePath = ExtractFilePathFromConnectionString(connectionString);
         
-        try
-        {
-            // Force LiteDB to store and retrieve all DateTime values in UTC.
-            // LiteDB 5.x stores DateTime as BSON DateTime (UTC milliseconds)
-            // but on deserialization may return DateTimeKind.Local, silently
-            // converting UTC dates to local time.  When those dates are later
-            // used to rebuild Bitcoin taproot scripts (CLTV locktimes, expiry
-            // dates), the different Kind causes .Date to return a different
-            // calendar day in non-UTC timezones, producing a different script
-            // hash and "Witness program hash mismatch".
-            BsonMapper.Global.RegisterType<DateTime>(
-                serialize: dt => new BsonValue(dt.ToUniversalTime()),
-                deserialize: bson => bson.AsDateTime.ToUniversalTime()
-            );
+        // Force LiteDB to store and retrieve all DateTime values in UTC.
+        // LiteDB 5.x stores DateTime as BSON DateTime (UTC milliseconds)
+        // but on deserialization may return DateTimeKind.Local, silently
+        // converting UTC dates to local time.  When those dates are later
+        // used to rebuild Bitcoin taproot scripts (CLTV locktimes, expiry
+        // dates), the different Kind causes .Date to return a different
+        // calendar day in non-UTC timezones, producing a different script
+        // hash and "Witness program hash mismatch".
+        BsonMapper.Global.RegisterType<DateTime>(
+            serialize: dt => new BsonValue(dt.ToUniversalTime()),
+            deserialize: bson => bson.AsDateTime.ToUniversalTime()
+        );
 
-            _database = new LiteDatabase(connectionString);
-            _logger.LogInformation("Initialized LiteDB database: {ConnectionString}", connectionString);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to initialize LiteDB database: {ConnectionString}", connectionString);
-            throw;
-        }
+        _database = OpenDatabaseWithRecovery(connectionString);
     }
 
     public IDocumentCollection<T> GetCollection<T>() where T : BaseDocument
@@ -176,5 +167,44 @@ public class LiteDbDocumentDatabase : IAngorDocumentDatabase
         _database.Checkpoint();
         _database.Dispose();
         _logger.LogInformation("LiteDB database disposed");
+    }
+
+    /// <summary>
+    /// Opens the LiteDB database. If the initial open fails (e.g. corrupted WAL from
+    /// an unclean Android shutdown), deletes the WAL journal file and retries.
+    /// This preserves the main data file while discarding uncommitted changes.
+    /// </summary>
+    private LiteDatabase OpenDatabaseWithRecovery(string connectionString)
+    {
+        try
+        {
+            var db = new LiteDatabase(connectionString);
+            _logger.LogInformation("Initialized LiteDB database: {Path}", _databasePath);
+            return db;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "LiteDB failed to open, attempting WAL recovery: {Path}", _databasePath);
+
+            try
+            {
+                // LiteDB 5.x WAL file uses the "-log" suffix
+                var walPath = _databasePath + "-log";
+                if (File.Exists(walPath))
+                {
+                    File.Delete(walPath);
+                    _logger.LogInformation("Deleted corrupted WAL file: {WalPath}", walPath);
+                }
+
+                var db = new LiteDatabase(connectionString);
+                _logger.LogInformation("LiteDB opened successfully after WAL recovery: {Path}", _databasePath);
+                return db;
+            }
+            catch (Exception retryEx)
+            {
+                _logger.LogError(retryEx, "LiteDB failed to open even after WAL recovery: {Path}", _databasePath);
+                throw;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `OnStop` lifecycle handler in `MainActivity` to checkpoint LiteDB (flush WAL to main data file) and immediately persist prototype settings (selected wallet ID, theme) before Android can kill the process
- Add WAL recovery in `LiteDbDocumentDatabase` — if the database fails to open due to a corrupted journal from an unclean shutdown, the `-log` WAL file is deleted and the database is retried, preserving the main data file
- Add `FlushAsync()` to `PrototypeSettings` for immediate persistence, bypassing the 250ms throttle used during normal operation

## Root Cause
When the user swipes the app away on Android, the process is killed without any lifecycle hooks firing to flush pending writes. This could cause:
1. **LiteDB WAL corruption** — if a write was in-flight, the WAL journal could be left in an inconsistent state, causing `GetMetadatas()` to fail on next launch and the wallet list to appear empty
2. **Lost `SelectedWalletId`** — the settings save was throttled by 250ms and ran on a background task, so it could be dropped if the process was killed too quickly

## Files Changed
- `src/design/App.Android/MainActivity.cs` — `OnStop` override
- `src/design/App/UI/Shell/ShellViewModel.cs` — `PrototypeSettings.FlushAsync()`
- `src/sdk/Angor.Data.Documents.LiteDb/LiteDbDocumentDatabase.cs` — `OpenDatabaseWithRecovery()`