### PR TITLE
feat(cli): CLI improvements for MCP testing workflow

### DIFF
--- a/src/cli/Angor.Cli/Commands/Config/ConfigCommands.cs
+++ b/src/cli/Angor.Cli/Commands/Config/ConfigCommands.cs
@@ -18,6 +18,8 @@ public static class ConfigCommands
         cmd.AddCommand(BuildShowCommand(networkConfig, networkService, jsonOptions));
         cmd.AddCommand(BuildGetNetworkCommand(networkConfig));
         cmd.AddCommand(BuildSetNetworkCommand(networkService));
+        cmd.AddCommand(BuildGetDebugModeCommand(networkConfig));
+        cmd.AddCommand(BuildSetDebugModeCommand(networkConfig));
 
         return cmd;
     }
@@ -87,6 +89,29 @@ public static class ConfigCommands
             Console.WriteLine($"Network set to: {network}");
             Console.WriteLine("Restart the CLI for the change to take effect.");
         }, networkArg);
+        return cmd;
+    }
+
+    private static Command BuildGetDebugModeCommand(INetworkConfiguration networkConfig)
+    {
+        var cmd = new Command("get-debug-mode", "Show current debug mode status");
+        cmd.SetHandler(() =>
+        {
+            Console.WriteLine($"Debug mode: {(networkConfig.GetDebugMode() ? "enabled" : "disabled")}");
+        });
+        return cmd;
+    }
+
+    private static Command BuildSetDebugModeCommand(INetworkConfiguration networkConfig)
+    {
+        var enabledArg = new Argument<bool>("enabled", "true to enable, false to disable");
+
+        var cmd = new Command("set-debug-mode", "Enable or disable debug mode (testnet only: stages immediately claimable)") { enabledArg };
+        cmd.SetHandler((bool enabled) =>
+        {
+            networkConfig.SetDebugMode(enabled);
+            Console.WriteLine($"Debug mode {(enabled ? "enabled" : "disabled")}.");
+        }, enabledArg);
         return cmd;
     }
 }

--- a/src/cli/Angor.Cli/Commands/Founder/FounderCommands.cs
+++ b/src/cli/Angor.Cli/Commands/Founder/FounderCommands.cs
@@ -8,6 +8,7 @@ using Angor.Sdk.Funding.Founder.Operations;
 using Angor.Sdk.Funding.Projects;
 using Angor.Sdk.Funding.Projects.Dtos;
 using Angor.Sdk.Funding.Shared;
+using Angor.Shared;
 using Angor.Shared.Models;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -33,6 +34,9 @@ public static class FounderCommands
         cmd.AddCommand(BuildSpendStageCommand(founderService, jsonOptions));
         cmd.AddCommand(BuildSubmitTxCommand(founderService, jsonOptions));
         cmd.AddCommand(BuildMoonshotCommand(founderService, jsonOptions));
+        cmd.AddCommand(BuildCreateProfileCommand(projectService, jsonOptions));
+        cmd.AddCommand(BuildCreateInfoCommand(projectService, jsonOptions));
+        cmd.AddCommand(BuildCreateProjectCommand(projectService, jsonOptions));
 
         return cmd;
     }
@@ -269,16 +273,16 @@ public static class FounderCommands
         var projectIdOption = new Option<string>("--project-id", "Project ID") { IsRequired = true };
         var feeRateOption = new Option<long>("--fee-rate", "Fee rate in sat/vB") { IsRequired = true };
         var stageIdOption = new Option<int>("--stage-id", "Stage ID to spend") { IsRequired = true };
-        var addressOption = new Option<string>("--address", "Investor address") { IsRequired = true };
+        var addressOption = new Option<string[]>("--address", "Investor address(es)") { IsRequired = true, AllowMultipleArgumentsPerToken = true };
 
         var cmd = new Command("spend-stage", "Spend funds from a project stage")
         {
             walletIdOption, projectIdOption, feeRateOption, stageIdOption, addressOption
         };
-        cmd.SetHandler(async (string walletId, string projectId, long feeRate, int stageId, string address) =>
+        cmd.SetHandler(async (string walletId, string projectId, long feeRate, int stageId, string[] addresses) =>
         {
             var fee = new FeeEstimation { FeeRate = feeRate * 1000, Confirmations = 1 };
-            var toSpend = new[] { new SpendTransactionDto { InvestorAddress = address, StageId = stageId } };
+            var toSpend = addresses.Select(a => new SpendTransactionDto { InvestorAddress = a, StageId = stageId }).ToArray();
 
             var result = await founderService.SpendStageFunds(
                 new SpendStageFunds.SpendStageFundsRequest(new WalletId(walletId), new ProjectId(projectId), fee, toSpend));
@@ -291,6 +295,7 @@ public static class FounderCommands
 
             Console.WriteLine($"Transaction draft created: {result.Value.TransactionDraft.TransactionId}");
             Console.WriteLine($"Fee: {result.Value.TransactionDraft.TransactionFee} sats");
+            Console.WriteLine($"Transaction Hex: {result.Value.TransactionDraft.SignedTxHex}");
         }, walletIdOption, projectIdOption, feeRateOption, stageIdOption, addressOption);
         return cmd;
     }
