### PR TITLE
Polish mobile project browsing UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,6 +405,7 @@ FodyWeavers.xsd
 
 # AI task notes
 ai-tasks/
+RESUME.md
 
 # Windows reserved device names
 nul

--- a/src/design/App/Composition/CompositionRoot.cs
+++ b/src/design/App/Composition/CompositionRoot.cs
@@ -120,7 +120,7 @@ public static class CompositionRoot
         {
             if (OperatingSystem.IsWindows())
                 services.AddSingleton<ISecureKeyProvider, DpapiSecureKeyProvider>();
-            else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+            else if (OperatingSystem.IsLinux())
                 services.AddSingleton<ISecureKeyProvider, LinuxSecureKeyProvider>();
             else
                 throw new PlatformNotSupportedException("No ISecureKeyProvider implementation available for this platform.");

--- a/src/design/App/Composition/CompositionRoot.cs
+++ b/src/design/App/Composition/CompositionRoot.cs
@@ -120,7 +120,7 @@ public static class CompositionRoot
         {
             if (OperatingSystem.IsWindows())
                 services.AddSingleton<ISecureKeyProvider, DpapiSecureKeyProvider>();
-            else if (OperatingSystem.IsLinux())
+            else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
                 services.AddSingleton<ISecureKeyProvider, LinuxSecureKeyProvider>();
             else
                 throw new PlatformNotSupportedException("No ISecureKeyProvider implementation available for this platform.");

--- a/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml
@@ -15,7 +15,9 @@
     <UserControl.Styles>
         <Style Selector="Button.SearchIconButton">
             <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
             <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Foreground" Value="{DynamicResource TextMuted}" />
             <Setter Property="Padding" Value="10,0" />
             <Setter Property="MinWidth" Value="40" />
             <Setter Property="HorizontalContentAlignment" Value="Center" />
@@ -23,9 +25,58 @@
         </Style>
         <Style Selector="Button.SearchIconButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
         </Style>
         <Style Selector="Button.SearchIconButton:pressed /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+        </Style>
+        <Style Selector="Button.SearchIconButton:disabled /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="Foreground" Value="{DynamicResource TextMuted}" />
+        </Style>
+        <Style Selector="TextBox.SearchField">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="CornerRadius" Value="0" />
+            <Setter Property="Padding" Value="14,0" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+        <Style Selector="TextBox.SearchField:pointerover /template/ Border#PART_Border">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+        </Style>
+        <Style Selector="TextBox.SearchField:focus /template/ Border#PART_Border">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+        </Style>
+        <Style Selector="TextBox.SearchField:focus-within /template/ Border#PART_Border">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+        </Style>
+        <Style Selector="TextBox.SearchField /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+        </Style>
+        <Style Selector="TextBox.SearchField:pointerover /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+        </Style>
+        <Style Selector="TextBox.SearchField:focus /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+        </Style>
+        <Style Selector="TextBox.SearchField:focus-within /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
         </Style>
     </UserControl.Styles>
 
@@ -50,7 +101,7 @@
         <controls:ScrollableView Name="ProjectListPanel" ContentPadding="24,24,24,24">
             <StackPanel Spacing="16">
                 <!-- Header with search bar and refresh button -->
-                <Grid Name="FindProjectsHeaderGrid" ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,Auto">
+                <Grid Name="FindProjectsHeaderGrid" ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,Auto,Auto">
                     <TextBlock Name="DiscoverProjectsTitle"
                                Grid.Row="0" Grid.Column="0"
                                Text="Discover Projects"
@@ -58,35 +109,30 @@
                                VerticalAlignment="Center" />
                     <!-- Search bar -->
                     <Border Name="SearchContainer"
-                            Grid.Row="0" Grid.Column="1"
-                            Background="{DynamicResource CardSurface}"
-                            CornerRadius="12"
-                            Padding="4,0"
-                            Margin="16,0"
-                            BorderBrush="{DynamicResource StrokeSubtle}"
-                            BorderThickness="1"
-                            VerticalAlignment="Center"
-                            MinHeight="44">
-                        <Grid ColumnDefinitions="Auto,*,Auto">
-                            <i:Icon Grid.Column="0"
-                                    Value="fa-solid fa-magnifying-glass"
-                                    FontSize="14"
-                                    Foreground="{DynamicResource TextMuted}"
-                                    Margin="12,0,6,0"
-                                    VerticalAlignment="Center" />
-                            <TextBox Grid.Column="1"
-                                      Name="SearchTextBox"
-                                      Text="{Binding SearchText, Mode=TwoWay}"
-                                      PlaceholderText="Search by Project ID..."
-                                      BorderThickness="0"
-                                      Background="Transparent"
-                                      VerticalAlignment="Center"
-                                      Padding="4,8" />
-                            <Button Grid.Column="2"
+                             Grid.Row="0" Grid.Column="1"
+                             Background="{DynamicResource Surface}"
+                             CornerRadius="22"
+                             Padding="0"
+                             Margin="16,0"
+                             BorderBrush="{DynamicResource StrokeSubtle}"
+                             BorderThickness="1"
+                             VerticalAlignment="Center"
+                             MinHeight="44">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <TextBox Grid.Column="0"
+                                       Name="SearchTextBox"
+                                       Classes="SearchField"
+                                       Text="{Binding SearchText, Mode=TwoWay}"
+                                       PlaceholderText="Search by Project ID..."
+                                       VerticalAlignment="Center"
+                                       VerticalContentAlignment="Center"
+                                       MinHeight="42" />
+                            <Button Grid.Column="1"
                                      Name="SearchButton"
                                      Classes="SearchIconButton"
                                      VerticalAlignment="Center"
-                                     IsEnabled="{Binding !IsSearching}">
+                                     Foreground="{DynamicResource TextMuted}"
+                                     Margin="0,0,6,0">
                                 <Panel Width="18" Height="18">
                                     <i:Icon Value="fa-solid fa-magnifying-glass"
                                             FontSize="13"
@@ -122,17 +168,28 @@
                         </Grid>
                     </Border>
                     <!-- Search error message -->
-                    <TextBlock Name="SearchErrorText"
-                               Grid.Row="1" Grid.Column="1"
-                               Text="{Binding SearchError}"
-                               IsVisible="{Binding SearchError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                               Foreground="Red"
-                               FontSize="12"
-                               Margin="16,4,0,0"
-                               VerticalAlignment="Bottom" />
+                    <StackPanel Name="SearchErrorContainer"
+                                Grid.Row="1" Grid.Column="1"
+                                Orientation="Horizontal"
+                                Spacing="6"
+                                Margin="18,6,0,0"
+                                IsVisible="{Binding SearchError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                        <i:Icon Value="fa-solid fa-circle-info"
+                                FontSize="11"
+                                Foreground="{DynamicResource TextMuted}"
+                                VerticalAlignment="Center" />
+                        <TextBlock Name="SearchErrorText"
+                                   Text="{Binding SearchError}"
+                                   Foreground="{DynamicResource TextMuted}"
+                                   FontSize="12"
+                                   FontWeight="Medium"
+                                   TextWrapping="Wrap"
+                                   VerticalAlignment="Center" />
+                    </StackPanel>
                     <Button Name="RefreshProjectsButton" Grid.Row="0" Grid.Column="2"
                             Classes="Primary Light MobileAction"
                             Padding="12,8"
+                            MinHeight="44"
                             VerticalAlignment="Center"
                             IsEnabled="{Binding !IsLoading}">
                         <StackPanel Orientation="Horizontal" Spacing="8">

--- a/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml.cs
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
+using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using App.UI.Shared;
@@ -25,8 +26,10 @@ public partial class FindProjectsView : UserControl, ISectionView
     private ScrollableView? _projectListScrollable;
     private ScrollViewer? _listScrollViewer;
     private Grid? _headerGrid;
+    private TextBlock? _discoverProjectsTitle;
     private Border? _searchContainer;
-    private TextBlock? _searchErrorText;
+    private TextBox? _searchBox;
+    private StackPanel? _searchErrorContainer;
 
     // Lazy-mounted drill-down children — materialised on first visibility
     // to avoid the ~1800-line XAML inflate cost on the initial tab switch.
@@ -52,8 +55,9 @@ public partial class FindProjectsView : UserControl, ISectionView
         _investPanel = this.FindControl<Panel>("InvestPagePanel");
         _projectListScrollable = this.FindControl<ScrollableView>("ProjectListPanel");
         _headerGrid = this.FindControl<Grid>("FindProjectsHeaderGrid");
+        _discoverProjectsTitle = this.FindControl<TextBlock>("DiscoverProjectsTitle");
         _searchContainer = this.FindControl<Border>("SearchContainer");
-        _searchErrorText = this.FindControl<TextBlock>("SearchErrorText");
+        _searchErrorContainer = this.FindControl<StackPanel>("SearchErrorContainer");
 
         // Wire refresh button
         var refreshBtn = this.FindControl<Button>("RefreshProjectsButton");
@@ -68,7 +72,7 @@ public partial class FindProjectsView : UserControl, ISectionView
 
         // Wire search button and Enter key on search TextBox
         var searchBtn = this.FindControl<Button>("SearchButton");
-        var searchBox = this.FindControl<TextBox>("SearchTextBox");
+        _searchBox = this.FindControl<TextBox>("SearchTextBox");
         if (searchBtn != null)
         {
             searchBtn.Click += async (_, _) =>
@@ -77,9 +81,9 @@ public partial class FindProjectsView : UserControl, ISectionView
                     await fvm.SearchByProjectIdAsync();
             };
         }
-        if (searchBox != null)
+        if (_searchBox != null)
         {
-            searchBox.KeyDown += async (_, args) =>
+            _searchBox.KeyDown += async (_, args) =>
             {
                 if (args.Key == Key.Enter && DataContext is FindProjectsViewModel fvm)
                     await fvm.SearchByProjectIdAsync();
@@ -100,6 +104,7 @@ public partial class FindProjectsView : UserControl, ISectionView
         }
 
         // Listen for taps on ProjectCard elements to open project detail
+        AddHandler(PointerPressedEvent, OnPointerPressed, RoutingStrategies.Tunnel);
         AddHandler(InputElement.TappedEvent, OnCardTapped, RoutingStrategies.Bubble);
         var findMs = sw.ElapsedMilliseconds;
 
@@ -129,43 +134,62 @@ public partial class FindProjectsView : UserControl, ISectionView
                 ? new Thickness(16, 16, 16, 96)
                 : new Thickness(24);
 
-        if (_headerGrid == null || _searchContainer == null || _searchErrorText == null)
+        if (_headerGrid == null || _searchContainer == null || _searchErrorContainer == null)
             return;
 
         if (isCompact)
         {
+            if (_discoverProjectsTitle != null)
+                _discoverProjectsTitle.IsVisible = true;
+
             _headerGrid.ColumnDefinitions[0].Width = GridLength.Star;
             _headerGrid.ColumnDefinitions[1].Width = new GridLength(0);
             _headerGrid.ColumnDefinitions[2].Width = GridLength.Auto;
             _headerGrid.RowDefinitions[1].Height = GridLength.Auto;
+            _headerGrid.RowDefinitions[2].Height = GridLength.Auto;
 
             Grid.SetRow(_searchContainer, 1);
             Grid.SetColumn(_searchContainer, 0);
             Grid.SetColumnSpan(_searchContainer, 3);
             _searchContainer.Margin = new Thickness(0, 12, 0, 0);
 
-            Grid.SetRow(_searchErrorText, 1);
-            Grid.SetColumn(_searchErrorText, 0);
-            Grid.SetColumnSpan(_searchErrorText, 3);
-            _searchErrorText.Margin = new Thickness(0, 60, 0, 0);
+            Grid.SetRow(_searchErrorContainer, 2);
+            Grid.SetColumn(_searchErrorContainer, 0);
+            Grid.SetColumnSpan(_searchErrorContainer, 3);
+            _searchErrorContainer.Margin = new Thickness(14, 6, 14, 0);
         }
         else
         {
+            if (_discoverProjectsTitle != null)
+                _discoverProjectsTitle.IsVisible = false;
+
             _headerGrid.ColumnDefinitions[0].Width = GridLength.Auto;
             _headerGrid.ColumnDefinitions[1].Width = GridLength.Star;
             _headerGrid.ColumnDefinitions[2].Width = GridLength.Auto;
             _headerGrid.RowDefinitions[1].Height = GridLength.Auto;
+            _headerGrid.RowDefinitions[2].Height = new GridLength(0);
 
             Grid.SetRow(_searchContainer, 0);
             Grid.SetColumn(_searchContainer, 1);
             Grid.SetColumnSpan(_searchContainer, 1);
-            _searchContainer.Margin = new Thickness(16, 0);
+            _searchContainer.Margin = new Thickness(0, 0, 16, 0);
 
-            Grid.SetRow(_searchErrorText, 1);
-            Grid.SetColumn(_searchErrorText, 1);
-            Grid.SetColumnSpan(_searchErrorText, 1);
-            _searchErrorText.Margin = new Thickness(16, 4, 0, 0);
+            Grid.SetRow(_searchErrorContainer, 1);
+            Grid.SetColumn(_searchErrorContainer, 1);
+            Grid.SetColumnSpan(_searchErrorContainer, 1);
+            _searchErrorContainer.Margin = new Thickness(2, 6, 0, 0);
         }
+    }
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (_searchBox == null || !_searchBox.IsKeyboardFocusWithin)
+            return;
+
+        if (e.Source is not Visual source || _searchContainer?.IsVisualAncestorOf(source) == true)
+            return;
+
+        Focus();
     }
 
     private void SubscribeToVisibility()

