### PR TITLE
Fix mobile settings layouts

### DIFF
--- a/src/design/App.Android/MainActivity.cs
+++ b/src/design/App.Android/MainActivity.cs
@@ -135,6 +135,20 @@ public class MainActivity : AvaloniaMainActivity
         GetLogger()?.LogInformation("Lifecycle: OnNewIntent action={Action} flags={Flags}", intent?.Action, intent?.Flags);
     }
 
+    public override bool DispatchKeyEvent(KeyEvent? e)
+    {
+        if (e?.KeyCode == Keycode.Back)
+        {
+            if (e.Action == KeyEventActions.Down && CanHandleShellBack())
+                return true;
+
+            if (e.Action == KeyEventActions.Up && TryHandleShellBack())
+                return true;
+        }
+
+        return base.DispatchKeyEvent(e);
+    }
+
     public override void OnBackPressed()
     {
         if (_handlingPlatformBack)
@@ -143,14 +157,28 @@ public class MainActivity : AvaloniaMainActivity
             return;
         }
 
-        Dispatcher.UIThread.Post(() =>
-        {
-            if (ShellService.TryHandlePlatformBack()) return;
+        if (TryHandleShellBack())
+            return;
 
-            _handlingPlatformBack = true;
-            OnBackPressed();
-            _handlingPlatformBack = false;
-        });
+        _handlingPlatformBack = true;
+        base.OnBackPressed();
+        _handlingPlatformBack = false;
+    }
+
+    private static bool CanHandleShellBack()
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+            return ShellService.CanHandlePlatformBack();
+
+        return Dispatcher.UIThread.InvokeAsync(ShellService.CanHandlePlatformBack).GetAwaiter().GetResult();
+    }
+
+    private static bool TryHandleShellBack()
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+            return ShellService.TryHandlePlatformBack();
+
+        return Dispatcher.UIThread.InvokeAsync(ShellService.TryHandlePlatformBack).GetAwaiter().GetResult();
     }
 }
 

--- a/src/design/App/Automation/AutomationFlows.cs
+++ b/src/design/App/Automation/AutomationFlows.cs
@@ -2175,14 +2175,17 @@ public static class AutomationFlows
             await ClickByNameAsync(window, "SubmitButton");
             await Task.Delay(500);
 
-            // Click "Pay invoice instead" button
-            await ClickByNameAsync(window, "PayInvoiceInsteadButton", TimeSpan.FromSeconds(15));
-            await Task.Delay(1000);
-
             var pf = await Dispatcher.UIThread.InvokeAsync(() => investVm.PaymentFlow);
             if (pf == null)
             {
                 return new InvestViaInvoiceResponse { Success = false, Error = "PaymentFlow not available" };
+            }
+
+            // If no wallet can pay directly, the flow now opens the invoice screen immediately.
+            if (pf.CurrentScreen != global::App.UI.Shared.PaymentFlow.PaymentFlowScreen.Invoice)
+            {
+                await ClickByNameAsync(window, "PayInvoiceInsteadButton", TimeSpan.FromSeconds(15));
+                await Task.Delay(1000);
             }
 
             // Wait for on-chain address to be generated (both tabs need it)

--- a/src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs
+++ b/src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs
@@ -715,6 +715,7 @@ public partial class InvestPageViewModel : ReactiveObject, IDisposable
                 await InvestAfterPaymentAsync(walletId, fundingAddress, amount),
             OnPayWithWallet = async (walletId, amount, feeRate) =>
                 await InvestWithWalletAsync(walletId, amount, feeRate),
