### PR TITLE
UI polish: refresh spinner, tab loading, and log export fixes

### DIFF
--- a/src/design/App/Composition/CompositionRoot.cs
+++ b/src/design/App/Composition/CompositionRoot.cs
@@ -185,6 +185,7 @@ public static class CompositionRoot
                 sp.GetRequiredService<ICurrencyService>(),
                 sp.GetRequiredService<IWalletContext>(),
                 sp.GetRequiredService<Func<BitcoinNetwork>>(),
+                sp.GetRequiredService<PrototypeSettings>(),
                 sp.GetRequiredService<ILoggerFactory>().CreateLogger<InvestPageViewModel>()));
 
         services.AddSingleton<Func<MyProjectItemViewModel, ManageProjectViewModel>>(sp =>

--- a/src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs
+++ b/src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs
@@ -14,6 +14,7 @@ using App.UI.Shared;
 using App.UI.Shared.PaymentFlow;
 using ProjectType = App.UI.Shared.ProjectType;
 using App.UI.Shared.Services;
+using App.UI.Shell;
 using Microsoft.Extensions.Logging;
 using MonitorOp = Angor.Sdk.Funding.Investor.Operations.MonitorAddressForFunds;
 
@@ -117,6 +118,7 @@ public partial class InvestPageViewModel : ReactiveObject, IDisposable
     private readonly IWalletContext _walletContext;
     private readonly Func<BitcoinNetwork> _getNetwork;
     private readonly ILogger<InvestPageViewModel> _logger;
+    private readonly PrototypeSettings _prototypeSettings;
     private readonly CompositeDisposable _disposables = new();
     // ── Project Reference ──
     public ProjectItemViewModel Project { get; }
@@ -253,6 +255,7 @@ public partial class InvestPageViewModel : ReactiveObject, IDisposable
         ICurrencyService currencyService,
         IWalletContext walletContext,
         Func<BitcoinNetwork> getNetwork,
+        PrototypeSettings prototypeSettings,
         ILogger<InvestPageViewModel> logger)
     {
         Project = project;
@@ -264,6 +267,7 @@ public partial class InvestPageViewModel : ReactiveObject, IDisposable
         _currencyService = currencyService;
         _walletContext = walletContext;
         _getNetwork = getNetwork;
+        _prototypeSettings = prototypeSettings;
         _logger = logger;
 
         _logger.LogInformation("InvestPageViewModel created for project '{ProjectName}' (ID: {ProjectId}, Type: {ProjectType})",
@@ -722,6 +726,7 @@ public partial class InvestPageViewModel : ReactiveObject, IDisposable
             _currencyService,
             _getNetwork,
             _logger,
+            _prototypeSettings,
             config);
     }
 

--- a/src/design/App/UI/Sections/Funds/CreateWalletModal.axaml
+++ b/src/design/App/UI/Sections/Funds/CreateWalletModal.axaml
@@ -350,7 +350,7 @@
                             BorderThickness="1"
                             CornerRadius="8"
                             Padding="16">
-                        <TextBlock Name="SeedPhraseDisplay"
+                        <SelectableTextBlock Name="SeedPhraseDisplay"
                                    Text="abandon ability able about above absent absorb abstract absurd abuse access accident"
                                    FontSize="14"
                                    FontFamily="Cascadia Mono, Consolas, monospace"

--- a/src/design/App/UI/Sections/MyProjects/Deploy/DeployFlowViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/Deploy/DeployFlowViewModel.cs
@@ -13,6 +13,7 @@ using Angor.Shared.Integration.Lightning;
 using App.UI.Shared;
 using App.UI.Shared.PaymentFlow;
 using App.UI.Shared.Services;
+using App.UI.Shell;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 using ReactiveUI;
@@ -46,6 +47,7 @@ public partial class DeployFlowViewModel : ReactiveObject
     private readonly IWalletContext _walletContext;
     private readonly Func<BitcoinNetwork> _getNetwork;
     private readonly ILogger<DeployFlowViewModel> _logger;
+    private readonly PrototypeSettings _prototypeSettings;
     private CancellationTokenSource? _invoiceMonitorCts;
 
     // ── State ──
@@ -97,6 +99,7 @@ public partial class DeployFlowViewModel : ReactiveObject
         ICurrencyService currencyService,
         IWalletContext walletContext,
         Func<BitcoinNetwork> getNetwork,
