### PR TITLE
fix: relay dedup bug (only one relay connected) and suppress noisy log sources

### DIFF
--- a/src/design/App/Composition/CompositionRoot.cs
+++ b/src/design/App/Composition/CompositionRoot.cs
@@ -72,6 +72,9 @@ public static class CompositionRoot
             var fileLogger = new LoggerConfiguration()
                 .Destructure.With<SensitiveDataRedactor>()
                 .MinimumLevel.Information()
+                .MinimumLevel.Override("System.Net.Http.HttpClient", Serilog.Events.LogEventLevel.Warning)
+                .MinimumLevel.Override("Angor.Shared.WalletOperations", Serilog.Events.LogEventLevel.Warning)
+                .MinimumLevel.Override("Angor.Shared.DerivationOperations", Serilog.Events.LogEventLevel.Warning)
                 .WriteTo.File(
                     logFilePath,
                     rollingInterval: Serilog.RollingInterval.Day,

--- a/src/sdk/Angor.Sdk/Common/NetworkConfiguration.cs
+++ b/src/sdk/Angor.Sdk/Common/NetworkConfiguration.cs
@@ -76,19 +76,19 @@ public class NetworkConfiguration : INetworkConfiguration
         {
             return new List<SettingsUrl>
             {
-                new() { Name = string.Empty, Url = "wss://relay.angor.io", IsPrimary = true },
-                new() { Name = string.Empty, Url = "wss://relay2.angor.io", IsPrimary = true },
-                new() { Name = string.Empty, Url = "wss://relay.damus.io", IsPrimary = true },
-                new() { Name = string.Empty, Url = "wss://nos.lol", IsPrimary = true },
-                new() { Name = string.Empty, Url = "wss://nostr-01.yakihonne.com", IsPrimary = true },
-                new() { Name = string.Empty, Url = "wss://nostr-02.yakihonne.com", IsPrimary = true },
+                new() { Name = "wss://relay.angor.io", Url = "wss://relay.angor.io", IsPrimary = true },
+                new() { Name = "wss://relay2.angor.io", Url = "wss://relay2.angor.io", IsPrimary = true },
+                new() { Name = "wss://relay.damus.io", Url = "wss://relay.damus.io", IsPrimary = true },
+                new() { Name = "wss://nos.lol", Url = "wss://nos.lol", IsPrimary = true },
+                new() { Name = "wss://nostr-01.yakihonne.com", Url = "wss://nostr-01.yakihonne.com", IsPrimary = true },
+                new() { Name = "wss://nostr-02.yakihonne.com", Url = "wss://nostr-02.yakihonne.com", IsPrimary = true },
             };
         }
 
         return new List<SettingsUrl>
         {
-            new() { Name = string.Empty, Url = "wss://relay.angor.io", IsPrimary = true },
-            new() { Name = string.Empty, Url = "wss://relay2.angor.io", IsPrimary = true },
+            new() { Name = "wss://relay.angor.io", Url = "wss://relay.angor.io", IsPrimary = true },
+            new() { Name = "wss://relay2.angor.io", Url = "wss://relay2.angor.io", IsPrimary = true },
         };
     }
 
@@ -101,17 +101,17 @@ public class NetworkConfiguration : INetworkConfiguration
             {
                 return new List<SettingsUrl>
                 {
-                    new() { Name = string.Empty, Url = "https://liquid.angor.online", IsPrimary = true },
+                    new() { Name = "liquid.angor.online", Url = "https://liquid.angor.online", IsPrimary = true },
                 };
             }
 
             return new List<SettingsUrl>
             {
-                new() { Name = string.Empty, Url = "https://explorer.angor.io", IsPrimary = false },
-                new() { Name = string.Empty, Url = "https://fulcrum.angor.online", IsPrimary = true },
-                new() { Name = string.Empty, Url = "https://electrs.angor.online", IsPrimary = false },
-                new() { Name = string.Empty, Url = "https://cyphermunkhouse.angor.online", IsPrimary = false },
-                new() { Name = string.Empty, Url = "https://indexer.angor.fund", IsPrimary = false },
+                new() { Name = "explorer.angor.io", Url = "https://explorer.angor.io", IsPrimary = false },
+                new() { Name = "fulcrum.angor.online", Url = "https://fulcrum.angor.online", IsPrimary = true },
+                new() { Name = "electrs.angor.online", Url = "https://electrs.angor.online", IsPrimary = false },
+                new() { Name = "cyphermunkhouse.angor.online", Url = "https://cyphermunkhouse.angor.online", IsPrimary = false },
+                new() { Name = "indexer.angor.fund", Url = "https://indexer.angor.fund", IsPrimary = false },
             };
         }
 