@@ -343,6 +348,132 @@ public static class FounderCommands
 
             Console.WriteLine(JsonSerializer.Serialize(result.Value, jsonOptions));
         }, eventIdOption);
+        return cmd;
+    }
+
+    private static Command BuildCreateProfileCommand(IProjectAppService projectService, JsonSerializerOptions jsonOptions)
+    {
+        var walletIdOption = new Option<string>("--wallet-id", "Wallet ID") { IsRequired = true };
+        var inputFileOption = new Option<string>("--input-file", "Path to JSON file with project data (CreateProjectDto)") { IsRequired = true };
+        var founderKeyOption = new Option<string>("--founder-key", "Founder key from create-keys") { IsRequired = true };
+        var recoveryKeyOption = new Option<string>("--recovery-key", "Recovery key from create-keys") { IsRequired = true };
+        var nostrPubKeyOption = new Option<string>("--nostr-pubkey", "Nostr public key from create-keys") { IsRequired = true };
+        var projectIdOption = new Option<string>("--project-id", "Project identifier from create-keys") { IsRequired = true };
+
+        var cmd = new Command("create-profile", "Create the Nostr profile for a new project")
+        {
+            walletIdOption, inputFileOption, founderKeyOption, recoveryKeyOption, nostrPubKeyOption, projectIdOption
+        };
+        cmd.SetHandler(async (string walletId, string inputFile, string founderKey, string recoveryKey, string nostrPubKey, string projectId) =>
+        {
+            var json = await File.ReadAllTextAsync(inputFile);
+            var project = JsonSerializer.Deserialize<CreateProjectDto>(json, jsonOptions);
+            if (project is null)
+            {
+                Console.Error.WriteLine("Error: Failed to deserialize project data from input file.");
+                return;
+            }
+
+            var seed = new ProjectSeedDto(founderKey, recoveryKey, nostrPubKey, projectId);
+            var result = await projectService.CreateProjectProfile(new WalletId(walletId), seed, project);
+
+            if (result.IsFailure)
+            {
+                Console.Error.WriteLine($"Error: {result.Error}");
+                return;
+            }
+
+            Console.WriteLine($"Profile created. Event ID: {result.Value.EventId}");
+        }, walletIdOption, inputFileOption, founderKeyOption, recoveryKeyOption, nostrPubKeyOption, projectIdOption);
+        return cmd;
+    }
+
+    private static Command BuildCreateInfoCommand(IProjectAppService projectService, JsonSerializerOptions jsonOptions)
+    {
+        var walletIdOption = new Option<string>("--wallet-id", "Wallet ID") { IsRequired = true };
+        var inputFileOption = new Option<string>("--input-file", "Path to JSON file with project data (CreateProjectDto)") { IsRequired = true };
+        var founderKeyOption = new Option<string>("--founder-key", "Founder key") { IsRequired = true };
+        var recoveryKeyOption = new Option<string>("--recovery-key", "Recovery key") { IsRequired = true };
+        var nostrPubKeyOption = new Option<string>("--nostr-pubkey", "Nostr public key") { IsRequired = true };
+        var projectIdOption = new Option<string>("--project-id", "Project identifier") { IsRequired = true };
+
+        var cmd = new Command("create-info", "Publish project info (stages, metadata) to Nostr")
+        {
+            walletIdOption, inputFileOption, founderKeyOption, recoveryKeyOption, nostrPubKeyOption, projectIdOption
+        };
+        cmd.SetHandler(async (string walletId, string inputFile, string founderKey, string recoveryKey, string nostrPubKey, string projectId) =>
+        {
+            var json = await File.ReadAllTextAsync(inputFile);
+            var project = JsonSerializer.Deserialize<CreateProjectDto>(json, jsonOptions);
+            if (project is null)
+            {
+                Console.Error.WriteLine("Error: Failed to deserialize project data from input file.");
+                return;
+            }
+
+            var seed = new ProjectSeedDto(founderKey, recoveryKey, nostrPubKey, projectId);
+            var result = await projectService.CreateProjectInfo(new WalletId(walletId), project, seed);
+
+            if (result.IsFailure)
+            {
+                Console.Error.WriteLine($"Error: {result.Error}");
+                return;
+            }
+
+            Console.WriteLine($"Project info published. Event ID: {result.Value.EventId}");
+        }, walletIdOption, inputFileOption, founderKeyOption, recoveryKeyOption, nostrPubKeyOption, projectIdOption);
+        return cmd;
+    }
+
+    private static Command BuildCreateProjectCommand(IProjectAppService projectService, JsonSerializerOptions jsonOptions)
+    {
+        var walletIdOption = new Option<string>("--wallet-id", "Wallet ID") { IsRequired = true };
+        var inputFileOption = new Option<string>("--input-file", "Path to JSON file with project data (CreateProjectDto)") { IsRequired = true };
+        var feeOption = new Option<long>("--fee", "Selected fee in sats") { IsRequired = true };
+        var infoEventIdOption = new Option<string>("--info-event-id", "Project info event ID from create-info") { IsRequired = true };
+        var founderKeyOption = new Option<string>("--founder-key", "Founder key") { IsRequired = true };
+        var recoveryKeyOption = new Option<string>("--recovery-key", "Recovery key") { IsRequired = true };
+        var nostrPubKeyOption = new Option<string>("--nostr-pubkey", "Nostr public key") { IsRequired = true };
+        var projectIdOption = new Option<string>("--project-id", "Project identifier") { IsRequired = true };
+
+        var cmd = new Command("create-project", "Create the on-chain Bitcoin project transaction")
+        {
+            walletIdOption, inputFileOption, feeOption, infoEventIdOption,
+            founderKeyOption, recoveryKeyOption, nostrPubKeyOption, projectIdOption
+        };
+        cmd.SetHandler(async context =>
+        {
+            var walletId = context.ParseResult.GetValueForOption(walletIdOption)!;
+            var inputFile = context.ParseResult.GetValueForOption(inputFileOption)!;
+            var fee = context.ParseResult.GetValueForOption(feeOption);
+            var infoEventId = context.ParseResult.GetValueForOption(infoEventIdOption)!;
+            var founderKey = context.ParseResult.GetValueForOption(founderKeyOption)!;
+            var recoveryKey = context.ParseResult.GetValueForOption(recoveryKeyOption)!;
+            var nostrPubKey = context.ParseResult.GetValueForOption(nostrPubKeyOption)!;
+            var projectId = context.ParseResult.GetValueForOption(projectIdOption)!;
+
+            var json = await File.ReadAllTextAsync(inputFile);
+            var project = JsonSerializer.Deserialize<CreateProjectDto>(json, jsonOptions);
+            if (project is null)
+            {
+                Console.Error.WriteLine("Error: Failed to deserialize project data from input file.");
+                return;
+            }
+
+            var seed = new ProjectSeedDto(founderKey, recoveryKey, nostrPubKey, projectId);
+            var result = await projectService.CreateProject(new WalletId(walletId), fee, project, infoEventId, seed);
+
+            if (result.IsFailure)
+            {
+                Console.Error.WriteLine($"Error: {result.Error}");
+                return;
+            }
+
+            Console.WriteLine($"Project created on-chain.");
+            Console.WriteLine($"Transaction ID: {result.Value.TransactionDraft.TransactionId}");
+            Console.WriteLine($"Transaction Hex: {result.Value.TransactionDraft.SignedTxHex}");
+            Console.WriteLine($"Fee: {result.Value.TransactionDraft.TransactionFee} sats");
+        });
         return cmd;
     }
 }