+        PrototypeSettings prototypeSettings,
         ILogger<DeployFlowViewModel> logger)
     {
         _walletAppService = walletAppService;
@@ -108,6 +111,7 @@ public partial class DeployFlowViewModel : ReactiveObject
         _currencyService = currencyService;
         _walletContext = walletContext;
         _getNetwork = getNetwork;
+        _prototypeSettings = prototypeSettings;
         _logger = logger;
         // Initialize ReactiveCommands for async payment operations
         PayWithWalletCommand = ReactiveCommand.CreateFromTask(PayWithWalletAsync);
@@ -169,6 +173,7 @@ public partial class DeployFlowViewModel : ReactiveObject
             _currencyService,
             _getNetwork,
             _logger,
+            _prototypeSettings,
             new PaymentFlowConfig
             {
                 AmountSats = deployFeeSats,

--- a/src/design/App/UI/Sections/Portfolio/PortfolioView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioView.axaml
@@ -104,10 +104,29 @@
                         <!-- Buttons Row: Refresh + Penalties -->
                         <StackPanel Orientation="Horizontal" Spacing="12" HorizontalAlignment="Center">
                             <Button Name="RefreshButton" Classes="Primary MobileAction" Padding="20,8"
-                                   AutomationProperties.AutomationId="PortfolioRefreshButton">
+                                   AutomationProperties.AutomationId="PortfolioRefreshButton"
+                                   IsEnabled="{Binding !IsLoading}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <i:Icon Value="fa-solid fa-arrows-rotate" FontSize="13"
-                                            Foreground="White" VerticalAlignment="Center" />
+                                            Foreground="White" VerticalAlignment="Center">
+                                        <i:Icon.RenderTransform>
+                                            <RotateTransform />
+                                        </i:Icon.RenderTransform>
+                                        <i:Icon.Styles>
+                                            <Style Selector="i|Icon.Spinning">
+                                                <Style.Animations>
+                                                    <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                        <KeyFrame Cue="0%">
+                                                            <Setter Property="RotateTransform.Angle" Value="0" />
+                                                        </KeyFrame>
+                                                        <KeyFrame Cue="100%">
+                                                            <Setter Property="RotateTransform.Angle" Value="360" />
+                                                        </KeyFrame>
+                                                    </Animation>
+                                                </Style.Animations>
+                                            </Style>
+                                        </i:Icon.Styles>
+                                    </i:Icon>
                                     <TextBlock Text="Refresh" FontSize="13" FontWeight="SemiBold"
                                                Foreground="White" VerticalAlignment="Center" />
                                 </StackPanel>
@@ -309,9 +328,28 @@
                             <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                                 <Button Name="MobileRefreshButton" Classes="MobileAction IconOnly" Padding="8,6" CornerRadius="8"
                                         Background="{DynamicResource SurfaceLow}"
-                                        BorderBrush="{DynamicResource Stroke}" BorderThickness="1">
+                                        BorderBrush="{DynamicResource Stroke}" BorderThickness="1"
+                                        IsEnabled="{Binding !IsLoading}">
                                     <i:Icon Value="fa-solid fa-arrows-rotate" FontSize="13"
-                                            Foreground="{DynamicResource TextMuted}" />
+                                            Foreground="{DynamicResource TextMuted}">
+                                        <i:Icon.RenderTransform>
+                                            <RotateTransform />
+                                        </i:Icon.RenderTransform>
+                                        <i:Icon.Styles>
+                                            <Style Selector="i|Icon.Spinning">
+                                                <Style.Animations>
+                                                    <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                        <KeyFrame Cue="0%">
+                                                            <Setter Property="RotateTransform.Angle" Value="0" />
+                                                        </KeyFrame>
+                                                        <KeyFrame Cue="100%">
+                                                            <Setter Property="RotateTransform.Angle" Value="360" />
+                                                        </KeyFrame>
+                                                    </Animation>
+                                                </Style.Animations>
+                                            </Style>
+                                        </i:Icon.Styles>
+                                    </i:Icon>
                                 </Button>
                                 <Button Name="MobilePenaltiesButton" Classes="MobileAction IconOnly" Padding="8,6" CornerRadius="8"
                                         Background="#F7931A" Cursor="Hand">

--- a/src/design/App/UI/Sections/Portfolio/PortfolioView.axaml.cs
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioView.axaml.cs
@@ -14,6 +14,7 @@ public partial class PortfolioView : UserControl, ISectionView
 {
     private IDisposable? _visibilitySubscription;
     private IDisposable? _layoutSubscription;
+    private IDisposable? _refreshSpinSubscription;
 
     // Cached controls for responsive layout
     private Grid? _portfolioGrid;
@@ -62,6 +63,20 @@ public partial class PortfolioView : UserControl, ISectionView
 
         // ── Responsive layout: 380px sidebar + content (desktop) → stacked (compact) ──
         SubscribeToLayoutMode();
+
+        // ── Refresh button spin animation ──
+        _refreshSpinSubscription = vm.WhenAnyValue(x => x.IsLoading)
+
+            .Subscribe(isLoading =>
+            {
+                var refreshBtn = this.FindControl<Button>("RefreshButton");
+                var icon = refreshBtn?.GetLogicalDescendants().OfType<Optris.Icons.Avalonia.Icon>().FirstOrDefault();
+                icon?.Classes.Set("Spinning", isLoading);
+
+                var mobileRefreshBtn = this.FindControl<Button>("MobileRefreshButton");
+                var mobileIcon = mobileRefreshBtn?.GetLogicalDescendants().OfType<Optris.Icons.Avalonia.Icon>().FirstOrDefault();
+                mobileIcon?.Classes.Set("Spinning", isLoading);
+            });
 
         // Mobile perf: sidebar is hidden via IsVisible=false on compact,
         // so no need to detach children. Strip hover transitions via .Mobile class.

--- a/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
@@ -784,6 +784,7 @@ public partial class PortfolioViewModel : ReactiveObject, IDisposable
         _logger.LogInformation("Loading recovery status for project '{ProjectName}' (ID: {ProjectId}, WalletId: {WalletId})",
             investment.ProjectName, investment.ProjectIdentifier, investment.InvestmentWalletId);
 
+        investment.IsProcessing = true;
         try
         {
             var request = new GetRecoveryStatus.GetRecoveryStatusRequest(
@@ -858,6 +859,10 @@ public partial class PortfolioViewModel : ReactiveObject, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error loading recovery status for project {ProjectId}", investment.ProjectIdentifier);
+        }
+        finally
+        {
+            investment.IsProcessing = false;
         }
     }
 

--- a/src/design/App/UI/Sections/Settings/SettingsView.axaml
+++ b/src/design/App/UI/Sections/Settings/SettingsView.axaml
@@ -527,29 +527,71 @@
                         </Border>
                         <Border Padding="24">
                             <StackPanel Spacing="20">
-                                <TextBlock Text="Download a backup of your account (seed) so you never lose access."
+                                <TextBlock Text="Your wallet seed phrase is the only way to recover your funds. Keep it safe and never share it with anyone."
                                            FontSize="14"
                                            Foreground="{DynamicResource TextMuted}"
                                            TextWrapping="Wrap" />
-                                <!-- Vue: green gradient action button -->
-                                <Button HorizontalAlignment="Left"
-                                        Classes="MobileAction"
-                                        Padding="20,14"
-                                        Background="{DynamicResource GreenGradient}"
-                                        Foreground="White"
-                                        BorderThickness="0"
+
+                                <!-- Seed phrase display (visible after reveal) -->
+                                <Border IsVisible="{Binding SeedWordsVisible}"
+                                        Background="{DynamicResource CreateWalletSeedBg}"
+                                        BorderBrush="{DynamicResource CreateWalletSeedBorder}"
+                                        BorderThickness="1"
                                         CornerRadius="8"
-                                        FontWeight="SemiBold"
-                                        FontSize="14"
-                                        IsEnabled="False"
-                                        Opacity="0.5">
-                                    <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <i:Icon Value="fa-solid fa-key"
-                                               FontSize="16"
-                                               Foreground="White" />
-                                        <TextBlock Text="Download Backup (Coming Soon)" VerticalAlignment="Center" />
-                                    </StackPanel>
-                                </Button>
+                                        Padding="16">
+                                    <TextBlock Text="{Binding SeedWords}"
+                                               FontSize="14"
+                                               FontFamily="Cascadia Mono, Consolas, monospace"
+                                               Foreground="{DynamicResource CreateWalletSeedText}"
+                                               TextWrapping="Wrap"
+                                               TextAlignment="Center" />
+                                </Border>
+
+                                <StackPanel Spacing="12">
+                                    <!-- Show/Hide Seed Words button -->
+                                    <Button Name="BtnRevealSeed"
+                                            Click="OnRevealSeedClick"
+                                            HorizontalAlignment="Left"
+                                            Classes="MobileAction"
+                                            Padding="20,14"
+                                            Background="{DynamicResource CreateWalletAmberBtnBg}"
+                                            Foreground="White"
+                                            BorderThickness="0"
+                                            CornerRadius="8"
+                                            FontWeight="SemiBold"
+                                            FontSize="14"
+                                            Cursor="Hand">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <i:Icon Value="fa-solid fa-eye"
+                                                   FontSize="16"
+                                                   Foreground="White" />
+                                            <TextBlock Name="RevealSeedText" Text="Show Seed Words"
+                                                       VerticalAlignment="Center" />
+                                        </StackPanel>
+                                    </Button>
+
+                                    <!-- Download Seed button (visible after reveal) -->
+                                    <Button Name="BtnDownloadBackup"
+                                            Click="OnDownloadBackupClick"
+                                            IsVisible="{Binding SeedWordsVisible}"
+                                            HorizontalAlignment="Left"
+                                            Classes="MobileAction"
+                                            Padding="20,14"
+                                            Background="{DynamicResource GreenGradient}"
+                                            Foreground="White"
+                                            BorderThickness="0"
+                                            CornerRadius="8"
+                                            FontWeight="SemiBold"
+                                            FontSize="14"
+                                            Cursor="Hand">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <i:Icon Value="fa-solid fa-download"
+                                                   FontSize="16"
+                                                   Foreground="White" />
+                                            <TextBlock Text="Download Seed" VerticalAlignment="Center" />
+                                        </StackPanel>
+                                    </Button>
+                                </StackPanel>
                             </StackPanel>
                         </Border>
                     </StackPanel>

--- a/src/design/App/UI/Sections/Settings/SettingsView.axaml
+++ b/src/design/App/UI/Sections/Settings/SettingsView.axaml
@@ -539,7 +539,7 @@
                                         BorderThickness="1"
                                         CornerRadius="8"
                                         Padding="16">
-                                    <TextBlock Text="{Binding SeedWords}"
+                                    <SelectableTextBlock Text="{Binding SeedWords}"
                                                FontSize="14"
                                                FontFamily="Cascadia Mono, Consolas, monospace"
                                                Foreground="{DynamicResource CreateWalletSeedText}"

--- a/src/design/App/UI/Sections/Settings/SettingsView.axaml.cs
+++ b/src/design/App/UI/Sections/Settings/SettingsView.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
+using Avalonia.Platform.Storage;
 using App.UI.Shared;
 using App.UI.Shared.Controls;
 using App.UI.Shell;
@@ -314,6 +315,63 @@ public partial class SettingsView : UserControl, ISectionView
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "OnExportLogsClick failed");
+        }
+    }
+
+    // ── Backup ──
+    private async void OnRevealSeedClick(object? sender, RoutedEventArgs e)
+    {
+        if (Vm == null) return;
+        if (Vm.SeedWordsVisible)
+        {
+            Vm.HideSeedWords();
+            var text = this.FindControl<TextBlock>("RevealSeedText");
+            if (text != null) text.Text = "Show Seed Words";
+        }
+        else
+        {
+            await Vm.LoadSeedWordsAsync();
+            var text = this.FindControl<TextBlock>("RevealSeedText");
+            if (text != null) text.Text = "Hide Seed Words";
+
+            // Clear backup warning after viewing seed words
+            Vm.MarkWalletBackedUp();
+        }
+    }
+
+    private async void OnDownloadBackupClick(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            if (Vm?.SeedWords == null) return;
+
+            var topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel?.StorageProvider == null) return;
+
+            var file = await topLevel.StorageProvider.SaveFilePickerAsync(
+                new FilePickerSaveOptions
+                {
+                    Title = "Save Seed Phrase",
+                    SuggestedFileName = "seed-backup.txt",
+                    DefaultExtension = "txt"
+                });
+
+            if (file != null)
+            {
+                await using var stream = await file.OpenWriteAsync();
+                await using var writer = new System.IO.StreamWriter(stream);
+                await writer.WriteAsync(Vm.SeedWords);
+
+                var shellVm = this.FindAncestorOfType<ShellView>()?.DataContext as ShellViewModel;
+                shellVm?.ShowToast("Seed phrase saved successfully.");
+            }
+
+            // Clear backup warning after downloading
+            Vm.MarkWalletBackedUp();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "OnDownloadBackupClick failed");
         }
     }
 