--- a/src/design/App/UI/Sections/Home/HomeView.axaml.cs
+++ b/src/design/App/UI/Sections/Home/HomeView.axaml.cs
@@ -74,29 +74,8 @@ public partial class HomeView : UserControl, ISectionView
         // keeps responding to IsCompact changes after being detached and re-attached
         // by the ShellView ContentControl swap during tab navigation.
 
-        // ── Mobile perf: defer the second card (below the fold in stacked
-        // layout) so first paint only inflates one Viewbox+Path SVG icon
-        // instead of two. GetFunded card arrives on ApplicationIdle — the
-        // user needs to scroll to see it anyway. Desktop renders both cards
-        // synchronously side-by-side.
-        if (OperatingSystem.IsAndroid() || OperatingSystem.IsIOS())
-        {
-            if (_homeGrid != null && _getFundedCard != null)
-            {
-                var idx = _homeGrid.Children.IndexOf(_getFundedCard);
-                if (idx >= 0)
-                {
-                    _homeGrid.Children.RemoveAt(idx);
-                    var gridRef = _homeGrid;
-                    var cardRef = _getFundedCard;
-                    Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-                    {
-                        var safeIdx = Math.Min(idx, gridRef.Children.Count);
-                        gridRef.Children.Insert(safeIdx, cardRef);
-                    }, Avalonia.Threading.DispatcherPriority.ApplicationIdle);
-                }
-            }
-        }
+        // Keep both cards in the visual tree on startup. Deferring the second
+        // card on mobile made first launch flaky when ApplicationIdle was delayed.
     }
 
     private void ApplyResponsiveLayout(bool isCompact)

