### PR TITLE
fix: guard against null RequestEventTime in BuildRecoveryTransaction for direct investments

### DIFF
--- a/src/cli/Angor.Cli/McpTools/InvestorTools.cs
+++ b/src/cli/Angor.Cli/McpTools/InvestorTools.cs
@@ -68,14 +68,82 @@ public class InvestorTools(IInvestmentAppService investorService)
             : $"Error: {result.Error}";
     }
 
-    [McpServerTool, Description("Get recovery status for an investment in a project")]
+    [McpServerTool, Description("Get recovery status for an investment in a project. Returns current state and available actions the investor can take to reclaim funds.")]
     public async Task<string> InvestorRecoveryStatus(string walletId, string projectId)
     {
         var result = await investorService.GetRecoveryStatus(
             new GetRecoveryStatus.GetRecoveryStatusRequest(new WalletId(walletId), new ProjectId(projectId)));
-        return result.IsSuccess
-            ? JsonSerializer.Serialize(result.Value, JsonOptions)
-            : $"Error: {result.Error}";
+        if (result.IsFailure)
+            return $"Error: {result.Error}";
+
+        var dto = result.Value.RecoveryData;
+        var actions = ComputeAvailableActions(dto);
+
+        return JsonSerializer.Serialize(new
+        {
+            recoveryData = result.Value,
+            availableActions = actions
+        }, JsonOptions);
+    }
+
+    private static List<object> ComputeAvailableActions(Angor.Sdk.Funding.Investor.Dtos.InvestorProjectRecoveryDto dto)
+    {
+        var actions = new List<object>();
+
+        if (!dto.HasUnspentItems)
+            return actions;
+
+        if (dto.EndOfProject)
+        {
+            actions.Add(new
+            {
+                action = "end-of-project-claim",
+                description = "Project has expired. Claim all remaining unspent funds back to your wallet (no penalty).",
+                command = "investor build-eop-claim"
+            });
+        }
+
+        if (dto.HasReleaseSignatures)
+        {
+            actions.Add(new
+            {
+                action = "release-claim",
+                description = "Founder has released your funds. Build a release transaction to claim them without penalty.",
+                command = "investor build-release"
+            });
+        }
+
+        if (!dto.EndOfProject && dto.IsAboveThreshold)
+        {
+            actions.Add(new
+            {
+                action = "recovery",
+                description = $"Initiate early recovery of your investment. This triggers a penalty period of {dto.PenaltyDays} days before funds can be fully claimed.",
+                command = "investor build-recovery"
+            });
+        }
+
+        if (dto.HasSpendableItemsInPenalty)
+        {
+            actions.Add(new
+            {
+                action = "penalty-release",
+                description = "Penalty period has expired. Claim your recovered funds.",
+                command = "investor build-penalty-release"
+            });
+        }
+
+        if (actions.Count == 0)
+        {
+            actions.Add(new
+            {
+                action = "wait",
+                description = $"This is a direct investment (below threshold). Early recovery is not available. Funds can be claimed after the project expires on {dto.ExpiryDate:yyyy-MM-dd}, or if the founder releases them.",
+                command = ""
+            });
+        }
+
+        return actions;
     }
 
     [McpServerTool, Description("Build a recovery transaction to reclaim invested funds")]

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildRecoveryTransaction.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/BuildRecoveryTransaction.cs
@@ -61,6 +61,15 @@ public static class BuildRecoveryTransaction
 
             var investmentTransaction = networkConfiguration.GetNetwork().CreateTransaction(investment.InvestmentTransactionHex);
 
+            // Direct investments (below threshold) skip the founder approval handshake,
+            // so there are no recovery signatures available. Recovery requires founder signatures
+            // that are only generated during the approval flow.
+            // Direct investments can use end-of-project claim after the project expires instead.
+            if (investment.RequestEventTime is null || investment.RequestEventId is null)
+                return Result.Failure<BuildRecoveryTransactionResponse>(
+                    "Recovery is not available for direct investments (below threshold). " +
+                    "Use end-of-project claim after the project expires, or ask the founder to release funds.");
+
             var signatureLookup = await LookupFounderSignatures(request.WalletId.Value, project.Value, investment.RequestEventTime.Value, investment.RequestEventId,
               investmentTransaction);
 


### PR DESCRIPTION
## Problem

\BuildRecoveryTransaction\ crashes with \InvalidOperationException: Nullable object must have a value\ when called for direct investments (below the penalty threshold).

The crash is at line 64 where \investment.RequestEventTime.Value\ is accessed, but \RequestEventTime\ is null for direct investments because they skip the founder approval handshake entirely.

## Root Cause

Direct investments bypass the founder approval flow:
- No \SignRecoveryRequest\ is sent to the founder via Nostr
- No \RequestEventTime\ or \RequestEventId\ is set on the investment record
- No founder recovery signatures are generated

The recovery transaction flow fundamentally requires those founder signatures, so it cannot work for direct investments.

## Changes

### 1. Guard against null crash in BuildRecoveryTransaction

Added an early guard that checks for null \RequestEventTime\/\RequestEventId\ and returns a clear \Result.Failure\ with an actionable message instead of crashing:

> Recovery is not available for direct investments (below threshold). Use end-of-project claim after the project expires, or ask the founder to release funds.

### 2. Add AvailableActions to recovery status response

\GetRecoveryStatus\ now computes and returns an \AvailableActions\ list that tells the caller exactly which spending paths are available given the current state:

| Action | When available |
|---|---|
| \end-of-project-claim\ | Project expired, unspent funds remain |
| \elease-claim\ | Founder released signatures (non-direct investments) |
| \ecovery\ | Above-threshold, non-direct investment, project not expired |
| \penalty-release\ | Recovery done, penalty period expired |
| \wait\ | Direct investment, no actions available yet |

Each action includes a human-readable description and the CLI command to execute. This makes the recovery status self-documenting for MCP agents and CLI users — they no longer need to understand the Angor domain model to figure out which command to run.

## Alternatives for Direct Investment Investors

- **End-of-project claim** (\BuildEndOfProjectClaim\): uses the expiry timelock script path — investor can unilaterally sweep remaining unspent outputs after project expiry, no founder signatures needed
- **Founder release**: founder can sign release signatures via the \ReleaseFunds\ flow

## Testing

All 317 SDK tests pass (including 7 specifically for \BuildRecoveryTransaction\).