### PR TITLE
fix: Android black screen + ANR on resume

### DIFF
--- a/src/design/App.Android/MainActivity.cs
+++ b/src/design/App.Android/MainActivity.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
@@ -20,15 +22,37 @@ namespace App.Android;
     MainLauncher = true,
     ScreenOrientation = ScreenOrientation.Portrait,
     WindowSoftInputMode = SoftInput.AdjustNothing,
+    LaunchMode = LaunchMode.SingleTask,
     ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
 public class MainActivity : AvaloniaMainActivity
 {
     private PerfTabReceiver? _perfReceiver;
     private bool _handlingPlatformBack;
 
+    private ILogger? GetLogger()
+    {
+        try
+        {
+            return global::App.App.Services?
+                .GetService<ILoggerFactory>()?
+                .CreateLogger<MainActivity>();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    protected override void OnCreate(Android.OS.Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+        GetLogger()?.LogInformation("Lifecycle: OnCreate taskId={TaskId} intent={Intent}", TaskId, Intent?.Action);
+    }
+
     protected override void OnResume()
     {
         base.OnResume();
+        GetLogger()?.LogInformation("Lifecycle: OnResume taskId={TaskId}", TaskId);
         _perfReceiver = new PerfTabReceiver();
         var filter = new IntentFilter("io.angor.app.PERF_TAB");
         RegisterReceiver(_perfReceiver, filter, ReceiverFlags.Exported);
@@ -36,6 +60,7 @@ public class MainActivity : AvaloniaMainActivity
 
     protected override void OnPause()
     {
+        GetLogger()?.LogInformation("Lifecycle: OnPause taskId={TaskId}", TaskId);
         base.OnPause();
         if (_perfReceiver != null)
         {
@@ -46,6 +71,10 @@ public class MainActivity : AvaloniaMainActivity
 
     protected override void OnStop()
     {
+        var logger = GetLogger();
+        var sw = Stopwatch.StartNew();
+        logger?.LogInformation("Lifecycle: OnStop BEGIN taskId={TaskId}", TaskId);
+
         base.OnStop();
 
         // Flush all pending state to disk before the process may be killed.
@@ -53,33 +82,57 @@ public class MainActivity : AvaloniaMainActivity
         try
         {
             var services = global::App.App.Services;
-            if (services == null) return;
-
-            // Checkpoint LiteDB to flush the WAL into the main data file
-            var db = services.GetService<IAngorDocumentDatabase>();
-            if (db != null)
+            if (services == null)
             {
-                db.CheckpointAsync().GetAwaiter().GetResult();
+                logger?.LogWarning("Lifecycle: OnStop — services is null, skipping flush");
+                return;
             }
 
-            // Flush prototype settings (selected wallet ID, theme, etc.)
-            var settings = services.GetService<PrototypeSettings>();
-            settings?.FlushAsync().GetAwaiter().GetResult();
+            // Run flush on a thread-pool thread so the main thread is not blocked.
+            // LiteDB's Checkpoint() is synchronous internally and can take hundreds
+            // of milliseconds — blocking the main thread triggers Android's ANR dialog.
+            bool completed = Task.Run(() =>
+            {
+                var flushSw = Stopwatch.StartNew();
+
+                var db = services.GetService<IAngorDocumentDatabase>();
+                if (db != null)
+                {
+                    db.CheckpointAsync().GetAwaiter().GetResult();
+                    logger?.LogInformation("Lifecycle: OnStop checkpoint done in {Ms}ms", flushSw.ElapsedMilliseconds);
+                }
+
+                var settings = services.GetService<PrototypeSettings>();
+                if (settings != null)
+                {
+                    settings.FlushAsync().GetAwaiter().GetResult();
+                    logger?.LogInformation("Lifecycle: OnStop settings flush done in {Ms}ms", flushSw.ElapsedMilliseconds);
+                }
+            }).Wait(TimeSpan.FromSeconds(3));
+
+            if (!completed)
+            {
+                logger?.LogWarning("Lifecycle: OnStop flush TIMED OUT after 3s");
+            }
         }
         catch (Exception ex)
         {
-            try
-            {
-                var logger = global::App.App.Services?
-                    .GetService<ILoggerFactory>()?
-                    .CreateLogger<MainActivity>();
-                logger?.LogError(ex, "Failed to flush data in OnStop");
-            }
-            catch
-            {
-                // Swallow — logging infrastructure may already be disposed
-            }
+            logger?.LogError(ex, "Lifecycle: OnStop flush FAILED after {Ms}ms", sw.ElapsedMilliseconds);
         }
+
+        logger?.LogInformation("Lifecycle: OnStop END totalMs={Ms}", sw.ElapsedMilliseconds);
+    }
+
+    protected override void OnDestroy()
+    {
+        GetLogger()?.LogInformation("Lifecycle: OnDestroy taskId={TaskId} isFinishing={IsFinishing}", TaskId, IsFinishing);
+        base.OnDestroy();
+    }
+
+    protected override void OnNewIntent(Intent? intent)
+    {
+        base.OnNewIntent(intent);
+        GetLogger()?.LogInformation("Lifecycle: OnNewIntent action={Action} flags={Flags}", intent?.Action, intent?.Flags);
     }
 
     public override void OnBackPressed()


### PR DESCRIPTION
## Problem

Users experience black/unresponsive screens and ANR dialogs when resuming the app from Android recents.

## Root Causes

1. **Duplicate Activity instances** — without \SingleTask\ launch mode, Android can create a second Activity when resuming from recents, leaving the original one rendering to a detached surface (black screen).

2. **Main-thread blocking in OnStop** — \CheckpointAsync().GetAwaiter().GetResult()\ blocks the main thread synchronously. LiteDB's \Checkpoint()\ is synchronous internally and can take hundreds of milliseconds, exceeding Android's ANR threshold.

## Changes

All in \src/design/App.Android/MainActivity.cs\:

- **\LaunchMode = LaunchMode.SingleTask\** on the \[Activity]\ attribute — prevents duplicate Activity instances; reuses the existing one via \OnNewIntent\
- **\Task.Run(...).Wait(TimeSpan.FromSeconds(3))\** for the OnStop flush — moves DB checkpoint and settings flush off the main thread with a 3-second timeout
- **Lifecycle logging** on OnCreate, OnResume, OnPause, OnStop (with flush timing), OnDestroy, and OnNewIntent — enables diagnosing future resume issues from device logs

## Verification

- The previous crash log showed zero lifecycle entries and only Nostr relay disconnects — these new logs will capture the full lifecycle sequence and flush durations
- \OnNewIntent\ logs confirm SingleTask is working (vs a second \OnCreate\ for duplicate Activity)