--- a/src/design/App/UI/Sections/Settings/SettingsViewModel.cs
+++ b/src/design/App/UI/Sections/Settings/SettingsViewModel.cs
@@ -125,7 +125,7 @@ public partial class SettingsViewModel : ReactiveObject, IDisposable
 
     public bool IsDarkThemeEnabled
     {
-        get => _prototypeSettings.IsDarkTheme;
+        get => _prototypeSettings.IsDarkTheme ?? Application.Current?.ActualThemeVariant == Avalonia.Styling.ThemeVariant.Dark;
         set
         {
             _prototypeSettings.IsDarkTheme = value;

--- a/src/design/App/UI/Shell/ShellViewModel.cs
+++ b/src/design/App/UI/Shell/ShellViewModel.cs
@@ -182,10 +182,10 @@ public partial class PrototypeSettings : ReactiveObject
     [Reactive] private bool isDebugMode;
 
     /// <summary>
-    /// When true, the app uses the Dark theme; otherwise Light.
-    /// Persisted to disk so the choice survives restarts.
+    /// When set, the app uses the selected theme. When unset, Avalonia follows
+    /// the operating system appearance on macOS, Linux, Windows, Android, and iOS.
     /// </summary>
-    [Reactive] private bool isDarkTheme;
+    [Reactive] private bool? isDarkTheme;
 
     /// <summary>
     /// Persisted wallet ID for the currently selected wallet.
@@ -222,17 +222,18 @@ public partial class PrototypeSettings : ReactiveObject
 
                         // Set IsDarkTheme last — its WhenAnyValue subscription
                         // applies the theme, so we want the other fields settled first.
-                        IsDarkTheme = result.Value.IsDarkTheme;
+                        IsDarkTheme = result.Value.HasThemeOverride
+                            ? result.Value.IsDarkTheme
+                            : null;
                     }
                 });
             });
 