--- a/src/cli/Angor.Cli/Commands/Investor/InvestorCommands.cs
+++ b/src/cli/Angor.Cli/Commands/Investor/InvestorCommands.cs
@@ -29,6 +29,9 @@ public static class InvestorCommands
         cmd.AddCommand(BuildCheckSignaturesCommand(investorService, jsonOptions));
         cmd.AddCommand(BuildSubmitTxCommand(investorService, jsonOptions));
         cmd.AddCommand(BuildGetNsecCommand(investorService, jsonOptions));
+        cmd.AddCommand(BuildNotifyFounderCommand(services, jsonOptions));
+        cmd.AddCommand(BuildGetInvestorKeyCommand(services, jsonOptions));
+        cmd.AddCommand(BuildRegisterInvestmentCommand(services, jsonOptions));
 
         return cmd;
     }
@@ -39,13 +42,15 @@ public static class InvestorCommands
         var projectIdOption = new Option<string>("--project-id", "Project ID") { IsRequired = true };
         var amountOption = new Option<long>("--amount", "Amount to invest in sats") { IsRequired = true };
         var feeRateOption = new Option<long>("--fee-rate", "Fee rate in sat/vB") { IsRequired = true };
+        var patternIdOption = new Option<byte?>("--pattern-id", "Pattern ID for Fund/Subscribe projects (0-255)");
 
