### PR TITLE
fix: Boltz Lightning invoice uses wrong network after runtime network switch

### DIFF
--- a/src/sdk/Angor.Sdk.Tests/Integration/Lightning/BoltzNetworkSwitchingTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Integration/Lightning/BoltzNetworkSwitchingTests.cs
@@ -1,0 +1,189 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Angor.Sdk.Common;
+using Angor.Shared.Integration.Lightning;
+using Angor.Shared.Integration.Lightning.Models;
+using Angor.Shared.Networks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Angor.Sdk.Tests.Integration.Lightning;
+
+/// <summary>
+/// Regression coverage for the bug where the lightning invoice generated on the
+/// invoice payment page was always anchored to the Boltz signet (Angornet) endpoint
+/// even after the user switched to mainnet in Settings.
+///
+/// Root cause was that <see cref="BoltzConfiguration.BaseUrl"/> was captured once at
+/// app startup and the singleton <see cref="BoltzSwapService"/> set
+/// <c>HttpClient.BaseAddress</c> in its constructor, so a later
+/// <c>INetworkConfiguration.SetNetwork(...)</c> never reached the Lightning swap path.
+/// </summary>
+public class BoltzNetworkSwitchingTests
+{
+    private const string ExpectedMainnetHost = "api.boltz.exchange";
+    private const string ExpectedTestnetHost = "test.boltz.angor.io";
+
+    [Fact]
+    public void ResolveBaseUrl_OnMainnet_ReturnsMainnetUrl()
+    {
+        var networkConfiguration = new NetworkConfiguration();
+        networkConfiguration.SetNetwork(new BitcoinMain());
+        var config = new BoltzConfiguration();
+
+        var resolved = config.ResolveBaseUrl(networkConfiguration);
+
+        Assert.Equal(ExpectedMainnetHost, new Uri(resolved).Host);
+    }
+
+    [Fact]
+    public void ResolveBaseUrl_OnAngornet_ReturnsTestnetUrl()
+    {
+        var networkConfiguration = new NetworkConfiguration();
+        networkConfiguration.SetNetwork(new Angornet());
+        var config = new BoltzConfiguration();
+
+        var resolved = config.ResolveBaseUrl(networkConfiguration);
+
+        Assert.Equal(ExpectedTestnetHost, new Uri(resolved).Host);
+    }
+
+    [Fact]
+    public void ResolveBaseUrl_WithOverride_AlwaysReturnsOverride()
+    {
+        var networkConfiguration = new NetworkConfiguration();
+        networkConfiguration.SetNetwork(new BitcoinMain());
+        var config = new BoltzConfiguration { OverrideBaseUrl = "https://my-boltz.example/" };
+
+        var resolved = config.ResolveBaseUrl(networkConfiguration);
+
+        Assert.Equal("my-boltz.example", new Uri(resolved).Host);
+    }
+
+    /// <summary>
+    /// The original bug: switching to mainnet at runtime still produced a signet
+    /// Lightning invoice because the Boltz HTTP base URL was frozen at startup.
+    /// This test creates a single <see cref="BoltzSwapService"/> instance (as DI
+    /// does — singleton lifetime), fires the swap-creation HTTP request twice
+    /// with a runtime network switch in between, and asserts that the second
+    /// request hits the mainnet host.
+    /// </summary>
+    [Fact]
+    public async Task BoltzSwapService_FollowsRuntimeNetworkSwitch_FromAngornetToMainnet()
+    {
+        var networkConfiguration = new NetworkConfiguration();
+        networkConfiguration.SetNetwork(new Angornet());
+
+        var handler = new RecordingHandler();
+        var httpClient = new HttpClient(handler);
+        var config = new BoltzConfiguration { UseV2Prefix = true };
+
+        var service = new BoltzSwapService(
+            httpClient,
+            config,
+            networkConfiguration,
+            new NullLogger<BoltzSwapService>());
+
+        // First call: still on Angornet (signet). The bug would have pinned the host here.
+        await service.GetReverseSwapFeesAsync();
+        var firstHost = handler.LastRequestUri?.Host;
+
+        // Simulate the Settings → Switch network → Mainnet action.
+        networkConfiguration.SetNetwork(new BitcoinMain());
+
+        // Second call: must now hit the mainnet host on the SAME singleton instance.
+        await service.GetReverseSwapFeesAsync();
+        var secondHost = handler.LastRequestUri?.Host;
+
+        Assert.Equal(ExpectedTestnetHost, firstHost);
+        Assert.Equal(ExpectedMainnetHost, secondHost);
+    }
+
+    [Fact]
+    public async Task BoltzSwapService_FollowsRuntimeNetworkSwitch_FromMainnetToAngornet()
+    {
+        var networkConfiguration = new NetworkConfiguration();
+        networkConfiguration.SetNetwork(new BitcoinMain());
+
+        var handler = new RecordingHandler();
+        var httpClient = new HttpClient(handler);
+        var config = new BoltzConfiguration { UseV2Prefix = true };
+
+        var service = new BoltzSwapService(
+            httpClient,
+            config,
+            networkConfiguration,
+            new NullLogger<BoltzSwapService>());
+
+        await service.GetReverseSwapFeesAsync();
+        var firstHost = handler.LastRequestUri?.Host;
+
+        networkConfiguration.SetNetwork(new Angornet());
+
+        await service.GetReverseSwapFeesAsync();
+        var secondHost = handler.LastRequestUri?.Host;
+
+        Assert.Equal(ExpectedMainnetHost, firstHost);
+        Assert.Equal(ExpectedTestnetHost, secondHost);
+    }
+
+    [Fact]
+    public async Task BoltzSwapService_RequestPath_IncludesV2Prefix()
+    {
+        var networkConfiguration = new NetworkConfiguration();
+        networkConfiguration.SetNetwork(new BitcoinMain());
+
+        var handler = new RecordingHandler();
+        var httpClient = new HttpClient(handler);
+        var config = new BoltzConfiguration { UseV2Prefix = true };
+
+        var service = new BoltzSwapService(
+            httpClient,
+            config,
+            networkConfiguration,
+            new NullLogger<BoltzSwapService>());
+
+        await service.GetReverseSwapFeesAsync();
+
+        Assert.NotNull(handler.LastRequestUri);
+        Assert.Equal("/v2/swap/reverse", handler.LastRequestUri!.AbsolutePath);
+    }
+
+    /// <summary>
+    /// Captures the URI of every outbound request and returns a minimal valid
+    /// reverse-swap-info JSON body so the calling code does not fail before we
+    /// can inspect what URL it built.
+    /// </summary>
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public Uri? LastRequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+
+            // Shape required by ReverseSwapInfoResponse so deserialisation succeeds.
+            const string body = """
+                {
+                  "BTC": {
+                    "BTC": {
+                      "fees": { "percentage": 0.5, "minerFees": { "claim": 100 } },
+                      "limits": { "minimal": 10000, "maximal": 25000000 }
+                    }
+                  }
+                }
+                """;
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body)
+                {
+                    Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+                }
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/src/sdk/Angor.Sdk.Tests/Integration/Lightning/LightningIntegrationTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Integration/Lightning/LightningIntegrationTests.cs
@@ -87,7 +87,7 @@ public class BoltzSwapIntegrationTests : IDisposable
 
         var boltzConfig = new BoltzConfiguration
         {
-            BaseUrl = BoltzApiUrl,
+            OverrideBaseUrl = BoltzApiUrl,
             UseV2Prefix = UseV2Prefix,
             TimeoutSeconds = 60
         };