-        // Apply persisted theme immediately (defaults to light until async load completes)
+        // Follow the operating system appearance until the user explicitly chooses
+        // a theme in the app.
         if (Application.Current != null)
         {
-            Application.Current.RequestedThemeVariant = isDarkTheme
-                ? Avalonia.Styling.ThemeVariant.Dark
-                : Avalonia.Styling.ThemeVariant.Light;
+            Application.Current.RequestedThemeVariant = Avalonia.Styling.ThemeVariant.Default;
         }
 
         // Apply theme whenever IsDarkTheme changes
@@ -245,9 +246,12 @@ public partial class PrototypeSettings : ReactiveObject
                     Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                     {
                         ShellService.PrepareForThemeChange(true);
-                        Application.Current.RequestedThemeVariant = dark
-                            ? Avalonia.Styling.ThemeVariant.Dark
-                            : Avalonia.Styling.ThemeVariant.Light;
+                        Application.Current.RequestedThemeVariant = dark switch
+                        {
+                            true => Avalonia.Styling.ThemeVariant.Dark,
+                            false => Avalonia.Styling.ThemeVariant.Light,
+                            null => Avalonia.Styling.ThemeVariant.Default,
+                        };
                         ShellService.PrepareForThemeChange(false);
                     }, Avalonia.Threading.DispatcherPriority.Render);
                 }