-        var cmd = new Command("build-draft", "Build an investment transaction draft") { walletIdOption, projectIdOption, amountOption, feeRateOption };
-        cmd.SetHandler(async (string walletId, string projectId, long amount, long feeRate) =>
+        var cmd = new Command("build-draft", "Build an investment transaction draft") { walletIdOption, projectIdOption, amountOption, feeRateOption, patternIdOption };
+        cmd.SetHandler(async (string walletId, string projectId, long amount, long feeRate, byte? patternId) =>
         {
             var result = await investorService.BuildInvestmentDraft(
                 new BuildInvestmentDraft.BuildInvestmentDraftRequest(
-                    new WalletId(walletId), new ProjectId(projectId), new Amount(amount), new DomainFeerate(feeRate)));
+                    new WalletId(walletId), new ProjectId(projectId), new Amount(amount), new DomainFeerate(feeRate),
+                    PatternId: patternId));
 
             if (result.IsFailure)
             {
@@ -54,7 +59,7 @@ public static class InvestorCommands
             }
 
             Console.WriteLine(JsonSerializer.Serialize(result.Value, jsonOptions));
-        }, walletIdOption, projectIdOption, amountOption, feeRateOption);
+        }, walletIdOption, projectIdOption, amountOption, feeRateOption, patternIdOption);
         return cmd;
     }
 
@@ -305,16 +310,40 @@ public static class InvestorCommands
         var feeOption = new Option<long>("--fee", "Transaction fee in sats") { IsRequired = true };
         var walletIdOption = new Option<string?>("--wallet-id", "Wallet ID (optional)");
         var projectIdOption = new Option<string?>("--project-id", "Project ID (optional)");
+        var investorKeyOption = new Option<string?>("--investor-key", "Investor public key (required for investment txs to notify founder via Nostr)");
+        var amountOption = new Option<long?>("--amount", "Investment amount in sats (for investment txs)");
 
-        var cmd = new Command("submit-tx", "Submit a signed investor transaction") { txHexOption, txIdOption, feeOption, walletIdOption, projectIdOption };
-        cmd.SetHandler(async (string txHex, string txId, long fee, string? walletId, string? projectId) =>
+        var cmd = new Command("submit-tx", "Submit a signed investor transaction") { txHexOption, txIdOption, feeOption, walletIdOption, projectIdOption, investorKeyOption, amountOption };
+        cmd.SetHandler(async context =>
         {
-            var draft = new TransactionDraft
+            var txHex = context.ParseResult.GetValueForOption(txHexOption)!;
+            var txId = context.ParseResult.GetValueForOption(txIdOption)!;
+            var fee = context.ParseResult.GetValueForOption(feeOption);
+            var walletId = context.ParseResult.GetValueForOption(walletIdOption);
+            var projectId = context.ParseResult.GetValueForOption(projectIdOption);
+            var investorKey = context.ParseResult.GetValueForOption(investorKeyOption);
+            var amount = context.ParseResult.GetValueForOption(amountOption);
+
+            TransactionDraft draft;
+            if (!string.IsNullOrEmpty(investorKey))
             {
-                SignedTxHex = txHex,
-                TransactionId = txId,
-                TransactionFee = new Amount(fee)
-            };
+                draft = new Angor.Sdk.Funding.Shared.TransactionDrafts.InvestmentDraft(investorKey)
+                {
+                    SignedTxHex = txHex,
+                    TransactionId = txId,
+                    TransactionFee = new Amount(fee),
+                    InvestedAmount = new Amount(amount ?? 0)
+                };
+            }
+            else
+            {
+                draft = new TransactionDraft
+                {
+                    SignedTxHex = txHex,
+                    TransactionId = txId,
+                    TransactionFee = new Amount(fee)
+                };
+            }
 
             var result = await investorService.SubmitTransactionFromDraft(
                 new PublishAndStoreInvestorTransaction.PublishAndStoreInvestorTransactionRequest(
@@ -327,7 +356,7 @@ public static class InvestorCommands
             }
 
             Console.WriteLine($"Transaction published: {result.Value.TransactionId}");
-        }, txHexOption, txIdOption, feeOption, walletIdOption, projectIdOption);
+        });
         return cmd;
     }
 
@@ -350,6 +379,127 @@ public static class InvestorCommands
 
             Console.WriteLine(result.Value.Nsec);
         }, walletIdOption, founderKeyOption);
