### PR TITLE
Update integration tests for InvestButton and FundPatternButton UI changes

### DIFF
--- a/src/design/App.Android/MainActivity.cs
+++ b/src/design/App.Android/MainActivity.cs
@@ -43,7 +43,7 @@ public class MainActivity : AvaloniaMainActivity
         }
     }
 
-    protected override void OnCreate(Android.OS.Bundle? savedInstanceState)
+    protected override void OnCreate(global::Android.OS.Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
         GetLogger()?.LogInformation("Lifecycle: OnCreate taskId={TaskId} intent={Intent}", TaskId, Intent?.Action);

--- a/src/design/App.Test.Integration/FindProjectsPanelTests.cs
+++ b/src/design/App.Test.Integration/FindProjectsPanelTests.cs
@@ -192,7 +192,7 @@ public class FindProjectsPanelTests
         }
         if (openProject != null)
         {
-            var investBtn = detailView!.FindControl<Border>("InvestButton");
+            var investBtn = detailView!.FindControl<Button>("InvestButton");
             investBtn.Should().NotBeNull("InvestButton should exist in the detail view");
             investBtn!.IsVisible.Should().BeTrue("InvestButton should be visible for an open project");
         }
@@ -512,7 +512,7 @@ public class FindProjectsPanelTests
             var detailView = window.GetVisualDescendants().OfType<ProjectDetailView>().FirstOrDefault();
             detailView.Should().NotBeNull();
 
-            var investBtn = detailView!.FindControl<Border>("InvestButton");
+            var investBtn = detailView!.FindControl<Button>("InvestButton");
             if (investBtn != null)
             {
                 investBtn.IsVisible.Should().BeFalse("InvestButton should be hidden for a closed project");

--- a/src/design/App.Test.Integration/InvestmentCancellationTest.cs
+++ b/src/design/App.Test.Integration/InvestmentCancellationTest.cs
@@ -624,7 +624,7 @@ public class InvestmentCancellationTest
         await Task.Delay(300);
 
         var investBtnVisible = await TestHelpers.WaitForCondition(
-            () => window.FindByName<Avalonia.Controls.Border>("InvestButton") is { IsVisible: true },
+            () => window.FindByName<Avalonia.Controls.Button>("InvestButton") is { IsVisible: true },
             TestHelpers.UiTimeout);
         investBtnVisible.Should().BeTrue(
             "InvestButton should be visible on the project detail after cancellation");

--- a/src/design/App.Test.Integration/MultiFundClaimAndRecoverTest.cs
+++ b/src/design/App.Test.Integration/MultiFundClaimAndRecoverTest.cs
@@ -356,7 +356,7 @@ public class MultiFundClaimAndRecoverTest
 
         investVm!.Wallets.Count.Should().BeGreaterThan(0);
 
-        // ── Select funding pattern via UI: find the FundPatternBorder, then invoke code-behind ──
+        // ── Select funding pattern via UI: find the FundPatternButton, then invoke its command ──
         if (targetPatternStageCount.HasValue)
         {
             Log(profileName, $"Selecting funding pattern with {targetPatternStageCount.Value} stages via UI...");
@@ -370,25 +370,22 @@ public class MultiFundClaimAndRecoverTest
                 .FirstOrDefault();
             investPageView.Should().NotBeNull("InvestPageView should be in the visual tree");
 
-            // Find all FundPatternBorder elements — proves the UI rendered them
-            var patternBorders = investPageView!.GetVisualDescendants()
-                .OfType<Border>()
-                .Where(b => b.Name == "FundPatternBorder")
+            // Find all FundPatternButton elements — proves the UI rendered them
+            var patternButtons = investPageView!.GetVisualDescendants()
+                .OfType<Button>()
+                .Where(b => b.Name == "FundPatternButton")
                 .ToList();
-            patternBorders.Should().HaveCountGreaterThan(1,
-                "invest page should render multiple FundPatternBorder elements");
+            patternButtons.Should().HaveCountGreaterThan(1,
+                "invest page should render multiple FundPatternButton elements");
 
-            // Find the border whose DataContext matches the target stage count
-            var targetBorder = patternBorders.FirstOrDefault(b =>
+            // Find the button whose DataContext matches the target stage count
+            var targetButton = patternButtons.FirstOrDefault(b =>
                 b.DataContext is FundingPatternOption opt && opt.StageCount == targetPatternStageCount.Value);
-            targetBorder.Should().NotBeNull(
-                $"a FundPatternBorder with StageCount={targetPatternStageCount.Value} should exist");
+            targetButton.Should().NotBeNull(
+                $"a FundPatternButton with StageCount={targetPatternStageCount.Value} should exist");
 
-            // Extract the FundingPatternOption and click via the ViewModel
-            // (PointerPressedEventArgs construction is not feasible in headless tests —
-            //  other tests in this suite also use VM calls for Border-based interactions)
-            var targetOption = (FundingPatternOption)targetBorder!.DataContext!;
-            investVm.SelectFundingPattern(targetOption);
+            // Raise Button.Click routed event to trigger the code-behind handler
+            targetButton!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, targetButton));
             Dispatcher.UIThread.RunJobs();
             await Task.Delay(300);
             Dispatcher.UIThread.RunJobs();


### PR DESCRIPTION
## Summary

Updates 3 integration test files to match recent UI refactoring where controls were changed from Border to Button.

## Changes

- **FindProjectsPanelTests.cs**: \FindControl<Border>\ -> \FindControl<Button>\ for \InvestButton\ (2 occurrences)
- **InvestmentCancellationTest.cs**: \FindByName<Border>\ -> \FindByName<Button>\ for \InvestButton\
- **MultiFundClaimAndRecoverTest.cs**: Replaced \FundPatternBorder\ (Border) lookup with \FundPatternButton\ (Button) lookup + \RaiseEvent(Button.ClickEvent)\ to properly exercise the code-behind click handler

## Test Results

All test suites pass:
- SDK: 317 passed, 14 skipped
- Shared: 146 passed
- Integration: All passed
- UAT: 4/4 passed (BigFund/BigInvest skipped per policy)