### PR TITLE
Advanced Editor for Investment Stages + UTC Date Fix

### DIFF
--- a/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
@@ -330,7 +330,7 @@ public partial class CreateProjectViewModel : ReactiveObject
                 this.RaisePropertyChanged(nameof(HasFormError));
                 this.RaisePropertyChanged(nameof(HasEndDateError));
                 // Revalidate all stage release dates against the new end date
-                foreach (var s in Stages) UpdateStageDateError(s);
+                UpdateAllStageDateErrors();
             });
 
         // ── Advanced Editor: subscribe to Stages collection to enable live % total and date validation ──
@@ -1159,9 +1159,9 @@ public partial class CreateProjectViewModel : ReactiveObject
             .Subscribe(_ => RaiseAdvancedEditorTotals())
             .DisposeWith(d);
         stage.WhenAnyValue(x => x.ReleaseDateValue)
-            .Subscribe(_ => UpdateStageDateError(stage))
+            .Subscribe(_ => UpdateAllStageDateErrors())
             .DisposeWith(d);
-        UpdateStageDateError(stage); // validate immediately on add
+        UpdateAllStageDateErrors(); // validate immediately on add
         _stageDisposables[stage] = d;
     }
 
@@ -1174,17 +1174,38 @@ public partial class CreateProjectViewModel : ReactiveObject
         }
     }
 
-    private void UpdateStageDateError(ProjectStageViewModel stage)
+    private void UpdateAllStageDateErrors()
     {
-        if (InvestEndDate.HasValue && stage.ReleaseDateValue != default)
+        var ordered = Stages.OrderBy(s => s.StageNumber).ToList();
+        DateOnly? endDate = InvestEndDate.HasValue ? DateOnly.FromDateTime(InvestEndDate.Value) : null;
+
+        for (int i = 0; i < ordered.Count; i++)
         {
-            var endDate = DateOnly.FromDateTime(InvestEndDate.Value);
-            stage.ReleaseDateError = stage.ReleaseDateValue < endDate
-                ? $"Must be on or after {endDate:dd MMM yyyy}"
-                : "";
-        }
-        else
-        {
+            var stage = ordered[i];
+            if (stage.ReleaseDateValue == default)
+            {
+                stage.ReleaseDateError = "";
+                continue;
+            }
+
+            // Rule 1: must be on or after funding end date
+            if (endDate.HasValue && stage.ReleaseDateValue < endDate.Value)
+            {
+                stage.ReleaseDateError = $"Must be on or after {endDate.Value:dd MMM yyyy}";
+                continue;
+            }
+
+            // Rule 2: must be after the previous stage's date
+            if (i > 0)
+            {
+                var prev = ordered[i - 1];
+                if (prev.ReleaseDateValue != default && stage.ReleaseDateValue <= prev.ReleaseDateValue)
+                {
+                    stage.ReleaseDateError = $"Must be after Stage {prev.StageNumber} ({prev.ReleaseDateValue:dd MMM yyyy})";
+                    continue;
+                }
+            }
+
             stage.ReleaseDateError = "";
         }
 

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
@@ -1129,6 +1129,9 @@ public partial class CreateProjectViewModel : ReactiveObject
             ? "Total: 100% ✓"
             : $"Total: {AdvancedEditorTotalPct:F0}%  —  needs {Math.Max(0, 100 - AdvancedEditorTotalPct):F0}% more";
 
+    /// <summary>True when at least one stage has a date validation error — drives the guidelines banner.</summary>
+    public bool HasAnyDateError => Stages.Any(s => s.HasDateError);
+
     private void OnStagesCollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
         if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
@@ -1184,6 +1187,9 @@ public partial class CreateProjectViewModel : ReactiveObject
         {
             stage.ReleaseDateError = "";
         }
+
+        // Refresh the banner that shows when any stage has a date error
+        this.RaisePropertyChanged(nameof(HasAnyDateError));
     }
 
     private void RaiseAdvancedEditorTotals()
@@ -1192,6 +1198,7 @@ public partial class CreateProjectViewModel : ReactiveObject
         this.RaisePropertyChanged(nameof(AdvancedEditorTotalIsComplete));
         this.RaisePropertyChanged(nameof(AdvancedEditorTotalIsIncomplete));
         this.RaisePropertyChanged(nameof(AdvancedEditorTotalLabel));
+        this.RaisePropertyChanged(nameof(HasAnyDateError));
     }
 
     /// <summary>Re-show the generate form to regenerate stages (without clearing existing ones first).</summary>

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
@@ -22,29 +22,54 @@ public record DurationPresetItem(int Value, string Label);
 /// A stage in the project's release/payout schedule.
 /// Generated from the payout pattern selection.
 /// </summary>