+        return cmd;
+    }
+
+    private static Command BuildNotifyFounderCommand(IServiceProvider services, JsonSerializerOptions jsonOptions)
+    {
+        var mediator = services.GetRequiredService<MediatR.IMediator>();
+        var walletIdOption = new Option<string>("--wallet-id", "Wallet ID") { IsRequired = true };
+        var projectIdOption = new Option<string>("--project-id", "Project ID") { IsRequired = true };
+        var txIdOption = new Option<string>("--tx-id", "Transaction ID") { IsRequired = true };
+        var investorKeyOption = new Option<string>("--investor-key", "Investor public key") { IsRequired = true };
+
+        var cmd = new Command("notify-founder", "Send Nostr notification to founder about an investment (use when submit-tx was done without --investor-key)")
+        {
+            walletIdOption, projectIdOption, txIdOption, investorKeyOption
+        };
+        cmd.SetHandler(async (string walletId, string projectId, string txId, string investorKey) =>
+        {
+            var draft = new Angor.Sdk.Funding.Shared.TransactionDrafts.InvestmentDraft(investorKey)
+            {
+                TransactionId = txId,
+                SignedTxHex = "N/A", // Not needed for notification
+                TransactionFee = new Amount(0)
+            };
+
+            var result = await mediator.Send(
+                new NotifyFounderOfInvestment.NotifyFounderOfInvestmentRequest(
+                    new WalletId(walletId), new ProjectId(projectId), draft));
+
+            if (result.IsFailure)
+            {
+                Console.Error.WriteLine($"Error: {result.Error}");
+                return;
+            }
+
+            Console.WriteLine(JsonSerializer.Serialize(new
+            {
+                eventId = result.Value.EventId,
+                eventTime = result.Value.EventTime
+            }, jsonOptions));
+        }, walletIdOption, projectIdOption, txIdOption, investorKeyOption);
+        return cmd;
+    }
+
+    private static Command BuildGetInvestorKeyCommand(IServiceProvider services, JsonSerializerOptions jsonOptions)
+    {
+        var seedwordsProvider = services.GetRequiredService<Angor.Sdk.Common.ISeedwordsProvider>();
+        var derivationOperations = services.GetRequiredService<Angor.Shared.IDerivationOperations>();
+        var projectService = services.GetRequiredService<Angor.Sdk.Funding.Services.IProjectService>();
+
+        var walletIdOption = new Option<string>("--wallet-id", "Wallet ID") { IsRequired = true };
+        var projectIdOption = new Option<string>("--project-id", "Project ID") { IsRequired = true };
+
+        var cmd = new Command("get-investor-key", "Derive the investor public key for a wallet+project pair")
+        {
+            walletIdOption, projectIdOption
+        };
+        cmd.SetHandler(async (string walletId, string projectId) =>
+        {
+            var sensitiveDataResult = await seedwordsProvider.GetSensitiveData(walletId);
+            if (sensitiveDataResult.IsFailure)
+            {
+                Console.Error.WriteLine($"Error: {sensitiveDataResult.Error}");
+                return;
+            }
+
+            var walletWords = sensitiveDataResult.Value.ToWalletWords();
+            var projectResult = await projectService.GetAsync(new ProjectId(projectId));
+            if (projectResult.IsFailure)
+            {
+                Console.Error.WriteLine($"Error: {projectResult.Error}");
+                return;
+            }
+
+            var investorKey = derivationOperations.DeriveInvestorKey(walletWords, projectResult.Value.FounderKey);
+            Console.WriteLine(investorKey);
+        }, walletIdOption, projectIdOption);
+        return cmd;
+    }
+
+    private static Command BuildRegisterInvestmentCommand(IServiceProvider services, JsonSerializerOptions jsonOptions)
+    {
+        var portfolioService = services.GetRequiredService<Angor.Sdk.Funding.Investor.Domain.IPortfolioService>();
+
+        var walletIdOption = new Option<string>("--wallet-id", "Wallet ID") { IsRequired = true };
+        var projectIdOption = new Option<string>("--project-id", "Project ID") { IsRequired = true };
+        var txIdOption = new Option<string>("--tx-id", "Investment transaction ID") { IsRequired = true };
+        var txHexOption = new Option<string?>("--tx-hex", "Investment transaction hex (optional)");
+        var investorKeyOption = new Option<string>("--investor-key", "Investor public key") { IsRequired = true };
+        var amountOption = new Option<long>("--amount", "Invested amount in sats") { IsRequired = true };
+
+        var cmd = new Command("register-investment", "Register an existing investment in the local portfolio (for recovery/release flows)")
+        {
+            walletIdOption, projectIdOption, txIdOption, txHexOption, investorKeyOption, amountOption
+        };
+        cmd.SetHandler(async context =>
+        {
+            var walletId = context.ParseResult.GetValueForOption(walletIdOption)!;
+            var projectId = context.ParseResult.GetValueForOption(projectIdOption)!;
+            var txId = context.ParseResult.GetValueForOption(txIdOption)!;
+            var txHex = context.ParseResult.GetValueForOption(txHexOption);
+            var investorKey = context.ParseResult.GetValueForOption(investorKeyOption)!;
+            var amount = context.ParseResult.GetValueForOption(amountOption);
+
+            var record = new Angor.Sdk.Funding.Investor.Domain.InvestmentRecord
+            {
+                ProjectIdentifier = projectId,
+                InvestmentTransactionHash = txId,
+                InvestmentTransactionHex = txHex,
+                InvestorPubKey = investorKey,
+                InvestedAmountSats = amount
+            };
+
+            var result = await portfolioService.AddOrUpdate(walletId, record);
+            if (result.IsFailure)
+            {
+                Console.Error.WriteLine($"Error: {result.Error}");
+                return;
+            }
+
+            Console.WriteLine($"Investment registered for project {projectId}");
+        });
         return cmd;
     }
 }