--- a/src/design/App/UI/Sections/Settings/SettingsViewModel.cs
+++ b/src/design/App/UI/Sections/Settings/SettingsViewModel.cs
@@ -99,6 +99,11 @@ public partial class SettingsViewModel : ReactiveObject, IDisposable
     // Log export
     [Reactive] private bool isExportingLogs;
 
+    // Backup
+    [Reactive] private string? seedWords;
+    [Reactive] private bool isLoadingSeedWords;
+    [Reactive] private bool seedWordsVisible;
+
     public bool CanExportLogs => _walletContext.SelectedWallet != null && !IsExportingLogs;
 
     private readonly PrototypeSettings _prototypeSettings;
@@ -503,6 +508,71 @@ public partial class SettingsViewModel : ReactiveObject, IDisposable
         finally
         {
             IsExportingLogs = false;
+        }
+    }
+
+    // Backup wallet
+    public async Task LoadSeedWordsAsync()
+    {
+        if (IsLoadingSeedWords) return;
+        var wallet = _walletContext.SelectedWallet;
+        if (wallet == null)
+        {
+            ToastRequested?.Invoke("No wallet selected.");
+            return;
+        }
+
+        IsLoadingSeedWords = true;
+        try
+        {
+            var result = await _walletAppService.GetSeedWords(wallet.Id);
+            if (result.IsFailure)
+            {
+                _logger.LogError("Failed to load seed words: {Error}", result.Error);
+                ToastRequested?.Invoke("Failed to load seed words.");
+                return;
+            }
+
+            SeedWords = result.Value;
+            SeedWordsVisible = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "LoadSeedWordsAsync failed");
+            ToastRequested?.Invoke($"Failed to load seed words: {ex.Message}");
+        }
+        finally
+        {
+            IsLoadingSeedWords = false;
+        }
+    }
+
+    public void HideSeedWords()
+    {
+        SeedWords = null;
+        SeedWordsVisible = false;
+    }
+
+    /// <summary>
+    /// Mark the selected wallet as backed up, clearing the backup warning.
+    /// </summary>
+    public void MarkWalletBackedUp()
+    {
+        var wallet = _walletContext.SelectedWallet;
+        if (wallet == null) return;
+
+        _prototypeSettings.ClearWalletNeedsBackup(wallet.Id.Value);
+        _shellViewModel.RefreshBackupWarning();
+    }
+
+    /// <summary>Whether the selected wallet needs backup.</summary>
+    public bool SelectedWalletNeedsBackup
+    {
+        get
+        {
+            var wallet = _walletContext.SelectedWallet;
+            if (wallet == null) return false;
+            return _prototypeSettings.DoesWalletNeedBackup(wallet.Id.Value);
         }
     }
 