+            SkipWalletSelectorWhenNoWalletCanPay = true,
         };
 
         return new PaymentFlowViewModel(

--- a/src/design/App/UI/Sections/Portfolio/RecoveryModalsView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/RecoveryModalsView.axaml
@@ -57,7 +57,7 @@
                     <Panel>
                         <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
                             <i:Icon Value="fa-solid fa-arrows-rotate" FontSize="20"
-                                    Foreground="{DynamicResource TextMuted}" />
+                                    Foreground="{DynamicResource PrimaryGreenBrush}" />
                             <TextBlock Text="Recovery" FontSize="24" FontWeight="Bold"
                                        Foreground="{DynamicResource TextStrong}" />
                         </StackPanel>
@@ -73,28 +73,36 @@
                         CornerRadius="0,0,15,15"
                         BorderBrush="{DynamicResource ModalHeaderBorder}"
                         Background="{DynamicResource RecoveryModalBg}">
-                    <StackPanel Orientation="Horizontal" Spacing="12" HorizontalAlignment="Right">
+                    <Grid ColumnDefinitions="*,12,*" HorizontalAlignment="Stretch">
                         <!-- Cancel -->
-                        <Button Name="CancelRecoveryModal" Classes="ModalBtn MobileAction" Cursor="Hand">
-                            <Border CornerRadius="8" Padding="24,12"
+                        <Button Name="CancelRecoveryModal" Grid.Column="0" Classes="ModalBtn MobileAction" Cursor="Hand"
+                                HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+                            <Border CornerRadius="8" Padding="24,12" HorizontalAlignment="Stretch"
                                     Background="{DynamicResource ModalCancelBg}">
                                 <TextBlock Text="Cancel" FontSize="14" FontWeight="SemiBold"
-                                           Foreground="{DynamicResource ModalCancelFg}" />
+                                           Foreground="{DynamicResource ModalCancelFg}"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Center" />
                             </Border>
                         </Button>
                         <!-- Confirm -->
-                        <Button Name="ConfirmRecoveryModal" Classes="ModalBtn MobileAction" Cursor="Hand">
-                            <Border CornerRadius="8" Padding="24,12"
+                        <Button Name="ConfirmRecoveryModal" Grid.Column="2" Classes="ModalBtn MobileAction" Cursor="Hand"
+                                HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+                            <Border CornerRadius="8" Padding="24,12" HorizontalAlignment="Stretch"
                                     ClipToBounds="True"
                                     Background="{DynamicResource GreenGradient}">
                                 <Panel>
                                     <TextBlock Text="Confirm" FontSize="14" FontWeight="SemiBold"
                                                Foreground="White"
                                                IsVisible="{Binding !IsProcessing}"
-                                               HorizontalAlignment="Center" />
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"
+                                               TextAlignment="Center" />
                                     <StackPanel Orientation="Horizontal" Spacing="8"
                                                 IsVisible="{Binding IsProcessing}"
-                                                HorizontalAlignment="Center">
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center">
                                         <i:Icon Value="fa-solid fa-spinner" FontSize="14" Foreground="White"
                                                 RenderTransformOrigin="50%,50%">
                                             <i:Icon.RenderTransform>
@@ -121,7 +129,7 @@
                                 </Panel>
                             </Border>
                         </Button>
-                    </StackPanel>
+                    </Grid>
                 </Border>
 
                 <!-- ── Scrollable Content ── -->
@@ -427,26 +435,34 @@
                         CornerRadius="0,0,15,15"
                         BorderBrush="{DynamicResource ModalHeaderBorder}"
                         Background="{DynamicResource RecoveryModalBg}">
-                    <StackPanel Orientation="Horizontal" Spacing="12" HorizontalAlignment="Right">
-                        <Button Name="CancelReleaseModal" Classes="ModalBtn MobileAction" Cursor="Hand">
-                            <Border CornerRadius="8" Padding="24,12"
+                    <Grid ColumnDefinitions="*,12,*" HorizontalAlignment="Stretch">
+                        <Button Name="CancelReleaseModal" Grid.Column="0" Classes="ModalBtn MobileAction" Cursor="Hand"
+                                HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+                            <Border CornerRadius="8" Padding="24,12" HorizontalAlignment="Stretch"
                                     Background="{DynamicResource ModalCancelBg}">
                                 <TextBlock Text="Cancel" FontSize="14" FontWeight="SemiBold"
-                                           Foreground="{DynamicResource ModalCancelFg}" />
+                                           Foreground="{DynamicResource ModalCancelFg}"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Center" />
                             </Border>
                         </Button>
-                        <Button Name="ConfirmReleaseModal" Classes="ModalBtn MobileAction" Cursor="Hand">
-                            <Border CornerRadius="8" Padding="24,12"
+                        <Button Name="ConfirmReleaseModal" Grid.Column="2" Classes="ModalBtn MobileAction" Cursor="Hand"
+                                HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+                            <Border CornerRadius="8" Padding="24,12" HorizontalAlignment="Stretch"
                                     ClipToBounds="True"
                                     Background="{DynamicResource GreenGradient}">
                                 <Panel>
                                     <TextBlock Text="Confirm" FontSize="14" FontWeight="SemiBold"
                                                Foreground="White"
                                                IsVisible="{Binding !IsProcessing}"
-                                               HorizontalAlignment="Center" />
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"
+                                               TextAlignment="Center" />
                                     <StackPanel Orientation="Horizontal" Spacing="8"
                                                 IsVisible="{Binding IsProcessing}"
-                                                HorizontalAlignment="Center">
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center">
                                         <i:Icon Value="fa-solid fa-spinner" FontSize="14" Foreground="White"
                                                 RenderTransformOrigin="50%,50%">
                                             <i:Icon.RenderTransform>
@@ -473,7 +489,7 @@
                                 </Panel>
                             </Border>
                         </Button>
-                    </StackPanel>
+                    </Grid>
                 </Border>
 
                 <!-- ── Scrollable Content ── -->

--- a/src/design/App/UI/Sections/Settings/SettingsView.axaml
+++ b/src/design/App/UI/Sections/Settings/SettingsView.axaml
@@ -317,7 +317,8 @@
                                                             x:Name="StatusBadge">
                                                         <TextBlock Text="{Binding Status}"
                                                                    FontSize="12"
-                                                                   FontWeight="SemiBold" />
+                                                                   FontWeight="SemiBold"
+                                                                   TextWrapping="NoWrap" />
                                                     </Border>
                                                     <!-- Link URL -->
                                                     <TextBlock Text="{Binding Url}"
@@ -325,6 +326,7 @@
                                                                FontWeight="Medium"
                                                                Foreground="{DynamicResource SettingsLinkFg}"
                                                                VerticalAlignment="Center"
+                                                               TextWrapping="NoWrap"
                                                                TextTrimming="CharacterEllipsis" />
                                                 </DockPanel>
                                             </Border>
@@ -416,7 +418,8 @@
                                                             x:Name="RelayStatusBadge">
                                                         <TextBlock Text="{Binding Status}"
                                                                    FontSize="12"
-                                                                   FontWeight="SemiBold" />
+                                                                   FontWeight="SemiBold"
+                                                                   TextWrapping="NoWrap" />
                                                     </Border>
                                                     <!-- Name -->
                                                     <TextBlock DockPanel.Dock="Right"
@@ -424,13 +427,17 @@
                                                                FontSize="14"
                                                                Foreground="{DynamicResource TextMuted}"
                                                                Margin="12,0"
-                                                               VerticalAlignment="Center" />
+                                                               VerticalAlignment="Center"
+                                                               TextWrapping="NoWrap"
+                                                               TextTrimming="CharacterEllipsis"
+                                                               MaxWidth="130" />
                                                     <!-- Link URL -->
                                                     <TextBlock Text="{Binding Url}"
                                                                FontSize="14"
                                                                FontWeight="Medium"
                                                                Foreground="{DynamicResource SettingsLinkFg}"
                                                                VerticalAlignment="Center"
+                                                               TextWrapping="NoWrap"
                                                                TextTrimming="CharacterEllipsis" />
                                                 </DockPanel>
                                             </Border>
@@ -970,7 +977,18 @@
                                 </Button>
                             </StackPanel>
 
-                            <!-- Confirmation checkbox: Vue .network-confirmation-checkbox -->
+                            </StackPanel>
+                        </Border>
+                    </ScrollViewer>
+
+                    <!-- Modal footer: Vue .modal-footer -->
+                    <Border Name="NetworkModalFooter"
+                            Grid.Row="2"
+                            BorderBrush="{DynamicResource Stroke}"
+                            BorderThickness="0,1,0,0"
+                            Padding="24,20">
+                        <StackPanel Spacing="16">
+                            <!-- Confirmation checkbox stays visible with the fixed footer actions. -->
                             <DockPanel Name="NetworkConfirmationRow">
                                 <CheckBox Classes="NetworkConfirmCheckbox"
                                           IsChecked="{Binding NetworkChangeConfirmed, Mode=TwoWay}"
@@ -984,28 +1002,8 @@
                                            LineHeight="21"
                                            VerticalAlignment="Top" />
                             </DockPanel>
-                            </StackPanel>
-                        </Border>
-                    </ScrollViewer>
 
-                    <!-- Modal footer: Vue .modal-footer -->
-                    <Border Name="NetworkModalFooter"
-                            Grid.Row="2"
-                            BorderBrush="{DynamicResource Stroke}"
-                            BorderThickness="0,1,0,0"
-                            Padding="24,20">
-                        <StackPanel Name="NetworkModalActions" Orientation="Horizontal" Spacing="12" HorizontalAlignment="Right">
-                            <Button Name="NetworkCancelButton"
-                                    Classes="MobileAction"
-                                    Padding="20,10"
-                                    Background="{DynamicResource ModalCancelBg}"
-                                    Foreground="{DynamicResource ModalCancelFg}"
-                                    BorderThickness="0"
-                                    CornerRadius="8"
-                                    FontWeight="SemiBold"
-                                    FontSize="14"
-                                    Click="OnCloseNetworkModal"
-                                    Content="Cancel" />
+                            <StackPanel Name="NetworkModalActions" Orientation="Horizontal" Spacing="12" HorizontalAlignment="Right">
                             <Button Name="NetworkConfirmButton"
                                     Classes="MobileAction"
                                     Padding="20,10"
@@ -1029,6 +1027,7 @@
                                                IsVisible="{Binding !IsSwitchingNetwork}" />
                                 </StackPanel>
                             </Button>
+                            </StackPanel>
                         </StackPanel>
                     </Border>
                 </Grid>

--- a/src/design/App/UI/Sections/Settings/SettingsView.axaml.cs
+++ b/src/design/App/UI/Sections/Settings/SettingsView.axaml.cs
@@ -23,7 +23,6 @@ public partial class SettingsView : UserControl, ISectionView
     private Border? _networkModalBody;
     private Border? _networkModalFooter;
     private StackPanel? _networkModalActions;
-    private Button? _networkCancelButton;
     private Button? _networkConfirmButton;
 
     /// <summary>Design-time only.</summary>
@@ -146,7 +145,6 @@ public partial class SettingsView : UserControl, ISectionView
         _networkModalBody = this.FindControl<Border>("NetworkModalBody");
         _networkModalFooter = this.FindControl<Border>("NetworkModalFooter");
         _networkModalActions = this.FindControl<StackPanel>("NetworkModalActions");
-        _networkCancelButton = this.FindControl<Button>("NetworkCancelButton");
         _networkConfirmButton = this.FindControl<Button>("NetworkConfirmButton");
     }
 