--- a/src/cli/Angor.Cli/Composition/CompositionRoot.cs
+++ b/src/cli/Angor.Cli/Composition/CompositionRoot.cs
@@ -83,7 +83,6 @@ public static class CompositionRoot
 
         // Security — headless implementations
         services.AddSingleton<IPassphraseProvider>(new HeadlessPassphraseProvider());
-        services.AddSingleton<IPasswordProvider>(new HeadlessPasswordProvider(isMcpMode));
         services.AddSingleton<IWalletSecurityContext, WalletSecurityContext>();
         services.AddSingleton<IWalletEncryption, AesWalletEncryption>();
 
@@ -96,6 +95,10 @@ public static class CompositionRoot
             services.AddSingleton<ISecureKeyProvider, LinuxSecureKeyProvider>(); // Fallback for macOS
         else
             throw new PlatformNotSupportedException("No ISecureKeyProvider implementation available for this platform.");
+
+        // Password provider needs ISecureKeyProvider, so register after it
+        services.AddSingleton<IPasswordProvider>(sp =>
+            new HeadlessPasswordProvider(isMcpMode, sp.GetRequiredService<ISecureKeyProvider>()));
 
         // Register SDK services
         WalletContextServices.Register(services, serilogLogger, network);

--- a/src/cli/Angor.Cli/Composition/HeadlessPasswordProvider.cs
+++ b/src/cli/Angor.Cli/Composition/HeadlessPasswordProvider.cs
@@ -5,24 +5,33 @@ using CSharpFunctionalExtensions;
 namespace Angor.Cli.Composition;
 
 /// <summary>
-/// Provides wallet password from environment variable ANGOR_WALLET_PASSWORD.
-/// In CLI interactive mode, falls back to console prompt.
-/// In MCP mode, fails with a clear error if the env var is not set.
+/// Provides wallet password from the secure key provider (DPAPI on Windows, keyring on Linux),
+/// falling back to environment variable ANGOR_WALLET_PASSWORD.
+/// In CLI interactive mode, falls back further to console prompt.
+/// In MCP mode, fails with a clear error if neither source is available.
 /// </summary>