--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowView.axaml
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowView.axaml
@@ -400,7 +400,26 @@
                             <StackPanel Orientation="Horizontal" Spacing="6">
                                 <i:Icon Value="fa-solid fa-arrows-rotate" FontSize="11"
                                         Foreground="{DynamicResource DeployFeePillText}"
-                                        VerticalAlignment="Center" />
+                                        VerticalAlignment="Center"
+                                        RenderTransformOrigin="50%,50%">
+                                    <i:Icon.RenderTransform>
+                                        <RotateTransform />
+                                    </i:Icon.RenderTransform>
+                                    <i:Icon.Styles>
+                                        <Style Selector="i|Icon[IsVisible=True]">
+                                            <Style.Animations>
+                                                <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                    <KeyFrame Cue="0%">
+                                                        <Setter Property="RotateTransform.Angle" Value="0" />
+                                                    </KeyFrame>
+                                                    <KeyFrame Cue="100%">
+                                                        <Setter Property="RotateTransform.Angle" Value="360" />
+                                                    </KeyFrame>
+                                                </Animation>
+                                            </Style.Animations>
+                                        </Style>
+                                    </i:Icon.Styles>
+                                </i:Icon>
                                 <TextBlock Text="{Binding PaymentStatusText}"
                                            AutomationProperties.AutomationId="InvestPaymentStatus"
                                            FontSize="12" FontWeight="Medium"