@@ -179,10 +177,6 @@ public partial class SettingsView : UserControl, ISectionView
                 : Avalonia.Layout.HorizontalAlignment.Right;
         }
 
-        if (_networkCancelButton != null)
-            _networkCancelButton.HorizontalAlignment = isCompact
-                ? Avalonia.Layout.HorizontalAlignment.Stretch
-                : Avalonia.Layout.HorizontalAlignment.Left;
         if (_networkConfirmButton != null)
             _networkConfirmButton.HorizontalAlignment = isCompact
                 ? Avalonia.Layout.HorizontalAlignment.Stretch

--- a/src/design/App/UI/Shared/Helpers/ShellService.cs
+++ b/src/design/App/UI/Shared/Helpers/ShellService.cs
@@ -48,6 +48,12 @@ public static class ShellService
     /// <summary>
     /// Route platform back requests through the shell navigation stack.
     /// </summary>
+    public static bool CanHandlePlatformBack()
+        => _vm?.CanHandlePlatformBack() ?? false;
+
+    /// <summary>
+    /// Route platform back requests through the shell navigation stack.
+    /// </summary>
     public static bool TryHandlePlatformBack()
         => _vm?.TryHandlePlatformBack() ?? false;
 }

--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowConfig.cs
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowConfig.cs
@@ -50,4 +50,10 @@ public record PaymentFlowConfig
     /// Null = hide the "Pay with Wallet" button (invoice-only flow).
     /// </summary>
     public Func<WalletId, long, long, Task<Result>>? OnPayWithWallet { get; init; }