@@ -107,6 +107,7 @@ public class BoltzSwapIntegrationTests : IDisposable
 
         _boltzWebSocketClient = new BoltzWebSocketClient(
             boltzConfig,
+            _networkConfiguration,
             new NullLogger<BoltzWebSocketClient>());
 
         var inMemoryCollection = new InMemoryBoltzSwapCollection();

--- a/src/sdk/Angor.Sdk/Funding/FundingContextServices.cs
+++ b/src/sdk/Angor.Sdk/Funding/FundingContextServices.cs
@@ -71,11 +71,14 @@ public static class FundingContextServices
         services.TryAddSingleton<IAddressPollingService, AddressPollingService>();
         services.TryAddSingleton<IMempoolMonitoringService, MempoolMonitoringService>();
         
-        // Lightning Network / Boltz submarine swap services
-        // Using testnet by default for development
+        // Lightning Network / Boltz submarine swap services.
+        // BoltzConfiguration carries only an optional URL override (for the BOLTZ_API_URL
+        // env var or integration tests); when unset, BoltzSwapService / BoltzWebSocketClient
+        // resolve the URL from INetworkConfiguration on each call, so a runtime network
+        // switch (mainnet ↔ signet) is honoured without rebuilding the container.
         services.TryAddSingleton<BoltzConfiguration>(_ => new BoltzConfiguration
         {
-            BaseUrl = Environment.GetEnvironmentVariable("BOLTZ_API_URL") ?? BoltzConfiguration.TestnetUrl,
+            OverrideBaseUrl = Environment.GetEnvironmentVariable("BOLTZ_API_URL"),
             TimeoutSeconds = 30,
             UseV2Prefix = true
         });