--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs
@@ -10,6 +10,7 @@ using Angor.Shared.Integration.Lightning.Models;
 using Angor.Sdk.Funding.Shared;
 using Angor.Sdk.Wallet.Domain;
 using App.UI.Shared.Services;
+using App.UI.Shell;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 using ReactiveUI;
@@ -50,6 +51,7 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
     private readonly Func<BitcoinNetwork> _getNetwork;
     private readonly ILogger _logger;
     private readonly PaymentFlowConfig _config;
+    private readonly PrototypeSettings _prototypeSettings;
     private readonly CompositeDisposable _disposables = new();
     private CancellationTokenSource? _monitorCts;
 
@@ -139,6 +141,7 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
         ICurrencyService currencyService,
         Func<BitcoinNetwork> getNetwork,
         ILogger logger,
+        PrototypeSettings prototypeSettings,
         PaymentFlowConfig config)
     {
         _walletAppService = walletAppService;
@@ -149,6 +152,7 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
         _currencyService = currencyService;
         _getNetwork = getNetwork;
         _logger = logger;
+        _prototypeSettings = prototypeSettings;
         _config = config;
         SelectedFeeRate = config.FeeRateSatsPerVbyte;
         SuccessTitle = config.SuccessTitle;
@@ -563,6 +567,10 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
 
         await _walletContext.ReloadAsync();
         _logger.LogInformation("Wallet auto-created: {WalletId}", result.Value.Value);
+
+        // Mark this auto-created wallet as needing backup
+        _prototypeSettings.MarkWalletNeedsBackup(result.Value.Value);
+
         return Result.Success();
     }
 

--- a/src/design/App/UI/Shared/Services/LogExportService.cs
+++ b/src/design/App/UI/Shared/Services/LogExportService.cs
@@ -73,14 +73,23 @@ public class LogExportService : ILogExportService
         var supportDmKey = _derivationOperations.DeriveSupportDmKey(walletWords);
         var supportDmKeyHex = Encoders.Hex.EncodeData(supportDmKey.ToBytes());
 
-        // 4. Encrypt the zip using NIP-04 (ECDH shared secret with support npub)
+        // 4. Encrypt the zip using NIP-44 (ECDH shared secret with support npub)
+        //    NIP-44 has a 65535-byte plaintext limit, so encrypt in chunks.
         var zipBase64 = Convert.ToBase64String(zipBytes);
-        var encryptedBlob = await _encryptionService.EncryptNostrContentAsync(
-            supportDmKeyHex, supportNpubHex, zipBase64);
+        var encryptedChunks = new List<string>();
+        const int chunkSize = 60_000; // leave headroom below 65535
+        for (var i = 0; i < zipBase64.Length; i += chunkSize)
+        {
+            var chunk = zipBase64.Substring(i, Math.Min(chunkSize, zipBase64.Length - i));
+            var encryptedChunk = await _encryptionService.EncryptNostrContentAsync(
+                supportDmKeyHex, supportNpubHex, chunk);
+            encryptedChunks.Add(encryptedChunk);
+        }
+        var encryptedBlob = string.Join("\n", encryptedChunks);
         var encryptedBytes = System.Text.Encoding.UTF8.GetBytes(encryptedBlob);
 
         // 5. Upload encrypted blob to Blossom