+
+    /// <summary>
+    /// If true, starts directly on the invoice screen when no wallet has enough available
+    /// balance for a direct wallet payment.
+    /// </summary>
+    public bool SkipWalletSelectorWhenNoWalletCanPay { get; init; }
 }

--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs
@@ -227,7 +227,12 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
                 this.RaisePropertyChanged(nameof(QrCodeContent));
             }).DisposeWith(_disposables);
 
-        SelectWallet(_walletContext.SelectedWallet ?? Wallets.FirstOrDefault());
+        SelectWallet(GetInitialWalletSelection());
+
+        if (ShouldStartWithInvoice())
+        {
+            ShowInvoice();
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -245,6 +250,31 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
 
         wallet.IsSelected = true;
         SelectedWallet = wallet;
+    }
+
+    private WalletInfo? GetInitialWalletSelection()
+    {
+        WalletInfo? selectedWallet = _walletContext.SelectedWallet;
+
+        if (!_config.SkipWalletSelectorWhenNoWalletCanPay)
+            return selectedWallet ?? Wallets.FirstOrDefault();
+
+        if (selectedWallet != null && CanWalletPay(selectedWallet))
+            return selectedWallet;
+
+        return Wallets.FirstOrDefault(CanWalletPay) ?? selectedWallet ?? Wallets.FirstOrDefault();
+    }
+
+    private bool ShouldStartWithInvoice()
+    {
+        return _config.SkipWalletSelectorWhenNoWalletCanPay
+            && _config.OnPayWithWallet != null
+            && !Wallets.Any(CanWalletPay);
+    }
+
+    private bool CanWalletPay(WalletInfo wallet)
+    {
+        return wallet.AvailableSats >= _config.AmountSats;
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/src/design/App/UI/Shell/ShellViewModel.cs
+++ b/src/design/App/UI/Shell/ShellViewModel.cs
@@ -940,12 +940,35 @@ public partial class ShellViewModel : ReactiveObject, IDisposable
     /// the same in-app back actions used by the mobile floating back bars.
     /// Returns false when the app is already at a root screen so Android may exit.
     /// </summary>
-    public bool TryHandlePlatformBack()
+    public bool CanHandlePlatformBack()
     {
         SyncDetailStateFromCachedViews();
 
+        return IsModalOpen
+               || IsInvestPageOpen
+               || IsProjectDetailOpen
+               || IsInvestmentDetailOpen
+               || IsCreatingProject
+               || IsManageFundsOpen
+               || IsEditProfileOpen;
+    }
+
+    /// <summary>
+    /// Handles platform back requests (Android physical/system back) by routing to
+    /// the same in-app back actions used by the mobile floating back bars.
+    /// Returns false when the app is already at a root screen so Android may exit.
+    /// </summary>
+    public bool TryHandlePlatformBack()
+    {
+        if (!CanHandlePlatformBack())
+            return false;
+
         if (IsModalOpen)
         {
+            if (ModalContent is IBackdropCloseable closeable)
+            {
+                closeable.OnBackdropCloseRequested();
+            }
             HideModal();
             return true;
         }


### PR DESCRIPTION
## Summary
- remove the redundant cancel action from the change-network modal
- keep the network-change confirmation checkbox in the fixed modal footer
- prevent settings indexer and relay URLs from wrapping into narrow vertical columns on mobile

## Testing
- JAVA_HOME="/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home" dotnet build "src/design/App.Android/App.Android.csproj" -f net10.0-android -c Debug -p:JavaSdkDirectory="/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home"
- Installed and launched on USB-connected Android device via dotnet build -t:Install and adb monkey