@@ -267,7 +271,7 @@ public partial class PrototypeSettings : ReactiveObject
         saveSettingsCts = new CancellationTokenSource();
 
         bool currentDebugMode = IsDebugMode;
-        bool currentDarkTheme = IsDarkTheme;
+        bool? currentDarkTheme = IsDarkTheme;
         string? currentWalletId = SelectedWalletId;
         HashSet<string> currentBackupSet = new(WalletsNeedingBackup);
         CancellationToken token = saveSettingsCts.Token;
@@ -277,6 +281,7 @@ public partial class PrototypeSettings : ReactiveObject
             Result saveResult = await _store.Save(SettingsKey, new PrototypeSettingsData
             {
                 IsDebugMode = currentDebugMode,
+                HasThemeOverride = currentDarkTheme.HasValue,
                 IsDarkTheme = currentDarkTheme,
                 SelectedWalletId = currentWalletId,
                 WalletsNeedingBackup = currentBackupSet,
@@ -304,6 +309,7 @@ public partial class PrototypeSettings : ReactiveObject
         Result saveResult = await _store.Save(SettingsKey, new PrototypeSettingsData
         {
             IsDebugMode = IsDebugMode,
+            HasThemeOverride = IsDarkTheme.HasValue,
             IsDarkTheme = IsDarkTheme,
             SelectedWalletId = SelectedWalletId,
             WalletsNeedingBackup = new HashSet<string>(WalletsNeedingBackup),
@@ -336,7 +342,8 @@ public partial class PrototypeSettings : ReactiveObject
     private class PrototypeSettingsData
     {
         public bool IsDebugMode { get; set; }
-        public bool IsDarkTheme { get; set; }
+        public bool HasThemeOverride { get; set; }
+        public bool? IsDarkTheme { get; set; }
         public string? SelectedWalletId { get; set; }
         public HashSet<string>? WalletsNeedingBackup { get; set; }
     }
@@ -1123,7 +1130,7 @@ public partial class ShellViewModel : ReactiveObject, IDisposable
 
     public bool IsDarkThemeEnabled
     {
-        get => _prototypeSettings.IsDarkTheme;
+        get => _prototypeSettings.IsDarkTheme ?? Application.Current?.ActualThemeVariant == Avalonia.Styling.ThemeVariant.Dark;
         set
         {
             _prototypeSettings.IsDarkTheme = value;


### PR DESCRIPTION
## Summary
- Polishes the Find Projects search bar, error message, and desktop alignment.
- Keeps Home cards mounted on mobile startup to avoid flaky first launch rendering.
- Makes the app follow the OS light/dark appearance by default unless the user explicitly toggles a theme.

## Validation
- dotnet build src/design/App.Desktop/App.Desktop.csproj
- Desktop app relaunched locally

## Notes
- Android install was not rerun after the latest changes because no ADB device was connected.