@@ -119,9 +119,9 @@ public class NetworkConfiguration : INetworkConfiguration
         {
             return new List<SettingsUrl>
             {
-                new() { Name = string.Empty, Url = "https://test.explorer.angor.io", IsPrimary = false },
-                new() { Name = string.Empty, Url = "https://signet.angor.online", IsPrimary = true },
-                new() { Name = string.Empty, Url = "https://signet2.angor.online", IsPrimary = false },
+                new() { Name = "test.explorer.angor.io", Url = "https://test.explorer.angor.io", IsPrimary = false },
+                new() { Name = "signet.angor.online", Url = "https://signet.angor.online", IsPrimary = true },
+                new() { Name = "signet2.angor.online", Url = "https://signet2.angor.online", IsPrimary = false },
             };
         }
 

--- a/src/shared/Angor.Shared/Services/NostrCommunicationFactory.cs
+++ b/src/shared/Angor.Shared/Services/NostrCommunicationFactory.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reactive.Linq;
+using Angor.Shared.Models;
 using ConcurrentCollections;
 using Microsoft.Extensions.Logging;
 using Nostr.Client.Client;
@@ -62,9 +63,11 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
         }
 
         foreach (var url in networkService.GetDiscoveryRelays()
-                     .Where(url => _nostrMultiWebsocketClientDiscovery.FindClient(url.Name) == null))
+                     .Where(url => !string.IsNullOrWhiteSpace(url.Url))
+                     .Where(url => _nostrMultiWebsocketClientDiscovery.FindClient(GetRelayKey(url)) == null))
         {
-            var communicator = CreateCommunicator(url.Url, url.Name);
+            var relayKey = GetRelayKey(url);
+            var communicator = CreateCommunicator(url.Url, relayKey);
             var client = new NostrWebsocketClient(communicator, _clientLogger);
 
             _serviceSubscriptions.Add(client.Streams.EoseStream.Subscribe(x =>
@@ -133,9 +136,11 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
     private void ConnectToAllRelaysInTheSettings(INetworkService networkService)
     {
         foreach (var url in networkService.GetRelays()
-                     .Where(url => _nostrMultiWebsocketClient.FindClient(url.Name) == null))
+                     .Where(url => !string.IsNullOrWhiteSpace(url.Url))
+                     .Where(url => _nostrMultiWebsocketClient.FindClient(GetRelayKey(url)) == null))
         {
-            var communicator = CreateCommunicator(url.Url, url.Name);
+            var relayKey = GetRelayKey(url);
+            var communicator = CreateCommunicator(url.Url, relayKey);
             var client = new NostrWebsocketClient(communicator, _clientLogger);
             
             _serviceSubscriptions.Add(client.Streams.EoseStream.Subscribe(x =>
@@ -228,6 +233,13 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
     {
         return _nostrMultiWebsocketClient?.Clients.Count ?? 0;
     }
+
+    /// <summary>
+    /// Returns a unique key for identifying a relay client.
+    /// Uses Url when Name is empty (the common default), matching the pattern used by discovery relays.
+    /// </summary>
+    private static string GetRelayKey(SettingsUrl url) =>
+        string.IsNullOrWhiteSpace(url.Name) ? url.Url : url.Name;
 
     public INostrCommunicator CreateCommunicator(string uri, string relayName)
     {


### PR DESCRIPTION
## Summary

Fixes a critical relay connectivity bug and reduces log noise, discovered while investigating a user-submitted encrypted log file.

### Relay dedup bug (HIGH)

All default relays in `NetworkConfiguration.GetDefaultRelayUrls()` were created with `Name = string.Empty`. The `NostrCommunicationFactory` deduplicates relays using `FindClient(url.Name)` — since every relay shared the same empty-string name, after the first relay was registered, `FindClient("")` matched it, and **all subsequent relays were silently skipped**. This meant only one relay was ever connected.

**Fixes:**
- `NostrCommunicationFactory`: dedup by URL (via new `GetRelayKey()` helper) instead of Name; also skip entries with empty/whitespace URLs
- `NetworkConfiguration`: set `Name = URL` for all default relay and explorer entries, matching the pattern already used by discovery relays

### Log noise (LOW)

The existing `AddFilter()` calls on `Microsoft.Extensions.Logging` did not propagate to the Serilog file logger, so `HttpClient`, `WalletOperations`, and `DerivationOperations` were flooding logs with verbose output.

**Fix:** Added `MinimumLevel.Override()` on the Serilog `LoggerConfiguration` in `CompositionRoot.cs`.

## Files changed

- `src/shared/Angor.Shared/Services/NostrCommunicationFactory.cs`
- `src/sdk/Angor.Sdk/Common/NetworkConfiguration.cs`
- `src/design/App/Composition/CompositionRoot.cs`