-public class ProjectStageViewModel
+public partial class ProjectStageViewModel : ReactiveObject
 {
-    public int StageNumber { get; set; }
-    public string Percentage { get; set; } = "0%";
-    public string ReleaseDate { get; set; } = "";
-    public string AmountBtc { get; set; } = "0.00000000";
+    // [Reactive] generates the public PascalCase property for each field via source generator.
+    // Do NOT manually re-declare those properties — the generator would produce duplicate definitions.
+    [Reactive] private int stageNumber;
+    [Reactive] private string percentage = "0%";
+    [Reactive] private string releaseDate = "";
+    [Reactive] private string amountBtc = "0.00000000";
 
     /// <summary>
     /// The actual typed release date used for deployment.
     /// This is the source of truth — <see cref="ReleaseDate"/> is only for display.
     /// </summary>
-    public DateOnly ReleaseDateValue { get; set; }
+    [Reactive] private DateOnly releaseDateValue;
 
     /// <summary>Label for this stage row — "Stage", "Monthly Payout", "Weekly Payout", "Payment", etc.</summary>
-    public string StageLabel { get; set; } = "Stage";
+    [Reactive] private string stageLabel = "Stage";
 
     /// <summary>
     /// Pre-formatted display text for the right side of the stage row.
     /// Investment: "8% (0.0800 BTC) released on 28th April 2026"
     /// Fund/Sub: "33% paid on 28th April 2026"
     /// </summary>
-    public string DisplayText { get; set; } = "";
-    public double PercentageValue { get; set; }
+    [Reactive] private string displayText = "";
+    [Reactive] private double percentageValue;
+
+    /// <summary>
+    /// CalendarDatePicker bridge — converts between DateOnly (domain) and DateTime? (Avalonia control).
+    /// The source generator does NOT generate this — it is hand-written.
+    /// Setting this updates <see cref="ReleaseDateValue"/> (source of truth) and <see cref="ReleaseDate"/> (display string).
+    /// </summary>
+    public DateTime? ReleaseDateAsDateTime
+    {
+        get => ReleaseDateValue == default
+            ? null
+            : ReleaseDateValue.ToDateTime(TimeOnly.MinValue);
+        set
+        {
+            var incoming = value.HasValue
+                ? DateOnly.FromDateTime(value.Value)
+                : DateOnly.MinValue;
+            if (ReleaseDateValue == incoming) return;
+            ReleaseDateValue = incoming;
+            if (value.HasValue)
+                ReleaseDate = ReleaseDateValue.ToString("dd MMMM yyyy");
+            this.RaisePropertyChanged();
+        }
+    }
 }
 
 /// <summary>
@@ -1012,7 +1037,16 @@ public partial class CreateProjectViewModel : ReactiveObject
     public void ToggleAdvancedEditor()
     {
         IsAdvancedEditor = !IsAdvancedEditor;
+        this.RaisePropertyChanged(nameof(IsNotAdvancedEditor));
+        this.RaisePropertyChanged(nameof(AdvancedEditorButtonText));
+        this.RaisePropertyChanged(nameof(IsAdvancedEditorVisible));
     }
+
+    /// <summary>
+    /// True when Advanced Editor should actually be shown — requires IsAdvancedEditor AND IsInvestment.
+    /// Fund/Subscription use their own payout schedule and don't support the advanced stage editor.
+    /// </summary>
+    public bool IsAdvancedEditorVisible => IsAdvancedEditor && IsInvestment;
 
     /// <summary>Re-show the generate form to regenerate stages (without clearing existing ones first).</summary>
     public void ShowRegenerateForm()

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
@@ -24,8 +24,6 @@ public record DurationPresetItem(int Value, string Label);
 /// </summary>
 public partial class ProjectStageViewModel : ReactiveObject
 {
-    // [Reactive] generates the public PascalCase property for each field via source generator.
-    // Do NOT manually re-declare those properties — the generator would produce duplicate definitions.
     [Reactive] private int stageNumber;
     [Reactive] private string percentage = "0%";
     [Reactive] private string releaseDate = "";
@@ -633,6 +631,7 @@ public partial class CreateProjectViewModel : ReactiveObject
         this.RaisePropertyChanged(nameof(IsFund));
         this.RaisePropertyChanged(nameof(IsSubscription));
         this.RaisePropertyChanged(nameof(IsTypeSelected));
+        this.RaisePropertyChanged(nameof(IsAdvancedEditorVisible));
         this.RaisePropertyChanged(nameof(StepNames));
         this.RaisePropertyChanged(nameof(Step4Title));
         this.RaisePropertyChanged(nameof(Step5Title));
@@ -1032,6 +1031,9 @@ public partial class CreateProjectViewModel : ReactiveObject
             Stages[i].StageNumber = i + 1;
         this.RaisePropertyChanged(nameof(HasStages));
         this.RaisePropertyChanged(nameof(ScheduleSummary));
+
+        if (Stages.Count == 0)
+            ShowGenerateForm = true;
     }
 
     public void ToggleAdvancedEditor()

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
@@ -46,6 +46,49 @@ public partial class ProjectStageViewModel : ReactiveObject
     [Reactive] private string displayText = "";
     [Reactive] private double percentageValue;
 