-public class HeadlessPasswordProvider(bool isMcpMode) : IPasswordProvider
+public class HeadlessPasswordProvider(bool isMcpMode, ISecureKeyProvider secureKeyProvider) : IPasswordProvider
 {
-    public Task<Maybe<string>> Get(WalletId walletId)
+    public async Task<Maybe<string>> Get(WalletId walletId)
     {
+        // First try: DPAPI / secure key store (contains the actual encryption key)
+        var secureKey = await secureKeyProvider.Get(walletId);
+        if (secureKey.HasValue)
+        {
+            return secureKey;
+        }
+
+        // Second try: environment variable
         var envPassword = Environment.GetEnvironmentVariable("ANGOR_WALLET_PASSWORD");
         if (!string.IsNullOrEmpty(envPassword))
         {
-            return Task.FromResult(Maybe<string>.From(envPassword));
+            return Maybe<string>.From(envPassword);
         }
 
         if (isMcpMode)
         {
             // In MCP mode, stdin is reserved for JSON-RPC — cannot prompt interactively.
-            return Task.FromResult(Maybe<string>.None);
+            return Maybe<string>.None;
         }
 
         // CLI interactive mode — prompt on console.
@@ -30,10 +39,10 @@ public class HeadlessPasswordProvider(bool isMcpMode) : IPasswordProvider
         var password = ReadPasswordFromConsole();
         if (string.IsNullOrEmpty(password))
         {
-            return Task.FromResult(Maybe<string>.None);
+            return Maybe<string>.None;
         }
 
-        return Task.FromResult(Maybe<string>.From(password));
+        return Maybe<string>.From(password);
     }
 
     private static string ReadPasswordFromConsole()

--- a/src/cli/Angor.Cli/McpTools/ConfigTools.cs
+++ b/src/cli/Angor.Cli/McpTools/ConfigTools.cs
@@ -41,4 +41,17 @@ public class ConfigTools(INetworkConfiguration networkConfig, INetworkService ne
         networkService.CheckAndSetNetwork(string.Empty, network);
         return $"Network set to: {network}. Restart for the change to take effect.";
     }
+
+    [McpServerTool, Description("Get current debug mode status. When debug mode is enabled on testnet, investment windows are always open and stages are immediately claimable.")]
+    public string ConfigGetDebugMode()
+    {
+        return JsonSerializer.Serialize(new { debugMode = networkConfig.GetDebugMode() }, JsonOptions);
+    }
+
+    [McpServerTool, Description("Enable or disable debug mode. When enabled on testnet, investment windows are always open and stages are immediately claimable. Takes effect immediately.")]
+    public string ConfigSetDebugMode(bool enabled)
+    {
+        networkConfig.SetDebugMode(enabled);
+        return $"Debug mode {(enabled ? "enabled" : "disabled")}.";
+    }
 }

--- a/src/cli/Angor.Cli/McpTools/FounderTools.cs
+++ b/src/cli/Angor.Cli/McpTools/FounderTools.cs
@@ -6,6 +6,7 @@ using Angor.Sdk.Funding.Founder.Domain;
 using Angor.Sdk.Funding.Founder.Dtos;
 using Angor.Sdk.Funding.Founder.Operations;
 using Angor.Sdk.Funding.Projects;
+using Angor.Sdk.Funding.Projects.Dtos;
 using Angor.Sdk.Funding.Shared;
 using Angor.Shared.Models;
 using ModelContextProtocol.Server;
@@ -138,6 +139,51 @@ public class FounderTools(IFounderAppService founderService, IProjectAppService 
     {
         var result = await founderService.GetMoonshotProject(
             new GetMoonshotProject.GetMoonshotProjectRequest(eventId));
+        return result.IsSuccess
+            ? JsonSerializer.Serialize(result.Value, JsonOptions)
+            : $"Error: {result.Error}";
+    }
+
+    [McpServerTool, Description("Create a Nostr profile for a new project. Provide project data as JSON string with fields: projectName, description, avatarUri, bannerUri, sats, startDate, targetAmount, penaltyDays, stages (array of {startDate, percentageOfTotal}), projectType (0=Invest, 1=Fund). Returns the profile event ID.")]
+    public async Task<string> FounderCreateProfile(string walletId, string founderKey, string recoveryKey,
+        string nostrPubKey, string projectIdentifier, string projectDataJson)
+    {
+        var project = JsonSerializer.Deserialize<CreateProjectDto>(projectDataJson, JsonOptions);
+        if (project is null)
+            return "Error: Failed to deserialize project data JSON.";
+
+        var seed = new ProjectSeedDto(founderKey, recoveryKey, nostrPubKey, projectIdentifier);
+        var result = await projectService.CreateProjectProfile(new WalletId(walletId), seed, project);
+        return result.IsSuccess
+            ? JsonSerializer.Serialize(new { eventId = result.Value.EventId }, JsonOptions)
+            : $"Error: {result.Error}";
+    }
+
+    [McpServerTool, Description("Publish project info (stages, metadata) to Nostr. Use the same project data JSON as create-profile. Returns the info event ID needed for create-project.")]
+    public async Task<string> FounderCreateInfo(string walletId, string founderKey, string recoveryKey,
+        string nostrPubKey, string projectIdentifier, string projectDataJson)
+    {
+        var project = JsonSerializer.Deserialize<CreateProjectDto>(projectDataJson, JsonOptions);
+        if (project is null)
+            return "Error: Failed to deserialize project data JSON.";
+
+        var seed = new ProjectSeedDto(founderKey, recoveryKey, nostrPubKey, projectIdentifier);
+        var result = await projectService.CreateProjectInfo(new WalletId(walletId), project, seed);
+        return result.IsSuccess
+            ? JsonSerializer.Serialize(new { eventId = result.Value.EventId }, JsonOptions)
+            : $"Error: {result.Error}";
+    }
+
+    [McpServerTool, Description("Create the on-chain Bitcoin project transaction. Requires the info event ID from FounderCreateInfo. Use the same project data JSON. Returns a transaction draft with txId and fee.")]
+    public async Task<string> FounderCreateProject(string walletId, long feeSats, string infoEventId,
+        string founderKey, string recoveryKey, string nostrPubKey, string projectIdentifier, string projectDataJson)
+    {
+        var project = JsonSerializer.Deserialize<CreateProjectDto>(projectDataJson, JsonOptions);
+        if (project is null)
+            return "Error: Failed to deserialize project data JSON.";
+
+        var seed = new ProjectSeedDto(founderKey, recoveryKey, nostrPubKey, projectIdentifier);
+        var result = await projectService.CreateProject(new WalletId(walletId), feeSats, project, infoEventId, seed);
         return result.IsSuccess
             ? JsonSerializer.Serialize(result.Value, JsonOptions)
             : $"Error: {result.Error}";

--- a/src/cli/Angor.Cli/McpTools/InvestorTools.cs
+++ b/src/cli/Angor.Cli/McpTools/InvestorTools.cs
@@ -17,12 +17,13 @@ public class InvestorTools(IInvestmentAppService investorService)
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    [McpServerTool, Description("Build an investment transaction draft for a project")]
-    public async Task<string> InvestorBuildDraft(string walletId, string projectId, long amountSats, long feeRateSatPerVb)
+    [McpServerTool, Description("Build an investment transaction draft for a project. For Fund/Subscribe projects, patternId is required (byte 0-255).")]
+    public async Task<string> InvestorBuildDraft(string walletId, string projectId, long amountSats, long feeRateSatPerVb, byte? patternId = null)
     {
         var result = await investorService.BuildInvestmentDraft(
             new BuildInvestmentDraft.BuildInvestmentDraftRequest(
-                new WalletId(walletId), new ProjectId(projectId), new Amount(amountSats), new DomainFeerate(feeRateSatPerVb)));
+                new WalletId(walletId), new ProjectId(projectId), new Amount(amountSats), new DomainFeerate(feeRateSatPerVb),
+                PatternId: patternId));
         return result.IsSuccess
             ? JsonSerializer.Serialize(result.Value, JsonOptions)
             : $"Error: {result.Error}";
@@ -200,16 +201,30 @@ public class InvestorTools(IInvestmentAppService investorService)
             : $"Error: {result.Error}";
     }
 
