### PR TITLE
fix: remove SupportNpub CI override that blanked the hardcoded default

### DIFF
--- a/.github/workflows/release-avalonia.yml
+++ b/.github/workflows/release-avalonia.yml
@@ -55,7 +55,7 @@ jobs:
         run: dotnet restore design/App.Desktop/App.Desktop.csproj
       
       - name: Build
-        run: dotnet build design/App.Desktop/App.Desktop.csproj --no-restore -c Release -p:SupportNpub=${{ vars.SUPPORT_NPUB }}
+        run: dotnet build design/App.Desktop/App.Desktop.csproj --no-restore -c Release
       
       - name: Test
         run: dotnet test sdk/Angor.Sdk.Tests/Angor.Sdk.Tests.csproj -c Release --verbosity normal
@@ -256,7 +256,6 @@ jobs:
             -p:ApplicationDisplayVersion=${{ needs.prepare.outputs.version }} \
             -p:ApplicationVersion=${{ github.run_number }} \
             -p:Version=${{ needs.prepare.outputs.version }} \
-            -p:SupportNpub=${{ vars.SUPPORT_NPUB }} \
             -p:AndroidKeyStore=true \
             -p:AndroidSigningKeyStore=${{ github.workspace }}/android.keystore \
             -p:AndroidSigningKeyAlias=${{ secrets.ANDROID_KEY_ALIAS }} \
@@ -273,7 +272,6 @@ jobs:
             -p:ApplicationDisplayVersion=${{ needs.prepare.outputs.version }} \
             -p:ApplicationVersion=${{ github.run_number }} \
             -p:Version=${{ needs.prepare.outputs.version }} \
-            -p:SupportNpub=${{ vars.SUPPORT_NPUB }} \
             -o ${{ github.workspace }}/artifacts/
       
       - name: Rename APK


### PR DESCRIPTION
## Summary

- Removed `-p:SupportNpub` from all three build commands in `release-avalonia.yml` (desktop test build, signed APK, unsigned APK)
- The hardcoded default in `App.csproj` is now always used

## Problem

When the `SUPPORT_NPUB` repository variable was not configured in GitHub Actions, the workflow passed `-p:SupportNpub=` (empty string) to MSBuild. This overrode the hardcoded value in `App.csproj`, causing `GetSupportNpubHex()` to return null and producing the 'Support npub is not configured' error at runtime on Android.