+    // ── Advanced Editor validation state ──
+    /// <summary>True when PercentageValue is 0 (stage has no allocation). Kept in sync by constructor subscription.</summary>
+    [Reactive] private bool hasPercentageError = true;
+
+    /// <summary>Non-empty when the release date is before the project's funding end date. Set by parent VM.</summary>
+    [Reactive] private string releaseDateError = "";
+
+    /// <summary>True when <see cref="ReleaseDateError"/> contains a message.</summary>
+    public bool HasDateError => !string.IsNullOrEmpty(ReleaseDateError);
+
+    public ProjectStageViewModel()
+    {
+        // Keep Percentage string and HasPercentageError in sync whenever PercentageValue changes.
+        // Skip(1) avoids the immediate false-positive error on construction (value is 0 before
+        // the object initializer has had a chance to set PercentageValue to the real value).
+        this.WhenAnyValue(x => x.PercentageValue)
+            .Skip(1)
+            .Subscribe(pct =>
+            {
+                Percentage = $"{pct:F0}%";
+                HasPercentageError = pct <= 0;
+                this.RaisePropertyChanged(nameof(PercentageDecimal));
+            });
+
+        // HasDateError is a computed string→bool, raise it whenever ReleaseDateError changes.
+        this.WhenAnyValue(x => x.ReleaseDateError)
+            .Subscribe(_ => this.RaisePropertyChanged(nameof(HasDateError)));
+    }
+
+    /// <summary>
+    /// Decimal bridge for NumericUpDown (Avalonia Value is decimal?) — converts to/from PercentageValue (double).
+    /// This avoids a double→decimal? type-mismatch binding error at runtime.
+    /// </summary>
+    public decimal? PercentageDecimal
+    {
+        get => PercentageValue <= 0 ? null : (decimal)PercentageValue;
+        set
+        {
+            PercentageValue = (double)(value ?? 0);
+            this.RaisePropertyChanged();
+        }
+    }
+
     /// <summary>
     /// CalendarDatePicker bridge — converts between DateOnly (domain) and DateTime? (Avalonia control).
     /// The source generator does NOT generate this — it is hand-written.
@@ -55,7 +98,7 @@ public partial class ProjectStageViewModel : ReactiveObject
     {
         get => ReleaseDateValue == default
             ? null
-            : ReleaseDateValue.ToDateTime(TimeOnly.MinValue);
+            : ReleaseDateValue.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
         set
         {
             var incoming = value.HasValue
@@ -176,6 +219,9 @@ public partial class CreateProjectViewModel : ReactiveObject
     private readonly IWalletContext _walletContext;
     private bool _isLoadingDraft;
 
+    /// <summary>Per-stage subscriptions for the Advanced Editor live-total and date validation.</summary>
+    private readonly Dictionary<ProjectStageViewModel, CompositeDisposable> _stageDisposables = new();
+
     /// <summary>
     /// True when debug mode is enabled AND on testnet.
     /// Controls visibility of the "Debug Prefill Data" button in Step 2.
@@ -283,7 +329,12 @@ public partial class CreateProjectViewModel : ReactiveObject
                 EndDateError = "";
                 this.RaisePropertyChanged(nameof(HasFormError));
                 this.RaisePropertyChanged(nameof(HasEndDateError));
+                // Revalidate all stage release dates against the new end date
+                foreach (var s in Stages) UpdateStageDateError(s);
             });
+
+        // ── Advanced Editor: subscribe to Stages collection to enable live % total and date validation ──
+        Stages.CollectionChanged += OnStagesCollectionChanged;
 
         // ── Auto-save draft on any user input change (debounced) ──
         Observable.Merge(
@@ -712,11 +763,17 @@ public partial class CreateProjectViewModel : ReactiveObject
                 $"Unknown project type '{ProjectType}'. Cannot deploy project with an unrecognized type.")
         };
 
-        // Parse dates
-        if (!DateTime.TryParse(StartDate, out var startDt))
+        // Parse dates — always specify UTC so ToUniversalTime() in the JSON serializer is a no-op.
+        // DateTime.TryParse on a date-only string (e.g. "2026-05-18") produces DateTimeKind.Unspecified,
+        // which ToUniversalTime() treats as local → subtracts UTC offset → off by 1 day for non-UTC users.
+        if (!DateTime.TryParse(StartDate, out var startDtRaw))
             throw new InvalidOperationException(
                 $"Invalid start date '{StartDate}'. Cannot deploy project without a valid start date.");