--- a/src/shared/Angor.Shared/Integration/Lightning/BoltzSwapService.cs
+++ b/src/shared/Angor.Shared/Integration/Lightning/BoltzSwapService.cs
@@ -20,7 +20,6 @@ public class BoltzSwapService : IBoltzSwapService
     private readonly INetworkConfiguration _networkConfiguration;
     private readonly ILogger<BoltzSwapService> _logger;
     private readonly JsonSerializerOptions _jsonOptions;
-    private readonly string _apiPrefix;
 
     public BoltzSwapService(
         HttpClient httpClient,
@@ -33,9 +32,10 @@ public class BoltzSwapService : IBoltzSwapService
         _networkConfiguration = networkConfiguration ?? throw new ArgumentNullException(nameof(networkConfiguration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-        _httpClient.BaseAddress = new Uri(_configuration.BaseUrl);
+        // BaseAddress is intentionally not set: it captures the URL at construction time
+        // and singleton HttpClient/BoltzSwapService instances would never see a runtime
+        // network switch. Each request resolves the base URL via BuildUri().
         _httpClient.Timeout = TimeSpan.FromSeconds(_configuration.TimeoutSeconds);
-        _apiPrefix = _configuration.ApiPrefix;
 
         _jsonOptions = new JsonSerializerOptions
         {
@@ -44,6 +44,17 @@ public class BoltzSwapService : IBoltzSwapService
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
         };
+    }
+
+    /// <summary>
+    /// Builds an absolute URI for the given relative API path, resolving the base URL
+    /// from <see cref="INetworkConfiguration"/> on every call so a runtime network switch
+    /// (mainnet ↔ signet) is honoured without rebuilding the DI container.
+    /// </summary>
+    private Uri BuildUri(string relativePath)
+    {
+        var baseUrl = _configuration.ResolveBaseUrl(_networkConfiguration);
+        return new Uri(new Uri(baseUrl), $"{_configuration.ApiPrefix}{relativePath}");
     }
 
     /// <summary>
@@ -101,7 +112,7 @@ public class BoltzSwapService : IBoltzSwapService
 
             var content = new StringContent(requestJson, System.Text.Encoding.UTF8);
             content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            var response = await _httpClient.PostAsync($"{_apiPrefix}swap/reverse", content);
+            var response = await _httpClient.PostAsync(BuildUri("swap/reverse"), content);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -170,7 +181,7 @@ public class BoltzSwapService : IBoltzSwapService
         {
             _logger.LogDebug("Getting swap status for {SwapId}", swapId);
 
-            var response = await _httpClient.GetAsync($"{_apiPrefix}swap/{swapId}");
+            var response = await _httpClient.GetAsync(BuildUri($"swap/{swapId}"));
 
             if (!response.IsSuccessStatusCode)
             {
@@ -212,7 +223,7 @@ public class BoltzSwapService : IBoltzSwapService
         {
             _logger.LogDebug("Getting swap details for {SwapId}", swapId);
 
-            var response = await _httpClient.GetAsync($"{_apiPrefix}swap/reverse/{swapId}");
+            var response = await _httpClient.GetAsync(BuildUri($"swap/reverse/{swapId}"));
 
             if (!response.IsSuccessStatusCode)
             {
@@ -270,7 +281,7 @@ public class BoltzSwapService : IBoltzSwapService
                 PubNonce = pubNonce
             };
 
-            var response = await _httpClient.PostAsJsonAsync($"{_apiPrefix}swap/reverse/{swapId}/claim", request, _jsonOptions);
+            var response = await _httpClient.PostAsJsonAsync(BuildUri($"swap/reverse/{swapId}/claim"), request, _jsonOptions);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -309,7 +320,7 @@ public class BoltzSwapService : IBoltzSwapService
             _logger.LogInformation("Broadcasting transaction via Boltz API");
 
             var request = new BroadcastRequest { Hex = transactionHex };
-            var response = await _httpClient.PostAsJsonAsync($"{_apiPrefix}chain/BTC/transaction", request, _jsonOptions);
+            var response = await _httpClient.PostAsJsonAsync(BuildUri("chain/BTC/transaction"), request, _jsonOptions);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -340,7 +351,7 @@ public class BoltzSwapService : IBoltzSwapService
         {
             _logger.LogDebug("Fetching reverse swap fee information from Boltz");
 
-            var response = await _httpClient.GetAsync($"{_apiPrefix}swap/reverse");
+            var response = await _httpClient.GetAsync(BuildUri("swap/reverse"));
 
             if (!response.IsSuccessStatusCode)
             {

--- a/src/shared/Angor.Shared/Integration/Lightning/BoltzWebSocketClient.cs
+++ b/src/shared/Angor.Shared/Integration/Lightning/BoltzWebSocketClient.cs
@@ -13,29 +13,41 @@ namespace Angor.Shared.Integration.Lightning;
 /// </summary>
 public class BoltzWebSocketClient : IBoltzWebSocketClient, IAsyncDisposable
 {
-    private readonly string _webSocketUrl;
+    private readonly BoltzConfiguration _configuration;
+    private readonly INetworkConfiguration _networkConfiguration;
     private readonly ILogger<BoltzWebSocketClient> _logger;
     private readonly JsonSerializerOptions _jsonOptions;
     private ClientWebSocket? _webSocket;
 
     public BoltzWebSocketClient(
         BoltzConfiguration configuration,
+        INetworkConfiguration networkConfiguration,
         ILogger<BoltzWebSocketClient> logger)
     {
-        var baseUrl = configuration.BaseUrl
-            .Replace("https://", "wss://")
-            .Replace("http://", "ws://")
-            .TrimEnd('/');
-
-        var wsPath = configuration.UseV2Prefix ? "/v2/ws" : "/ws";
-        _webSocketUrl = $"{baseUrl}{wsPath}";
-
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _networkConfiguration = networkConfiguration ?? throw new ArgumentNullException(nameof(networkConfiguration));
         _logger = logger;
         _jsonOptions = new JsonSerializerOptions
         {
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
+    }
+
+    /// <summary>
+    /// Resolves the WebSocket URL from the current Boltz base URL.
+    /// Called on every connect so a runtime network switch (mainnet ↔ signet)
+    /// is honoured without rebuilding the client.
+    /// </summary>
+    private string ResolveWebSocketUrl()
+    {
+        var baseUrl = _configuration.ResolveBaseUrl(_networkConfiguration)
+            .Replace("https://", "wss://")
+            .Replace("http://", "ws://")
+            .TrimEnd('/');
+
+        var wsPath = _configuration.UseV2Prefix ? "/v2/ws" : "/ws";
+        return $"{baseUrl}{wsPath}";
     }
 
     private const int MaxReconnectAttempts = 5;
@@ -59,13 +71,14 @@ public class BoltzWebSocketClient : IBoltzWebSocketClient, IAsyncDisposable
             {
                 _webSocket?.Dispose();
                 _webSocket = new ClientWebSocket();
-                await _webSocket.ConnectAsync(new Uri(_webSocketUrl), linkedCts.Token);
+                var webSocketUrl = ResolveWebSocketUrl();
+                await _webSocket.ConnectAsync(new Uri(webSocketUrl), linkedCts.Token);
 
                 _logger.LogInformation(
                     attempt == 0
                         ? "Connected to Boltz WebSocket at {Url}"
                         : "Reconnected to Boltz WebSocket at {Url} (attempt {Attempt})",
-                    _webSocketUrl, attempt);
+                    webSocketUrl, attempt);
 
                 attempt = 0;
 

--- a/src/shared/Angor.Shared/Integration/Lightning/Models/BoltzConfiguration.cs
+++ b/src/shared/Angor.Shared/Integration/Lightning/Models/BoltzConfiguration.cs
@@ -1,8 +1,11 @@
+using Blockcore.Networks;
+
 namespace Angor.Shared.Integration.Lightning.Models
 {
     /// <summary>
     /// Configuration for Boltz swap service.
-    /// Set BaseUrl based on your environment (mainnet or testnet).
+    /// The active base URL is resolved per-call via <see cref="ResolveBaseUrl"/>,
+    /// so a runtime network switch (mainnet ↔ testnet) is honoured without rebuilding the container.
     /// </summary>
     public class BoltzConfiguration
     {
@@ -10,9 +13,12 @@ namespace Angor.Shared.Integration.Lightning.Models
         public const string TestnetUrl = "https://test.boltz.angor.io/";
 
         /// <summary>
-        /// The Boltz API base URL. Defaults to mainnet.
+        /// Optional explicit base URL override. When non-empty, takes precedence over the
+        /// network-derived URL (used for integration tests and the BOLTZ_API_URL env var).
+        /// When null/empty, services pick <see cref="MainnetUrl"/> or <see cref="TestnetUrl"/>
+        /// based on the current <see cref="INetworkConfiguration"/>.
         /// </summary>
-        public string BaseUrl { get; set; } = MainnetUrl;
+        public string? OverrideBaseUrl { get; set; }
 
         /// <summary>
         /// Request timeout in seconds.
@@ -30,6 +36,26 @@ namespace Angor.Shared.Integration.Lightning.Models
         /// Gets the API path prefix based on configuration.
         /// </summary>
         public string ApiPrefix => UseV2Prefix ? "v2/" : "";
+
+        /// <summary>
+        /// Resolves the active base URL. Uses <see cref="OverrideBaseUrl"/> when set,
+        /// otherwise picks the URL for the current network (mainnet vs. test/signet).
+        /// Always returns a value ending in '/' so it can be safely used as an
+        /// <see cref="Uri"/> base for relative requests.
+        /// </summary>
+        public string ResolveBaseUrl(INetworkConfiguration networkConfiguration)
+        {
+            var resolved = !string.IsNullOrWhiteSpace(OverrideBaseUrl)
+                ? OverrideBaseUrl!
+                : SelectByNetwork(networkConfiguration);
+
+            return resolved.EndsWith('/') ? resolved : resolved + "/";
+        }
+
+        private static string SelectByNetwork(INetworkConfiguration networkConfiguration)
+        {
+            var network = networkConfiguration.GetNetwork();
+            return network.NetworkType == NetworkType.Mainnet ? MainnetUrl : TestnetUrl;
+        }
     }
 }
-

--- a/src/webapp/Angor.Client/Program.cs
+++ b/src/webapp/Angor.Client/Program.cs
@@ -79,10 +79,11 @@ builder.Services.AddScoped<IMessageService, MessageService>();
 
 builder.Services.AddScoped<IBoltzSwapStorageService, BoltzSwapStorageService>();
 
-// Lightning Network / Boltz submarine swap services
+// Lightning Network / Boltz submarine swap services.
+// No OverrideBaseUrl: the Boltz services resolve mainnet vs. signet from
+// INetworkConfiguration on every call.
 builder.Services.AddSingleton<BoltzConfiguration>(_ => new BoltzConfiguration
 {
-    BaseUrl = BoltzConfiguration.TestnetUrl,
     TimeoutSeconds = 30,
     UseV2Prefix = true
 });


### PR DESCRIPTION
## Summary

- The Lightning invoice generated on the invoice payment page stayed pinned to the Angor signet Boltz endpoint (`https://test.boltz.angor.io/`) even after the user switched the wallet to Mainnet in Settings.
- Root cause: `BoltzConfiguration.BaseUrl` was captured once at app startup, and `BoltzSwapService` set `HttpClient.BaseAddress` in its constructor. Both `BoltzSwapService` and `BoltzWebSocketClient` are singleton/long-lived, so the runtime `INetworkConfiguration.SetNetwork(...)` in `SettingsViewModel.SwitchNetworkStorageAsync` never reached the Lightning swap path — on-chain addresses flipped to mainnet but Lightning invoices remained signet.
- Fix: `BoltzConfiguration` now carries an optional `OverrideBaseUrl` (for the `BOLTZ_API_URL` env var and integration tests) plus a `ResolveBaseUrl(INetworkConfiguration)` helper. `BoltzSwapService` builds absolute request URIs per call via `BuildUri(...)`, and `BoltzWebSocketClient` resolves its `wss://` URL at connect time. Same DI lifetimes, no container rebuild needed on network switch.

## Test plan

- [x] New unit tests in `BoltzNetworkSwitchingTests` (all green):
  - `ResolveBaseUrl_OnMainnet_ReturnsMainnetUrl`
  - `ResolveBaseUrl_OnAngornet_ReturnsTestnetUrl`
  - `ResolveBaseUrl_WithOverride_AlwaysReturnsOverride`
  - `BoltzSwapService_FollowsRuntimeNetworkSwitch_FromAngornetToMainnet` — the exact regression: one singleton service, switch network in between two calls, second call hits `api.boltz.exchange`.
  - `BoltzSwapService_FollowsRuntimeNetworkSwitch_FromMainnetToAngornet`
  - `BoltzSwapService_RequestPath_IncludesV2Prefix`
- [x] All other Lightning/Boltz tests pass (43 passed, 3 skipped integration tests as before).
- [x] `Angor.Client` (webapp) and `App` (Avalonia design app) build clean.
- [ ] Manual check on desktop: with a wallet on Angornet, open invoice payment page → confirm signet invoice. Switch to Mainnet in Settings → reopen invoice payment page → invoice now decodes to `lnbc...` (mainnet) instead of `lntbs...` / `lnsbt...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)