-        var uploadResult = await UploadToBlossom(encryptedBytes, ct);
+        var uploadResult = await UploadToBlossom(encryptedBytes, supportDmKeyHex, ct);
         if (uploadResult.IsFailure)
             return Result.Failure(uploadResult.Error);
 
@@ -166,7 +175,7 @@ public class LogExportService : ILogExportService
         return Result.Success(ms.ToArray());
     }
 
-    private async Task<Result<string>> UploadToBlossom(byte[] encryptedBytes, CancellationToken ct)
+    private async Task<Result<string>> UploadToBlossom(byte[] encryptedBytes, string nostrPrivateKeyHex, CancellationToken ct)
     {
         var settings = _networkStorage.GetSettings();
         var servers = settings.ImageServers
@@ -180,7 +189,7 @@ public class LogExportService : ILogExportService
         foreach (var server in servers)
         {
             var result = await _blossomUploadService.UploadAsync(
-                server.Url, encryptedBytes, "application/octet-stream", cancellationToken: ct);
+                server.Url, encryptedBytes, "application/octet-stream", nostrPrivateKeyHex, ct);
 
             if (result.IsSuccess)
                 return result;

--- a/src/design/App/UI/Shell/ShellView.axaml
+++ b/src/design/App/UI/Shell/ShellView.axaml
@@ -102,6 +102,20 @@
                         VerticalAlignment="Center" Margin="12,0,0,0">
                     <TextBlock Text="{Binding ProfileName}" FontSize="12" Foreground="White" />
                 </Border>
+                <!-- Backup warning — red badge, visible when selected wallet needs backup -->
+                <Border IsVisible="{Binding ShowBackupWarning}"
+                        Background="#DC2626"
+                        CornerRadius="4" Padding="8,2"
+                        VerticalAlignment="Center" Margin="12,0,0,0"
+                        Cursor="Hand"
+                        Name="BackupWarningBadge"
+                        PointerPressed="OnBackupWarningClick">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <i:Icon Value="fa-solid fa-triangle-exclamation"
+                               FontSize="12" Foreground="White" />
+                        <TextBlock Text="Backup Required" FontSize="12" Foreground="White" FontWeight="SemiBold" />
+                    </StackPanel>
+                </Border>
                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Right" Spacing="16" Orientation="Horizontal">
                     <TextBlock VerticalAlignment="Center"
                              AutomationProperties.AutomationId="ShellInvestedBalanceText">

--- a/src/design/App/UI/Shell/ShellView.axaml.cs
+++ b/src/design/App/UI/Shell/ShellView.axaml.cs
@@ -959,6 +959,17 @@ public partial class ShellView : UserControl
     }
 
     /// <summary>
+    /// Navigates to Settings when the backup warning badge is clicked.
+    /// </summary>
+    private void OnBackupWarningClick(object? sender, Avalonia.Input.PointerPressedEventArgs e)
+    {
+        if (DataContext is ShellViewModel vm)
+        {
+            vm.NavigateToSettings();
+        }
+    }
+
+    /// <summary>
     /// Opens the wallet switcher modal when the header wallet button is clicked.
     /// Vue: showWalletModal = true on wallet-selector-header click.
     /// </summary>

--- a/src/design/App/UI/Shell/ShellViewModel.cs
+++ b/src/design/App/UI/Shell/ShellViewModel.cs
@@ -193,6 +193,11 @@ public partial class PrototypeSettings : ReactiveObject
     /// </summary>
     [Reactive] private string? selectedWalletId;
 
+    /// <summary>
+    /// Set of wallet IDs that were auto-created (e.g. 1-click invest) and have not been backed up yet.
+    /// </summary>
+    [Reactive] private HashSet<string> walletsNeedingBackup = new();
+
     public PrototypeSettings(IStore store, ILogger<PrototypeSettings> logger)
     {
         _store = store;
@@ -213,6 +218,7 @@ public partial class PrototypeSettings : ReactiveObject
                     {
                         IsDebugMode = result.Value.IsDebugMode;
                         SelectedWalletId = result.Value.SelectedWalletId;
+                        WalletsNeedingBackup = result.Value.WalletsNeedingBackup ?? new HashSet<string>();
 
                         // Set IsDarkTheme last — its WhenAnyValue subscription
                         // applies the theme, so we want the other fields settled first.
@@ -248,7 +254,7 @@ public partial class PrototypeSettings : ReactiveObject
             });
 
         // Persist after visible state changes so disk I/O never competes with the theme flip.
-        this.WhenAnyValue(x => x.IsDebugMode, x => x.IsDarkTheme, x => x.SelectedWalletId)
+        this.WhenAnyValue(x => x.IsDebugMode, x => x.IsDarkTheme, x => x.SelectedWalletId, x => x.WalletsNeedingBackup)
             .Skip(1)
             .Throttle(TimeSpan.FromMilliseconds(250), RxSchedulers.TaskpoolScheduler)
             .Subscribe(_ => ScheduleSaveSettings());
