### PR TITLE
Fix: My Projects not showing new project on mobile after deploy

### DIFF
--- a/src/design/App/UI/Sections/MyProjects/MyProjectsView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/MyProjectsView.axaml.cs
@@ -347,6 +347,16 @@ public partial class MyProjectsView : UserControl, ISectionView
         var shell = this.FindAncestorOfType<ShellView>();
         if (shell?.DataContext is ShellViewModel shellVm)
             TryConsumePendingLaunchWizard(shellVm);
+
+        if (DataContext is MyProjectsViewModel { NeedsRefresh: true } vm)
+        {
+            vm.NeedsRefresh = false;
+            ScheduleFounderProjectsLoad(force: true);
+        }
+        else
+        {
+            ScheduleFounderProjectsLoad(force: false);
+        }
     }
 
     public void OnBecameInactive() { }

--- a/src/design/App/UI/Sections/MyProjects/MyProjectsViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/MyProjectsViewModel.cs
@@ -70,6 +70,8 @@ public partial class MyProjectsViewModel : ReactiveObject, IDisposable
     [Reactive] private EditProfileViewModel? selectedEditProject;
     [Reactive] private bool isLoading;
     [Reactive] private bool isInitialLoad = true;
+    /// <summary>Set after a project is deployed so the next tab activation reloads from DB.</summary>
+    public bool NeedsRefresh { get; set; }
     /// <summary>The create project wizard VM, injected via DI.</summary>
     public CreateProjectViewModel CreateProjectVm { get; }
 
@@ -245,6 +247,7 @@ public partial class MyProjectsViewModel : ReactiveObject, IDisposable
         });
         this.RaisePropertyChanged(nameof(HasProjects));
         this.RaisePropertyChanged(nameof(TotalRaised));
+        NeedsRefresh = true;
     }
 
     public void CloseCreateWizard()


### PR DESCRIPTION
## Problem

On mobile, after creating/deploying a project and navigating to the My Projects page, the newly created project doesn't appear until the user manually presses refresh. This works correctly on desktop.

## Root Cause

On mobile, section switching uses \SectionPanel\ which calls \OnBecameActive()\ — the view is never detached/reattached from the logical tree. On desktop, \OnAttachedToLogicalTree\ triggers \ScheduleFounderProjectsLoad(force: true)\, but this is explicitly skipped on Android/iOS. The \OnBecameActive()\ hook had no load trigger, so even though the project was saved to the local DB during deploy, nothing told the ViewModel to read it.

## Fix

- Added a \NeedsRefresh\ flag to \MyProjectsViewModel\, set to \	rue\ in \OnProjectDeployed()\
- \OnBecameActive()\ consumes the flag: if set, force-reloads from DB; otherwise only loads on initial visit
- This avoids unnecessary reloads on regular tab switches while ensuring newly deployed projects appear immediately