-    [McpServerTool, Description("Submit a signed investor transaction to the network")]
+    [McpServerTool, Description("Submit a signed investor transaction to the network. For investment transactions, provide investorKey and amountSats to enable Nostr founder notification.")]
     public async Task<string> InvestorSubmitTx(string signedTxHex, string transactionId, long feeSats,
-        string? walletId = null, string? projectId = null)
+        string? walletId = null, string? projectId = null, string? investorKey = null, long? amountSats = null)
     {
-        var draft = new TransactionDraft
+        TransactionDraft draft;
+        if (!string.IsNullOrEmpty(investorKey))
         {
-            SignedTxHex = signedTxHex,
-            TransactionId = transactionId,
-            TransactionFee = new Amount(feeSats)
-        };
+            draft = new Angor.Sdk.Funding.Shared.TransactionDrafts.InvestmentDraft(investorKey)
+            {
+                SignedTxHex = signedTxHex,
+                TransactionId = transactionId,
+                TransactionFee = new Amount(feeSats),
+                InvestedAmount = new Amount(amountSats ?? 0)
+            };
+        }
+        else
+        {
+            draft = new TransactionDraft
+            {
+                SignedTxHex = signedTxHex,
+                TransactionId = transactionId,
+                TransactionFee = new Amount(feeSats)
+            };
+        }
 
         var result = await investorService.SubmitTransactionFromDraft(
             new PublishAndStoreInvestorTransaction.PublishAndStoreInvestorTransactionRequest(


### PR DESCRIPTION
Applies stashed CLI improvements from previous testing session:

- **HeadlessPasswordProvider DPAPI fix**: Try secure key store (DPAPI/keyring) before falling back to env var
- **DI reorder**: Register ISecureKeyProvider before IPasswordProvider so the factory lambda can resolve it
- **Founder commands**: create-profile, create-info, create-project, spend-stage multi-address output
- **Investor commands**: notify-founder, get-investor-key, register-investment, --pattern-id on build-draft
- **submit-tx**: Creates InvestmentDraft (not TransactionDraft) when investorKey is provided, enabling Nostr founder notifications
- **Config commands**: set-debug-mode, get-debug-mode (CLI + MCP)
- **MCP tools**: FounderTools, ConfigTools, InvestorTools patternId + investorKey params