@@ -263,6 +269,7 @@ public partial class PrototypeSettings : ReactiveObject
         bool currentDebugMode = IsDebugMode;
         bool currentDarkTheme = IsDarkTheme;
         string? currentWalletId = SelectedWalletId;
+        HashSet<string> currentBackupSet = new(WalletsNeedingBackup);
         CancellationToken token = saveSettingsCts.Token;
 
         Task.Run(async () =>
@@ -272,6 +279,7 @@ public partial class PrototypeSettings : ReactiveObject
                 IsDebugMode = currentDebugMode,
                 IsDarkTheme = currentDarkTheme,
                 SelectedWalletId = currentWalletId,
+                WalletsNeedingBackup = currentBackupSet,
             });
 
             if (!token.IsCancellationRequested && saveResult.IsFailure)
@@ -298,6 +306,7 @@ public partial class PrototypeSettings : ReactiveObject
             IsDebugMode = IsDebugMode,
             IsDarkTheme = IsDarkTheme,
             SelectedWalletId = SelectedWalletId,
+            WalletsNeedingBackup = new HashSet<string>(WalletsNeedingBackup),
         });
 
         if (saveResult.IsFailure)
@@ -306,11 +315,30 @@ public partial class PrototypeSettings : ReactiveObject
         }
     }
 
+    /// <summary>Mark a wallet as needing backup (e.g. auto-created during 1-click invest).</summary>
+    public void MarkWalletNeedsBackup(string walletId)
+    {
+        var set = new HashSet<string>(WalletsNeedingBackup) { walletId };
+        WalletsNeedingBackup = set;
+    }
+
+    /// <summary>Clear the backup-needed flag for a wallet (after user backs up).</summary>
+    public void ClearWalletNeedsBackup(string walletId)
+    {
+        var set = new HashSet<string>(WalletsNeedingBackup);
+        set.Remove(walletId);
+        WalletsNeedingBackup = set;
+    }
+
+    /// <summary>Check if a wallet needs backup.</summary>
+    public bool DoesWalletNeedBackup(string walletId) => WalletsNeedingBackup.Contains(walletId);
+
     private class PrototypeSettingsData
     {
         public bool IsDebugMode { get; set; }
         public bool IsDarkTheme { get; set; }
         public string? SelectedWalletId { get; set; }
+        public HashSet<string>? WalletsNeedingBackup { get; set; }
     }
 }
 
@@ -468,6 +496,9 @@ public partial class ShellViewModel : ReactiveObject, IDisposable
     /// <summary>Invested balance display string for the header. Updated from SDK GetTotalInvested.</summary>
     [Reactive] private string investedBalanceDisplay = "0.0000";
 
+    /// <summary>Whether to show the red backup warning banner in the header.</summary>
+    [Reactive] private bool showBackupWarning;
+
     /// <summary>Available balance display string for the header. Uses selected wallet balance.</summary>
     public string AvailableBalanceDisplay =>
         SelectedWallet != null
@@ -556,6 +587,7 @@ public partial class ShellViewModel : ReactiveObject, IDisposable
                 this.RaisePropertyChanged(nameof(AvailableBalanceDisplay));
                 this.RaisePropertyChanged(nameof(SwitcherWallets));
                 _ = LoadTotalInvestedAsync(SelectedWallet);
+                RefreshBackupWarning();
             })
             .DisposeWith(_disposables);
 
@@ -675,6 +707,7 @@ public partial class ShellViewModel : ReactiveObject, IDisposable
         this.RaisePropertyChanged(nameof(SelectedWalletName));
         this.RaisePropertyChanged(nameof(AvailableBalanceDisplay));
         _ = LoadTotalInvestedAsync(wallet);
+        RefreshBackupWarning();
     }
 
     /// <summary>
@@ -1025,6 +1058,16 @@ public partial class ShellViewModel : ReactiveObject, IDisposable
     /// <param name="message">Toast text (e.g. "Copied to clipboard").</param>
     /// <param name="durationMs">Auto-dismiss delay. If 0 or not specified, auto-scales based on message length
     /// (min 3s, +1s per 30 chars, max 10s). Vue: 2000-3000ms for copy, 5000ms for save.</param>