-        DateTime? endDt = DateTime.TryParse(EndDate, out var ed) ? ed : null;
+        var startDt = DateTime.SpecifyKind(startDtRaw, DateTimeKind.Utc);
+
+        DateTime? endDt = null;
+        if (DateTime.TryParse(EndDate, out var endDtRaw))
+            endDt = DateTime.SpecifyKind(endDtRaw, DateTimeKind.Utc);
 
         // Build stages from the wizard's generated Stages collection
         var stageDtos = Stages.Select((s, i) =>
@@ -874,7 +931,7 @@ public partial class CreateProjectViewModel : ReactiveObject
             Stages.Add(new ProjectStageViewModel
             {
                 StageNumber = i + 1,
-                Percentage = $"{pct}%",
+                PercentageValue = pct,
                 ReleaseDate = FormatReleaseDateOrdinal(releaseDate),
                 ReleaseDateValue = DateOnly.FromDateTime(releaseDate),
                 AmountBtc = btcAmount.ToString("F4"),
@@ -936,7 +993,7 @@ public partial class CreateProjectViewModel : ReactiveObject
             Stages.Add(new ProjectStageViewModel
             {
                 StageNumber = i + 1,
-                Percentage = $"{pct}%",
+                PercentageValue = pct,
                 ReleaseDate = FormatReleaseDateOrdinal(releaseDate),
                 ReleaseDateValue = DateOnly.FromDateTime(releaseDate),
                 AmountBtc = (targetBtc * pct / 100).ToString("F4"),
@@ -1006,12 +1063,14 @@ public partial class CreateProjectViewModel : ReactiveObject
     public void AddStage()
     {
         var nextNum = Stages.Count + 1;
+        // Default percentage = whatever's left to reach 100, so the total badge stays clean
+        var usedPct = Stages.Sum(s => s.PercentageValue);
+        var defaultPct = Math.Max(0, 100 - usedPct);
+
         var stage = new ProjectStageViewModel
         {
             StageNumber = nextNum,
-            Percentage = "0%",
-            PercentageValue = 0,
-            ReleaseDate = "",
+            PercentageValue = defaultPct,
             ReleaseDateValue = DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(nextNum)),
             StageLabel = IsInvestment ? "Stage" : "Payout",
             DisplayText = ""
@@ -1049,6 +1108,91 @@ public partial class CreateProjectViewModel : ReactiveObject
     /// Fund/Subscription use their own payout schedule and don't support the advanced stage editor.
     /// </summary>
     public bool IsAdvancedEditorVisible => IsAdvancedEditor && IsInvestment;
+
+    // ── Advanced Editor: live % total ──
+
+    /// <summary>Sum of all stage PercentageValues. Updates live as the user edits stages.</summary>
+    public double AdvancedEditorTotalPct => Stages.Sum(s => s.PercentageValue);
+
+    /// <summary>True when stage percentages sum to 100 (within ±0.5 rounding tolerance).</summary>
+    public bool AdvancedEditorTotalIsComplete => Math.Abs(AdvancedEditorTotalPct - 100.0) < 0.5;
+
+    /// <summary>Inverse of <see cref="AdvancedEditorTotalIsComplete"/> — used for AXAML IsVisible.</summary>
+    public bool AdvancedEditorTotalIsIncomplete => !AdvancedEditorTotalIsComplete;
+
+    /// <summary>
+    /// Human-readable total % label shown below the stage list.
+    /// E.g. "Total: 75% — needs 25% more" or "Total: 100% ✓"
+    /// </summary>
+    public string AdvancedEditorTotalLabel =>
+        AdvancedEditorTotalIsComplete
+            ? "Total: 100% ✓"
+            : $"Total: {AdvancedEditorTotalPct:F0}%  —  needs {Math.Max(0, 100 - AdvancedEditorTotalPct):F0}% more";
+
+    private void OnStagesCollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
+        {
+            // Clear() fires Reset — dispose all tracked subscriptions
+            foreach (var d in _stageDisposables.Values) d.Dispose();
+            _stageDisposables.Clear();
+        }
+        else
+        {
+            if (e.NewItems != null)
+                foreach (ProjectStageViewModel stage in e.NewItems)
+                    SubscribeToStage(stage);
+            if (e.OldItems != null)
+                foreach (ProjectStageViewModel stage in e.OldItems)
+                    UnsubscribeFromStage(stage);
+        }
+        RaiseAdvancedEditorTotals();
+    }
+
+    private void SubscribeToStage(ProjectStageViewModel stage)
+    {
+        var d = new CompositeDisposable();
+        stage.WhenAnyValue(x => x.PercentageValue)
+            .Subscribe(_ => RaiseAdvancedEditorTotals())
+            .DisposeWith(d);
+        stage.WhenAnyValue(x => x.ReleaseDateValue)
+            .Subscribe(_ => UpdateStageDateError(stage))
+            .DisposeWith(d);
+        UpdateStageDateError(stage); // validate immediately on add
+        _stageDisposables[stage] = d;
+    }
+
+    private void UnsubscribeFromStage(ProjectStageViewModel stage)
+    {
+        if (_stageDisposables.TryGetValue(stage, out var d))
+        {
+            d.Dispose();
+            _stageDisposables.Remove(stage);
+        }
+    }
+
+    private void UpdateStageDateError(ProjectStageViewModel stage)
+    {
+        if (InvestEndDate.HasValue && stage.ReleaseDateValue != default)
+        {
+            var endDate = DateOnly.FromDateTime(InvestEndDate.Value);
+            stage.ReleaseDateError = stage.ReleaseDateValue < endDate
+                ? $"Must be on or after {endDate:dd MMM yyyy}"
+                : "";
+        }
+        else
+        {
+            stage.ReleaseDateError = "";
+        }
+    }
+
+    private void RaiseAdvancedEditorTotals()
+    {
+        this.RaisePropertyChanged(nameof(AdvancedEditorTotalPct));
+        this.RaisePropertyChanged(nameof(AdvancedEditorTotalIsComplete));
+        this.RaisePropertyChanged(nameof(AdvancedEditorTotalIsIncomplete));
+        this.RaisePropertyChanged(nameof(AdvancedEditorTotalLabel));
+    }
 
     /// <summary>Re-show the generate form to regenerate stages (without clearing existing ones first).</summary>
     public void ShowRegenerateForm()
@@ -1159,7 +1303,7 @@ public partial class CreateProjectViewModel : ReactiveObject
             Stages.Add(new ProjectStageViewModel
             {
                 StageNumber = i + 1,
-                Percentage = $"{pct}%",
+                PercentageValue = pct,
                 ReleaseDate = FormatReleaseDateOrdinal(releaseDate),
                 ReleaseDateValue = DateOnly.FromDateTime(releaseDate),
                 AmountBtc = (targetBtc * pct / 100).ToString("F4"),
@@ -1520,7 +1664,7 @@ public partial class CreateProjectViewModel : ReactiveObject
         Stages.Add(new ProjectStageViewModel
         {
             StageNumber = 1,
-            Percentage = "10%",
+            PercentageValue = 10,
             ReleaseDate = FormatReleaseDateOrdinal(today),
             ReleaseDateValue = DateOnly.FromDateTime(today),
             AmountBtc = (targetBtc * 0.10).ToString("F4"),
@@ -1530,7 +1674,7 @@ public partial class CreateProjectViewModel : ReactiveObject
         Stages.Add(new ProjectStageViewModel
         {
             StageNumber = 2,
-            Percentage = "30%",
+            PercentageValue = 30,
             ReleaseDate = FormatReleaseDateOrdinal(stage2Date),
             ReleaseDateValue = DateOnly.FromDateTime(stage2Date),
             AmountBtc = (targetBtc * 0.30).ToString("F4"),
@@ -1540,7 +1684,7 @@ public partial class CreateProjectViewModel : ReactiveObject
         Stages.Add(new ProjectStageViewModel
         {
             StageNumber = 3,
-            Percentage = "60%",
+            PercentageValue = 60,
             ReleaseDate = FormatReleaseDateOrdinal(stage3Date),
             ReleaseDateValue = DateOnly.FromDateTime(stage3Date),
             AmountBtc = (targetBtc * 0.60).ToString("F4"),

--- a/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep5View.axaml
+++ b/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep5View.axaml
@@ -528,6 +528,95 @@
             </StackPanel>
         </Panel>
 
+        <!-- ─── ADVANCED EDITOR (Investment only) ─── -->
+        <!-- Shown when IsAdvancedEditorVisible=true (IsAdvancedEditor AND IsInvestment). -->
+        <!-- AddStageButton / RemoveStageButton names bubble up to CreateProjectView.axaml.cs handlers. -->
+        <Border CornerRadius="12" BorderBrush="{DynamicResource Stroke}" BorderThickness="1"
+                Background="{DynamicResource Surface}" ClipToBounds="True"
+                IsVisible="{Binding IsAdvancedEditorVisible}">
+            <StackPanel Spacing="0">
+                <!-- Header -->
+                <Border Background="{DynamicResource SurfaceMedium}" CornerRadius="11,11,0,0" Padding="20,16">
+                    <TextBlock Text="Edit Stage Schedule" FontSize="16" FontWeight="Bold"
+                               Foreground="{DynamicResource TextStrong}" />
+                </Border>
+
+                <!-- Stage rows — editable percentage + date picker + remove -->
+                <ItemsControl ItemsSource="{Binding Stages}" Margin="20,16,20,4">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="mp:ProjectStageViewModel">
+                            <Border Padding="14,12" Margin="0,0,0,10" CornerRadius="10"
+                                    BorderBrush="{DynamicResource Stroke}" BorderThickness="1"
+                                    Background="{DynamicResource SurfaceHover}">
+                                <Grid ColumnDefinitions="Auto,*,*,Auto" ColumnSpacing="12">
+                                    <!-- Stage number badge -->
+                                    <Border Grid.Column="0" Width="36" Height="36" CornerRadius="18"
+                                            Background="{DynamicResource Accent}" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding StageNumber}" FontSize="14" FontWeight="Bold"
+                                                   Foreground="White"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                    </Border>
+
+                                    <!-- Percentage input -->
+                                    <StackPanel Grid.Column="1" Spacing="4" VerticalAlignment="Center">
+                                        <TextBlock Text="Percentage" FontSize="11" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource TextMuted}" />
+                                        <TextBox Text="{Binding Percentage, Mode=TwoWay}"
+                                                 Watermark="e.g. 25%"
+                                                 FontSize="14" Padding="10,8" CornerRadius="8" />
+                                    </StackPanel>
+
+                                    <!-- Release date picker -->
+                                    <StackPanel Grid.Column="2" Spacing="4" VerticalAlignment="Center">
+                                        <TextBlock Text="Release Date" FontSize="11" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource TextMuted}" />
+                                        <CalendarDatePicker
+                                            SelectedDate="{Binding ReleaseDateAsDateTime, Mode=TwoWay}"
+                                            FontSize="14" HorizontalAlignment="Stretch" />
+                                    </StackPanel>
+
+                                    <!-- Remove button -->
+                                    <Button Grid.Column="3" Name="RemoveStageButton"
+                                            Tag="{Binding}"
+                                            Background="Transparent"
+                                            BorderBrush="{DynamicResource ErrorBannerBorder}" BorderThickness="1"
+                                            CornerRadius="8" Padding="10,8"
+                                            VerticalAlignment="Center">
+                                        <i:Icon Value="fa-solid fa-trash" FontSize="14"
+                                                Foreground="{DynamicResource ErrorBannerText}" />
+                                    </Button>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <!-- Add Stage button -->
+                <Button Name="AddStageButton" Margin="20,0,20,12"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
+                        Background="Transparent"
+                        BorderBrush="{DynamicResource Stroke}" BorderThickness="1"
+                        CornerRadius="10" Padding="16,12" FontSize="14"
+                        Foreground="{DynamicResource TextMuted}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <i:Icon Value="fa-solid fa-plus" FontSize="14" />
+                        <TextBlock Text="Add Another Stage" FontSize="14" />
+                    </StackPanel>
+                </Button>
+
+                <!-- Stage guidelines -->
+                <Border Margin="20,0,20,16" Padding="12" CornerRadius="8"
+                        Background="#fffbeb" BorderBrush="#fde68a" BorderThickness="1">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <i:Icon Value="fa-solid fa-circle-info" FontSize="14" Foreground="#d97706"
+                                VerticalAlignment="Top" Margin="0,2,0,0" />
+                        <TextBlock FontSize="12" Foreground="#d97706" TextWrapping="Wrap"
+                                   Text="Stages must add up to 100%. Each release date must be after the funding end date." />
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
         <!-- Generated Stages/Payouts Card (shared by all types, read-only mode) — AngorApp pattern -->
         <Border CornerRadius="12" BorderBrush="{DynamicResource Accent}" BorderThickness="1"
                 Background="{DynamicResource BrandWash}" ClipToBounds="True"

--- a/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep5View.axaml
+++ b/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep5View.axaml
@@ -528,9 +528,7 @@
             </StackPanel>
         </Panel>
 
-        <!-- ─── ADVANCED EDITOR (Investment only) ─── -->
-        <!-- Shown when IsAdvancedEditorVisible=true (IsAdvancedEditor AND IsInvestment). -->
-        <!-- AddStageButton / RemoveStageButton names bubble up to CreateProjectView.axaml.cs handlers. -->
+        <!-- ─── Advanced Editor -->
         <Border CornerRadius="12" BorderBrush="{DynamicResource Stroke}" BorderThickness="1"
                 Background="{DynamicResource Surface}" ClipToBounds="True"
                 IsVisible="{Binding IsAdvancedEditorVisible}">

--- a/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep5View.axaml
+++ b/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep5View.axaml
@@ -543,51 +543,87 @@
                 <ItemsControl ItemsSource="{Binding Stages}" Margin="20,16,20,4">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate x:DataType="mp:ProjectStageViewModel">
-                            <Border Padding="14,12" Margin="0,0,0,10" CornerRadius="10"
+                            <!-- Outer wrapper clips to rounded corners -->
+                            <Border Margin="0,0,0,10" CornerRadius="10" ClipToBounds="True"
                                     BorderBrush="{DynamicResource Stroke}" BorderThickness="1"
                                     Background="{DynamicResource SurfaceHover}">
-                                <Grid ColumnDefinitions="Auto,*,*,Auto" ColumnSpacing="12">
-                                    <!-- Stage number badge -->
-                                    <Border Grid.Column="0" Width="36" Height="36" CornerRadius="18"
-                                            Background="{DynamicResource Accent}" VerticalAlignment="Center">
-                                        <TextBlock Text="{Binding StageNumber}" FontSize="14" FontWeight="Bold"
-                                                   Foreground="White"
-                                                   HorizontalAlignment="Center" VerticalAlignment="Center" />
-                                    </Border>
+                                <StackPanel>
+                                    <Grid ColumnDefinitions="Auto,*,*,Auto" ColumnSpacing="12" Margin="14,12,14,12">
+                                        <!-- Stage number badge -->
+                                        <Border Grid.Column="0" Width="36" Height="36" CornerRadius="18"
+                                                Background="{DynamicResource Accent}" VerticalAlignment="Top" Margin="0,4,0,0">
+                                            <TextBlock Text="{Binding StageNumber}" FontSize="14" FontWeight="Bold"
+                                                       Foreground="White"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Border>
 
-                                    <!-- Percentage input -->
-                                    <StackPanel Grid.Column="1" Spacing="4" VerticalAlignment="Center">
-                                        <TextBlock Text="Percentage" FontSize="11" FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource TextMuted}" />
-                                        <TextBox Text="{Binding Percentage, Mode=TwoWay}"
-                                                 Watermark="e.g. 25%"
-                                                 FontSize="14" Padding="10,8" CornerRadius="8" />
-                                    </StackPanel>
+                                        <!-- Percentage — NumericUpDown bound to decimal? bridge (avoids double↔decimal? mismatch) -->
+                                        <StackPanel Grid.Column="1" Spacing="4">
+                                            <TextBlock Text="Percentage %" FontSize="11" FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource TextMuted}" />
+                                            <NumericUpDown Value="{Binding PercentageDecimal, Mode=TwoWay}"
+                                                           Minimum="0" Maximum="100"
+                                                           Increment="1" FormatString="0"
+                                                           FontSize="14" />
+                                            <TextBlock Text="Must be greater than 0" FontSize="11"
+                                                       Foreground="#ef4444"
+                                                       IsVisible="{Binding HasPercentageError}" />
+                                        </StackPanel>
 
-                                    <!-- Release date picker -->
-                                    <StackPanel Grid.Column="2" Spacing="4" VerticalAlignment="Center">
-                                        <TextBlock Text="Release Date" FontSize="11" FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource TextMuted}" />
-                                        <CalendarDatePicker
-                                            SelectedDate="{Binding ReleaseDateAsDateTime, Mode=TwoWay}"
-                                            FontSize="14" HorizontalAlignment="Stretch" />
-                                    </StackPanel>
+                                        <!-- Release date picker + inline error -->
+                                        <StackPanel Grid.Column="2" Spacing="4">
+                                            <TextBlock Text="Release Date" FontSize="11" FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource TextMuted}" />
+                                            <CalendarDatePicker
+                                                SelectedDate="{Binding ReleaseDateAsDateTime, Mode=TwoWay}"
+                                                FontSize="14" HorizontalAlignment="Stretch" />
+                                            <TextBlock Text="{Binding ReleaseDateError}" FontSize="11"
+                                                       Foreground="#ef4444" TextWrapping="Wrap"
+                                                       IsVisible="{Binding HasDateError}" />
+                                        </StackPanel>
 
-                                    <!-- Remove button -->
-                                    <Button Grid.Column="3" Name="RemoveStageButton"
-                                            Tag="{Binding}"
-                                            Background="Transparent"
-                                            BorderBrush="{DynamicResource ErrorBannerBorder}" BorderThickness="1"
-                                            CornerRadius="8" Padding="10,8"
-                                            VerticalAlignment="Center">
-                                        <i:Icon Value="fa-solid fa-trash" FontSize="14"
-                                                Foreground="{DynamicResource ErrorBannerText}" />
-                                    </Button>
-                                </Grid>
+                                        <!-- Remove button -->
+                                        <Button Grid.Column="3" Name="RemoveStageButton"
+                                                Tag="{Binding}"
+                                                Background="Transparent"
+                                                BorderBrush="{DynamicResource ErrorBannerBorder}" BorderThickness="1"
+                                                CornerRadius="8" Padding="10,8"
+                                                VerticalAlignment="Top" Margin="0,20,0,0">
+                                            <i:Icon Value="fa-solid fa-trash" FontSize="14"
+                                                    Foreground="{DynamicResource ErrorBannerText}" />
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                             </Border>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
+
+                <!-- Live % total badge -->
+                <Panel Margin="20,0,20,8">
+                    <!-- Complete: green -->
+                    <Border IsVisible="{Binding AdvancedEditorTotalIsComplete}"
+                            Padding="12,10" CornerRadius="8"
+                            Background="#f0fdf4" BorderBrush="#86efac" BorderThickness="1">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <i:Icon Value="fa-solid fa-circle-check" FontSize="14" Foreground="#16a34a"
+                                    VerticalAlignment="Center" />
+                            <TextBlock Text="{Binding AdvancedEditorTotalLabel}" FontSize="13" FontWeight="SemiBold"
+                                       Foreground="#16a34a" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Border>
+                    <!-- Incomplete: amber -->
+                    <Border IsVisible="{Binding AdvancedEditorTotalIsIncomplete}"
+                            Padding="12,10" CornerRadius="8"
+                            Background="#fffbeb" BorderBrush="#fde68a" BorderThickness="1">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <i:Icon Value="fa-solid fa-circle-exclamation" FontSize="14" Foreground="#d97706"
+                                    VerticalAlignment="Center" />
+                            <TextBlock Text="{Binding AdvancedEditorTotalLabel}" FontSize="13" FontWeight="SemiBold"
+                                       Foreground="#d97706" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Border>
+                </Panel>
 
                 <!-- Add Stage button -->
                 <Button Name="AddStageButton" Margin="20,0,20,12"
@@ -609,7 +645,7 @@
                         <i:Icon Value="fa-solid fa-circle-info" FontSize="14" Foreground="#d97706"
                                 VerticalAlignment="Top" Margin="0,2,0,0" />
                         <TextBlock FontSize="12" Foreground="#d97706" TextWrapping="Wrap"
-                                   Text="Stages must add up to 100%. Each release date must be after the funding end date." />
+                                   Text="Each release date must be after the funding end date." />
                     </StackPanel>
                 </Border>
             </StackPanel>

--- a/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep5View.axaml
+++ b/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep5View.axaml
@@ -638,11 +638,12 @@
                     </StackPanel>
                 </Button>
 
-                <!-- Stage guidelines -->
+                <!-- Stage guidelines: only shown when at least one stage has a date error -->
                 <Border Margin="20,0,20,16" Padding="12" CornerRadius="8"
-                        Background="#fffbeb" BorderBrush="#fde68a" BorderThickness="1">
+                        Background="#fffbeb" BorderBrush="#fde68a" BorderThickness="1"
+                        IsVisible="{Binding HasAnyDateError}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <i:Icon Value="fa-solid fa-circle-info" FontSize="14" Foreground="#d97706"
+                        <i:Icon Value="fa-solid fa-triangle-exclamation" FontSize="14" Foreground="#d97706"
                                 VerticalAlignment="Top" Margin="0,2,0,0" />
                         <TextBlock FontSize="12" Foreground="#d97706" TextWrapping="Wrap"
                                    Text="Each release date must be after the funding end date." />

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectInfo.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectInfo.cs
@@ -100,14 +100,14 @@ public static class CreateProjectInfo
                         }
 
                         projectInfo.EndDate = project.EndDate ?? throw new InvalidOperationException("End date is required for Invest projects");
-                        projectInfo.ExpiryDate = project.ExpiryDate ?? project.Stages.OrderByDescending(x => x.startDate).First().startDate.AddMonths(2).ToDateTime(TimeOnly.MinValue);
+                        projectInfo.ExpiryDate = project.ExpiryDate ?? project.Stages.OrderByDescending(x => x.startDate).First().startDate.AddMonths(2).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
                         projectInfo.PenaltyDays = project.PenaltyDays;
                         projectInfo.PenaltyThreshold = project.PenaltyThreshold;
                         projectInfo.TargetAmount = project.TargetAmount.Sats;
                         projectInfo.Stages = project.Stages.Select(stage => new Stage
                         {
                             AmountToRelease = stage.PercentageOfTotal,
-                            ReleaseDate = stage.startDate.ToDateTime(TimeOnly.MinValue),
+                            ReleaseDate = stage.startDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
                         }).ToList();
                         break;
                     }


### PR DESCRIPTION
**Issues fixed:**

1. "Advanced Editor" button in Step 5 did nothing — no UI existed behind the toggle
2. Project dates (start, end, stage release) stored 1 day behind for users in non-UTC timezones

 
**What changed:**
1. Advanced Editor (Create Project -> Step 5)
2. Built the Advanced Editor UI: editable stage rows with NumericUpDown for %, CalendarDatePicker for release date, add/remove stage buttons
3. Live "Total: X% — needs Y% more" badge updates as user edits percentages
4. Inline error shown when a stage has 0% or a date before the funding end date
5. New stages default to the remaining % needed to reach 100 instead of 0
6. Removing all stages via the editor re-shows the generate form so the user isn't stuck
7. UTC timezone fix
8. Root cause: DateTime.TryParse and DateOnly.ToDateTime(TimeOnly.MinValue) both produce DateTimeKind.Unspecified; the JSON serializer calls .ToUniversalTime() which treats Unspecified as local time and subtracts the UTC offset — shifting all dates back by the user's UTC offset
9. Fixed by explicitly setting DateTimeKind.Utc on StartDate, EndDate, and all stage ReleaseDate values before passing to the SDK