+    /// <summary>
+    /// Refresh the backup warning state based on the selected wallet.
+    /// Called after wallet selection changes or after backup is completed.
+    /// </summary>
+    public void RefreshBackupWarning()
+    {
+        var wallet = _walletContext.SelectedWallet;
+        ShowBackupWarning = wallet != null && _prototypeSettings.DoesWalletNeedBackup(wallet.Id.Value);
+    }
+
     public void ShowToast(string message, int durationMs = 0)
     {
         // Cancel any previous dismiss timer

--- a/src/design/App/UI/Shell/ShellViewModel.cs
+++ b/src/design/App/UI/Shell/ShellViewModel.cs
@@ -1363,29 +1363,69 @@ public partial class ShellViewModel : ReactiveObject, IDisposable
     /// Optional <paramref name="onReuse"/> callback runs when returning an already-cached view
     /// (e.g. to reset sub-navigation state).
     /// </summary>
+    private bool _deferredViewReady;
+
     private object? GetOrCreateView(string key, Action<object>? onReuse = null)
     {
         if (_viewCache.TryGetValue(key, out var existing))
         {
-            var swReuse = Stopwatch.StartNew();
             onReuse?.Invoke(existing);
-            swReuse.Stop();
-            PerfLog("GetOrCreateView", $"key={key} cached=true onReuseMs={swReuse.ElapsedMilliseconds}");
-            return existing;
+            PerfLog("GetOrCreateView", $"key={key} cached=true");
+
+            // On the deferred re-evaluation, return the real view.
+            if (_deferredViewReady)
+            {
+                _deferredViewReady = false;
+                return existing;
+            }
+
+            // Defer swapping the cached view in so the tab highlight animates
+            // instantly without blocking on Avalonia's layout/measure pass.
+            _deferredViewReady = true;
+            Avalonia.Threading.Dispatcher.UIThread.Post(
+                () => this.RaisePropertyChanged(nameof(CurrentSectionContent)),
+                Avalonia.Threading.DispatcherPriority.Background);
+
+            return _loadingPlaceholder ??= CreateLoadingPlaceholder();
         }
 
-        var sw = Stopwatch.StartNew();
-        var view = _viewFactory(key);
-        sw.Stop();
-        PerfLog("GetOrCreateView", $"key={key} cached=false factoryMs={sw.ElapsedMilliseconds}");
-
-        if (view != null)
+        // Return a placeholder immediately and create the view on the
+        // next dispatcher frame so the UI doesn't freeze during DI + XAML inflate.
+        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
         {
-            _viewCache[key] = view;
-            ViewPreWarmed?.Invoke(key, view);
-            AttachRenderTiming(key, view, sw.ElapsedMilliseconds);
-        }
-        return view;
+            if (!_viewCache.ContainsKey(key))
+            {
+                var sw = Stopwatch.StartNew();
+                var view = _viewFactory(key);
+                sw.Stop();
+                PerfLog("GetOrCreateView", $"key={key} cached=false factoryMs={sw.ElapsedMilliseconds}");
+
+                if (view != null)
+                {
+                    _viewCache[key] = view;
+                    ViewPreWarmed?.Invoke(key, view);
+                    AttachRenderTiming(key, view, sw.ElapsedMilliseconds);
+                }
+            }
+            _deferredViewReady = true;
+            this.RaisePropertyChanged(nameof(CurrentSectionContent));
+        }, Avalonia.Threading.DispatcherPriority.Background);
+
+        return _loadingPlaceholder ??= CreateLoadingPlaceholder();
+    }
+
+    private Avalonia.Controls.Control? _loadingPlaceholder;
+
+    private static Avalonia.Controls.Control CreateLoadingPlaceholder()
+    {
+        return new Avalonia.Controls.TextBlock
+        {
+            Text = "Loading…",
+            FontSize = 16,
+            Opacity = 0.5,
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+        };
     }
 
     // ── Perf: programmatic tab switch for adb-driven benchmarks ──

--- a/src/sdk/Angor.Sdk/Wallet/Application/IWalletAppService.cs
+++ b/src/sdk/Angor.Sdk/Wallet/Application/IWalletAppService.cs
@@ -26,4 +26,7 @@ public interface IWalletAppService
     /// <summary>Get the compressed public key hex for a receive address owned by this wallet.
     /// Used as the claim key for Boltz Lightning swaps.</summary>
     Task<Result<string>> GetPublicKeyForAddress(WalletId walletId, string address);
+
+    /// <summary>Retrieve the seed words for an existing wallet (requires unlock/decryption).</summary>
+    Task<Result<string>> GetSeedWords(WalletId walletId);
 }

--- a/src/sdk/Angor.Sdk/Wallet/Infrastructure/Impl/WalletAppService.cs
+++ b/src/sdk/Angor.Sdk/Wallet/Infrastructure/Impl/WalletAppService.cs
@@ -495,4 +495,13 @@ public class WalletAppService(
             return Result.Failure<string>($"Error getting public key: {ex.Message}");
         }
     }
+
+    public async Task<Result<string>> GetSeedWords(WalletId walletId)
+    {
+        var sensitiveDataResult = await sensitiveWalletDataProvider.RequestSensitiveData(walletId);
+        if (sensitiveDataResult.IsFailure)
+            return Result.Failure<string>(sensitiveDataResult.Error);
+
+        return Result.Success(sensitiveDataResult.Value.seed);
+    }
 }


### PR DESCRIPTION
## Summary
- Add spinning animation to Portfolio refresh button while loading data
- Show a loading placeholder during tab switches to eliminate UI freeze on first and subsequent navigations
- Fix log export: chunk large payloads to stay within NIP-44's 65535-byte limit and add missing Blossom authorization header