### PR TITLE
Polish mobile create-project flow: single-tap image upload + scroll reset

### DIFF
--- a/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsView.axaml
@@ -272,6 +272,7 @@
                                 Progress="{Binding Progress}"
                                 ProjectType="{Binding ProjectType}"
                                 Status="{Binding Status}"
+                                HasInvested="{Binding HasInvested}"
                                 Banner="{Binding BannerUrl}"
                                 Avatar="{Binding AvatarUrl}"
                                 CurrencySymbol="{Binding $parent[UserControl].DataContext.CurrencySymbol}" />

--- a/src/design/App/UI/Sections/FindProjects/FindProjectsViewModel.cs
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsViewModel.cs
@@ -19,6 +19,20 @@ using Microsoft.Extensions.Logging;
 
 namespace App.UI.Sections.FindProjects;
 
+public class ProjectFaqItemViewModel
+{
+    public string Question { get; set; } = "";
+    public string Answer { get; set; } = "";
+}
+
+public class ProjectMediaItemViewModel
+{
+    public string Url { get; set; } = "";
+    public string Type { get; set; } = "image";
+    public bool IsVideo => Type.Equals("video", StringComparison.OrdinalIgnoreCase);
+    public string DisplayType => IsVideo ? "Video" : "Image";
+}
+
 /// <summary>
 /// Project data model for the UI. When SDK data is available, mapped from ProjectDto.
 /// </summary>
@@ -31,6 +45,64 @@ public class ProjectItemViewModel : INotifyPropertyChanged
     public string ProjectName { get; set; } = "";
     public string ShortDescription { get; set; } = "";
     public string Description { get; set; } = "";
+
+    private string _profileDescription = "";
+    public string ProfileDescription
+    {
+        get => _profileDescription;
+        set
+        {
+            _profileDescription = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(DisplayDescription));
+            OnPropertyChanged(nameof(HasDisplayDescription));
+        }
+    }
+
+    public string DisplayDescription => !string.IsNullOrWhiteSpace(ProfileDescription)
+        ? ProfileDescription
+        : Description;
+
+    public bool HasDisplayDescription => !string.IsNullOrWhiteSpace(DisplayDescription);
+
+    private bool _isProfileLoading;
+    public bool IsProfileLoading
+    {
+        get => _isProfileLoading;
+        set
+        {
+            _isProfileLoading = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(ShowProfileAccordions));
+        }
+    }
+
+    private bool _profileLoaded;
+    public bool ProfileLoaded
+    {
+        get => _profileLoaded;
+        set
+        {
+            _profileLoaded = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(ShowProfileAccordions));
+            OnPropertyChanged(nameof(ShowFaqEmptyState));
+            OnPropertyChanged(nameof(ShowMembersEmptyState));
+            OnPropertyChanged(nameof(ShowMediaEmptyState));
+        }
+    }
+
+    public ObservableCollection<ProjectFaqItemViewModel> FaqItems { get; } = new();
+    public ObservableCollection<string> MemberPubkeys { get; } = new();
+    public ObservableCollection<ProjectMediaItemViewModel> MediaItems { get; } = new();
+
+    public bool HasFaqItems => FaqItems.Count > 0;
+    public bool HasMemberPubkeys => MemberPubkeys.Count > 0;
+    public bool HasMediaItems => MediaItems.Count > 0;
+    public bool ShowProfileAccordions => IsProfileLoading || ProfileLoaded;
+    public bool ShowFaqEmptyState => ProfileLoaded && !HasFaqItems;
+    public bool ShowMembersEmptyState => ProfileLoaded && !HasMemberPubkeys;
+    public bool ShowMediaEmptyState => ProfileLoaded && !HasMediaItems;
 
     private int _investorCount;
     public int InvestorCount
@@ -144,6 +216,60 @@ public class ProjectItemViewModel : INotifyPropertyChanged
 
     /// <summary>True when the project is open AND the current user has NOT already invested.</summary>
     public bool IsOpenAndNotInvested => IsOpen && !HasInvested;
+
+    public void ApplyProfileData(FetchProjectProfileData.FetchProjectProfileDataResponse data)
+    {
+        ProfileDescription = !string.IsNullOrWhiteSpace(data.ProjectContent)
+            ? data.ProjectContent!
+            : data.Metadata?.About ?? "";
+
+        FaqItems.Clear();
+        if (data.FaqItems != null)
+        {
+            foreach (FaqItem item in data.FaqItems)
+            {
+                if (string.IsNullOrWhiteSpace(item.Question) && string.IsNullOrWhiteSpace(item.Answer))
+                    continue;
+
+                FaqItems.Add(new ProjectFaqItemViewModel
+                {
+                    Question = item.Question ?? "",
+                    Answer = item.Answer ?? ""
+                });
+            }
+        }
+
+        MemberPubkeys.Clear();
+        if (data.MemberPubkeys != null)
+        {
+            foreach (string member in data.MemberPubkeys.Where(m => !string.IsNullOrWhiteSpace(m)))
+                MemberPubkeys.Add(member);
+        }
+
+        MediaItems.Clear();
+        if (data.MediaItems != null)
+        {
+            foreach (MediaItem item in data.MediaItems)
+            {
+                if (string.IsNullOrWhiteSpace(item.Url))
+                    continue;
+
+                MediaItems.Add(new ProjectMediaItemViewModel
+                {
+                    Url = item.Url ?? "",
+                    Type = string.IsNullOrWhiteSpace(item.Type) ? "image" : item.Type!
+                });
+            }
+        }
+
+        ProfileLoaded = true;
+        OnPropertyChanged(nameof(HasFaqItems));
+        OnPropertyChanged(nameof(HasMemberPubkeys));
+        OnPropertyChanged(nameof(HasMediaItems));
+        OnPropertyChanged(nameof(ShowFaqEmptyState));
+        OnPropertyChanged(nameof(ShowMembersEmptyState));
+        OnPropertyChanged(nameof(ShowMediaEmptyState));
+    }
 
     /// <summary>Currency symbol for display (e.g. "BTC", "TBTC")</summary>
     public string CurrencySymbol { get; set; } = "BTC";
@@ -385,6 +511,7 @@ public partial class FindProjectsViewModel : ReactiveObject, IDisposable
     {
         _logger.LogInformation("Opening project detail: '{ProjectName}' (ID: {ProjectId})", project.ProjectName, project.ProjectId);
         SelectedProject = project;
+        _ = LoadProfileDataAsync(project);
     }
 
     public void CloseProjectDetail()
@@ -408,6 +535,40 @@ public partial class FindProjectsViewModel : ReactiveObject, IDisposable
     }
 
     public ObservableCollection<ProjectItemViewModel> Projects { get; } = new();
+
+    private async Task LoadProfileDataAsync(ProjectItemViewModel project)
+    {
+        if (string.IsNullOrWhiteSpace(project.ProjectId) || project.ProfileLoaded || project.IsProfileLoading)
+            return;
+
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() => project.IsProfileLoading = true);
+
+        try
+        {
+            Result<FetchProjectProfileData.FetchProjectProfileDataResponse> result =
+                await _projectAppService.FetchProjectProfileData(new ProjectId(project.ProjectId));
+
+            if (result.IsFailure)
+            {
+                _logger.LogDebug("Failed to load profile data for project {ProjectId}: {Error}",
+                    project.ProjectId, result.Error);
+                return;
+            }
+
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                project.ApplyProfileData(result.Value);
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Error loading profile data for project {ProjectId}", project.ProjectId);
+        }
+        finally
+        {
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() => project.IsProfileLoading = false);
+        }
+    }
 
     public FindProjectsViewModel(
         IProjectAppService projectAppService,

--- a/src/design/App/UI/Sections/FindProjects/ProjectDetailView.axaml
+++ b/src/design/App/UI/Sections/FindProjects/ProjectDetailView.axaml
@@ -103,13 +103,13 @@
                     <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                         <Viewbox Width="10" Height="16">
                             <Path Data="{StaticResource ChevronLeftThick}"
-                                  Fill="{DynamicResource TextStrong}"
+                                  Fill="{DynamicResource TextStrongBrush}"
                                   Width="320" Height="512" Stretch="Uniform" />
                         </Viewbox>
                         <TextBlock Text="Back"
                                    FontSize="14"
                                    FontWeight="Medium"
-                                   Foreground="{DynamicResource TextStrong}"
+                                   Foreground="{DynamicResource TextStrongBrush}"
                                    VerticalAlignment="Center" />
                     </StackPanel>
                 </Button>
@@ -128,12 +128,12 @@
                     Cursor="Hand">
                 <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                     <i:Icon Value="fa-solid fa-share" FontSize="14"
-                           Foreground="{DynamicResource TextStrong}"
+                           Foreground="{DynamicResource TextStrongBrush}"
                            VerticalAlignment="Center" />
                     <TextBlock Text="Share"
                                FontSize="14"
                                FontWeight="SemiBold"
-                               Foreground="{DynamicResource TextStrong}"
+                               Foreground="{DynamicResource TextStrongBrush}"
                                VerticalAlignment="Center" />
                 </StackPanel>
             </Button>
@@ -192,7 +192,7 @@
                 <TextBlock Text="{Binding ProjectName}"
                            FontSize="14"
                            FontWeight="SemiBold"
-                           Foreground="{DynamicResource TextStrong}"
+                           Foreground="{DynamicResource TextStrongBrush}"
                            VerticalAlignment="Center"
                            TextTrimming="CharacterEllipsis"
                            MaxWidth="400" />
@@ -250,11 +250,11 @@
                             <TextBlock Text="{Binding ProjectName}"
                                        FontSize="24"
                                        FontWeight="Bold"
-                                       Foreground="{DynamicResource TextStrong}"
+                                       Foreground="{DynamicResource TextStrongBrush}"
                                        TextWrapping="Wrap" />
                             <TextBlock Text="{Binding ShortDescription}"
                                        FontSize="15"
-                                       Foreground="{DynamicResource TextMuted}"
+                                       Foreground="{DynamicResource TextMutedBrush}"
                                        TextWrapping="Wrap"
                                        LineHeight="22" />
                         </StackPanel>
@@ -405,15 +405,15 @@
                                     HorizontalAlignment="Center">
                                 <i:Icon Value="fa-solid fa-clock"
                                        FontSize="32"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             </Border>
                             <TextBlock Text="Investment Period Closed"
                                        FontSize="22"
                                        FontWeight="Bold"
-                                       Foreground="{DynamicResource TextStrong}"
+                                       Foreground="{DynamicResource TextStrongBrush}"
                                        TextAlignment="Center"
                                        HorizontalAlignment="Center" />
-                            <TextBlock Foreground="{DynamicResource TextMuted}"
+                            <TextBlock Foreground="{DynamicResource TextMutedBrush}"
                                        FontSize="15"
                                        TextAlignment="Center"
                                        TextWrapping="Wrap"
@@ -441,18 +441,18 @@
                     <StackPanel Orientation="Horizontal" Spacing="12">
                         <i:Icon Value="fa-solid fa-align-left"
                                 FontSize="22"
-                                Foreground="{DynamicResource TextStrong}"
+                                Foreground="{DynamicResource TextStrongBrush}"
                                 VerticalAlignment="Center" />
                         <TextBlock Text="Project Description"
                                    FontSize="20"
                                    FontWeight="Bold"
-                                   Foreground="{DynamicResource TextStrong}"
+                                   Foreground="{DynamicResource TextStrongBrush}"
                                    VerticalAlignment="Center" />
                     </StackPanel>
                     <TextBlock Text="{Binding DisplayDescription}"
                                FontSize="15"
                                LineHeight="23"
-                               Foreground="{DynamicResource TextMuted}"
+                               Foreground="{DynamicResource TextMutedBrush}"
                                TextWrapping="Wrap" />
                 </StackPanel>
             </Border>
@@ -624,7 +624,7 @@
                         <TextBlock Text="{Binding InfoSectionTitle}"
                                    FontSize="20"
                                    FontWeight="Bold"
-                                   Foreground="{DynamicResource TextStrong}"
+                                   Foreground="{DynamicResource TextStrongBrush}"
                                    VerticalAlignment="Center" />
                     </StackPanel>
 
@@ -640,14 +640,14 @@
                             <StackPanel Spacing="8">
                                 <DockPanel>
                                     <TextBlock Text="Investment Start Date" FontSize="13" FontWeight="SemiBold"
-                                               Foreground="{DynamicResource TextMuted}" />
+                                               Foreground="{DynamicResource TextMutedBrush}" />
                                     <i:Icon Value="fa-solid fa-calendar"
                                            FontSize="18"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            DockPanel.Dock="Right" HorizontalAlignment="Right" />
                                 </DockPanel>
                                 <TextBlock Text="{Binding StartDate}" FontSize="20" FontWeight="Bold"
-                                           Foreground="{DynamicResource TextStrong}" />
+                                           Foreground="{DynamicResource TextStrongBrush}" />
                             </StackPanel>
                         </Border>
                         <!-- End Date -->
@@ -659,14 +659,14 @@
                             <StackPanel Spacing="8">
                                 <DockPanel>
                                     <TextBlock Text="Investment End Date" FontSize="13" FontWeight="SemiBold"
-                                               Foreground="{DynamicResource TextMuted}" />
+                                               Foreground="{DynamicResource TextMutedBrush}" />
                                     <i:Icon Value="fa-solid fa-calendar"
                                            FontSize="18"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            DockPanel.Dock="Right" HorizontalAlignment="Right" />
                                 </DockPanel>
                                 <TextBlock Text="{Binding EndDate}" FontSize="20" FontWeight="Bold"
-                                           Foreground="{DynamicResource TextStrong}" />
+                                           Foreground="{DynamicResource TextStrongBrush}" />
                             </StackPanel>
                         </Border>
                         <!-- Penalty Duration -->
@@ -678,14 +678,14 @@
                             <StackPanel Spacing="8">
                                 <DockPanel>
                                     <TextBlock Text="Penalty Duration" FontSize="13" FontWeight="SemiBold"
-                                               Foreground="{DynamicResource TextMuted}" />
+                                               Foreground="{DynamicResource TextMutedBrush}" />
                                     <i:Icon Value="fa-solid fa-clock"
                                            FontSize="18"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            DockPanel.Dock="Right" HorizontalAlignment="Right" />
                                 </DockPanel>
                                 <TextBlock FontSize="20" FontWeight="Bold"
-                                           Foreground="{DynamicResource TextStrong}">
+                                           Foreground="{DynamicResource TextStrongBrush}">
                                     <Run Text="{Binding PenaltyDays, Mode=OneWay}" /><Run Text=" days" />
                                 </TextBlock>
                             </StackPanel>
@@ -699,14 +699,14 @@
                             <StackPanel Spacing="8">
                                 <DockPanel>
                                     <TextBlock Text="Project Expiry Date" FontSize="13" FontWeight="SemiBold"
-                                               Foreground="{DynamicResource TextMuted}" />
+                                               Foreground="{DynamicResource TextMutedBrush}" />
                                     <i:Icon Value="fa-solid fa-calendar"
                                            FontSize="18"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            DockPanel.Dock="Right" HorizontalAlignment="Right" />
                                 </DockPanel>
                                 <TextBlock Text="{Binding ExpiryDate}" FontSize="20" FontWeight="Bold"
-                                           Foreground="{DynamicResource TextStrong}" />
+                                           Foreground="{DynamicResource TextStrongBrush}" />
                             </StackPanel>
                         </Border>
                     </Grid>
@@ -722,14 +722,14 @@
                             <StackPanel Spacing="8">
                                 <DockPanel>
                                     <TextBlock Text="Funding Frequency" FontSize="13" FontWeight="SemiBold"
-                                               Foreground="{DynamicResource TextMuted}" />
+                                               Foreground="{DynamicResource TextMutedBrush}" />
                                     <i:Icon Value="fa-solid fa-clock"
                                            FontSize="18"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            DockPanel.Dock="Right" HorizontalAlignment="Right" />
                                 </DockPanel>
                                 <TextBlock Text="{Binding PayoutFrequency}" FontSize="20" FontWeight="Bold"
-                                           Foreground="{DynamicResource TextStrong}" />
+                                           Foreground="{DynamicResource TextStrongBrush}" />
                             </StackPanel>
                         </Border>
                         <Border Grid.Column="2"
@@ -740,14 +740,14 @@
                             <StackPanel Spacing="8">
                                 <DockPanel>
                                     <TextBlock Text="Penalty Duration" FontSize="13" FontWeight="SemiBold"
-                                               Foreground="{DynamicResource TextMuted}" />
+                                               Foreground="{DynamicResource TextMutedBrush}" />
                                     <i:Icon Value="fa-solid fa-clock"
                                            FontSize="18"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            DockPanel.Dock="Right" HorizontalAlignment="Right" />
                                 </DockPanel>
                                 <TextBlock FontSize="20" FontWeight="Bold"
-                                           Foreground="{DynamicResource TextStrong}">
+                                           Foreground="{DynamicResource TextStrongBrush}">
                                     <Run Text="{Binding PenaltyDays, Mode=OneWay}" /><Run Text=" days" />
                                 </TextBlock>
                             </StackPanel>
@@ -764,9 +764,9 @@
                                 CornerRadius="12" Padding="20">
                             <StackPanel Spacing="8">
                                 <TextBlock Text="Subscription Price" FontSize="13" FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextMuted}" />
+                                           Foreground="{DynamicResource TextMutedBrush}" />
                                 <TextBlock Text="{Binding SubscriptionPriceDisplay}" FontSize="20" FontWeight="Bold"
-                                           Foreground="{DynamicResource TextStrong}" />
+                                           Foreground="{DynamicResource TextStrongBrush}" />
                             </StackPanel>
                         </Border>
                         <Border Grid.Column="2"
@@ -776,9 +776,9 @@
                                 CornerRadius="12" Padding="20">
                             <StackPanel Spacing="8">
                                 <TextBlock Text="Frequency" FontSize="13" FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextMuted}" />
+                                           Foreground="{DynamicResource TextMutedBrush}" />
                                 <TextBlock Text="{Binding PayoutFrequency}" FontSize="20" FontWeight="Bold"
-                                           Foreground="{DynamicResource TextStrong}" />
+                                           Foreground="{DynamicResource TextStrongBrush}" />
                             </StackPanel>
                         </Border>
                         <Border Grid.Column="4"
@@ -788,9 +788,9 @@
                                 CornerRadius="12" Padding="20">
                             <StackPanel Spacing="8">
                                 <TextBlock Text="Installments" FontSize="13" FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextMuted}" />
+                                           Foreground="{DynamicResource TextMutedBrush}" />
                                 <TextBlock Text="3/6/12" FontSize="20" FontWeight="Bold"
-                                           Foreground="{DynamicResource TextStrong}" />
+                                           Foreground="{DynamicResource TextStrongBrush}" />
                             </StackPanel>
                         </Border>
                     </Grid>
@@ -815,7 +815,7 @@
                         <DockPanel>
                             <i:Icon Value="fa-solid fa-circle-question"
                                    FontSize="24"
-                                   Foreground="{DynamicResource TextStrong}"
+                                   Foreground="{DynamicResource TextStrongBrush}"
                                    DockPanel.Dock="Left" Margin="0,0,12,0" />
                             <Border Name="FaqChevron"
                                     Classes="CollapsibleChevron"
@@ -823,11 +823,11 @@
                                     VerticalAlignment="Center">
                                 <i:Icon Value="fa-solid fa-chevron-down"
                                        FontSize="16"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             </Border>
                             <TextBlock Text="FAQ"
                                        FontSize="20" FontWeight="Bold"
-                                       Foreground="{DynamicResource TextStrong}"
+                                       Foreground="{DynamicResource TextStrongBrush}"
                                        VerticalAlignment="Center" />
                         </DockPanel>
                     </Border>
@@ -835,11 +835,11 @@
                     <StackPanel Name="FaqContent" IsVisible="False" Spacing="12" Margin="0,20,0,0">
                         <TextBlock Text="Loading FAQ..."
                                    FontSize="14"
-                                   Foreground="{DynamicResource TextMuted}"
+                                   Foreground="{DynamicResource TextMutedBrush}"
                                    IsVisible="{Binding IsProfileLoading}" />
                         <TextBlock Text="No FAQ items have been added for this project yet."
                                    FontSize="14"
-                                   Foreground="{DynamicResource TextMuted}"
+                                   Foreground="{DynamicResource TextMutedBrush}"
                                    IsVisible="{Binding ShowFaqEmptyState}" />
                         <ItemsControl ItemsSource="{Binding FaqItems}">
                             <ItemsControl.ItemTemplate>
@@ -854,12 +854,12 @@
                                             <TextBlock Text="{Binding Question}"
                                                        FontSize="15"
                                                        FontWeight="SemiBold"
-                                                       Foreground="{DynamicResource TextStrong}"
+                                                       Foreground="{DynamicResource TextStrongBrush}"
                                                        TextWrapping="Wrap" />
                                             <TextBlock Text="{Binding Answer}"
                                                        FontSize="14"
                                                        LineHeight="21"
-                                                       Foreground="{DynamicResource TextMuted}"
+                                                       Foreground="{DynamicResource TextMutedBrush}"
                                                        TextWrapping="Wrap" />
                                         </StackPanel>
                                     </Border>
@@ -887,7 +887,7 @@
                         <DockPanel>
                             <i:Icon Value="fa-solid fa-users"
                                    FontSize="24"
-                                   Foreground="{DynamicResource TextStrong}"
+                                   Foreground="{DynamicResource TextStrongBrush}"
                                    DockPanel.Dock="Left" Margin="0,0,12,0" />
                             <Border Name="MembersChevron"
                                     Classes="CollapsibleChevron"
@@ -895,11 +895,11 @@
                                     VerticalAlignment="Center">
                                 <i:Icon Value="fa-solid fa-chevron-down"
                                        FontSize="16"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             </Border>
                             <TextBlock Text="Members"
                                        FontSize="20" FontWeight="Bold"
-                                       Foreground="{DynamicResource TextStrong}"
+                                       Foreground="{DynamicResource TextStrongBrush}"
                                        VerticalAlignment="Center" />
                         </DockPanel>
                     </Border>
@@ -907,11 +907,11 @@
                     <StackPanel Name="MembersContent" IsVisible="False" Spacing="12" Margin="0,20,0,0">
                         <TextBlock Text="Loading members..."
                                    FontSize="14"
-                                   Foreground="{DynamicResource TextMuted}"
+                                   Foreground="{DynamicResource TextMutedBrush}"
                                    IsVisible="{Binding IsProfileLoading}" />
                         <TextBlock Text="No members have been added for this project yet."
                                    FontSize="14"
-                                   Foreground="{DynamicResource TextMuted}"
+                                   Foreground="{DynamicResource TextMutedBrush}"
                                    IsVisible="{Binding ShowMembersEmptyState}" />
                         <ItemsControl ItemsSource="{Binding MemberPubkeys}">
                             <ItemsControl.ItemTemplate>
@@ -925,13 +925,13 @@
                                         <DockPanel>
                                             <i:Icon Value="fa-solid fa-user"
                                                    FontSize="16"
-                                                   Foreground="{DynamicResource TextMuted}"
+                                                   Foreground="{DynamicResource TextMutedBrush}"
                                                    DockPanel.Dock="Left"
                                                    Margin="0,0,8,0" />
                                             <TextBlock Text="{Binding}"
                                                        FontSize="13"
                                                        FontFamily="Cascadia Code,Consolas,monospace"
-                                                       Foreground="{DynamicResource TextStrong}"
+                                                       Foreground="{DynamicResource TextStrongBrush}"
                                                        TextTrimming="CharacterEllipsis"
                                                        VerticalAlignment="Center" />
                                         </DockPanel>
@@ -960,7 +960,7 @@
                         <DockPanel>
                             <i:Icon Value="fa-solid fa-photo-film"
                                    FontSize="24"
-                                   Foreground="{DynamicResource TextStrong}"
+                                   Foreground="{DynamicResource TextStrongBrush}"
                                    DockPanel.Dock="Left" Margin="0,0,12,0" />
                             <Border Name="MediaChevron"
                                     Classes="CollapsibleChevron"
@@ -968,11 +968,11 @@
                                     VerticalAlignment="Center">
                                 <i:Icon Value="fa-solid fa-chevron-down"
                                        FontSize="16"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             </Border>
                             <TextBlock Text="Media"
                                        FontSize="20" FontWeight="Bold"
-                                       Foreground="{DynamicResource TextStrong}"
+                                       Foreground="{DynamicResource TextStrongBrush}"
                                        VerticalAlignment="Center" />
                         </DockPanel>
                     </Border>
@@ -980,11 +980,11 @@
                     <StackPanel Name="MediaContent" IsVisible="False" Spacing="12" Margin="0,20,0,0">
                         <TextBlock Text="Loading media..."
                                    FontSize="14"
-                                   Foreground="{DynamicResource TextMuted}"
+                                   Foreground="{DynamicResource TextMutedBrush}"
                                    IsVisible="{Binding IsProfileLoading}" />
                         <TextBlock Text="No media has been added for this project yet."
                                    FontSize="14"
-                                   Foreground="{DynamicResource TextMuted}"
+                                   Foreground="{DynamicResource TextMutedBrush}"
                                    IsVisible="{Binding ShowMediaEmptyState}" />
                         <ItemsControl ItemsSource="{Binding MediaItems}">
                             <ItemsControl.ItemTemplate>
@@ -1006,7 +1006,7 @@
                                                 <TextBlock Text="{Binding DisplayType}"
                                                            FontSize="12"
                                                            FontWeight="SemiBold"
-                                                           Foreground="{DynamicResource TextMuted}" />
+                                                           Foreground="{DynamicResource TextMutedBrush}" />
                                             </Border>
                                             <TextBlock Text="{Binding Url}"
                                                        FontSize="13"
@@ -1041,7 +1041,7 @@
                         <DockPanel>
                             <i:Icon Value="fa-solid fa-circle-info"
                                    FontSize="24"
-                                   Foreground="{DynamicResource TextStrong}"
+                                   Foreground="{DynamicResource TextStrongBrush}"
                                    DockPanel.Dock="Left" Margin="0,0,12,0" />
                             <Border Name="DetailsChevron"
                                     Classes="CollapsibleChevron"
@@ -1049,11 +1049,11 @@
                                     VerticalAlignment="Center">
                                 <i:Icon Value="fa-solid fa-chevron-down"
                                        FontSize="16"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             </Border>
                             <TextBlock Text="Project Details"
                                        FontSize="20" FontWeight="Bold"
-                                       Foreground="{DynamicResource TextStrong}"
+                                       Foreground="{DynamicResource TextStrongBrush}"
                                        VerticalAlignment="Center" />
                         </DockPanel>
                     </Border>
@@ -1063,7 +1063,7 @@
                         <!-- Explorer -->
                         <StackPanel Spacing="6">
                             <TextBlock Text="Explorer" FontSize="13" FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             <Button Name="ExplorerLink" Classes="Unstyled"
                                     Background="{DynamicResource SurfaceMedium}"
                                     BorderBrush="{DynamicResource Stroke}"
@@ -1074,7 +1074,7 @@
                                             VerticalAlignment="Center">
                                     <i:Icon Value="fa-solid fa-arrow-up-right-from-square"
                                            FontSize="18"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            VerticalAlignment="Center" />
                                     <TextBlock Text="View the transaction"
                                                FontSize="14"
@@ -1088,7 +1088,7 @@
                         <!-- Project ID -->
                         <StackPanel Spacing="6">
                             <TextBlock Text="Project ID" FontSize="13" FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             <Border Background="{DynamicResource SurfaceMedium}"
                                     BorderBrush="{DynamicResource Stroke}"
                                     BorderThickness="1"
@@ -1096,18 +1096,18 @@
                                 <DockPanel>
                                     <i:Icon Value="fa-solid fa-cloud"
                                            FontSize="18"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            DockPanel.Dock="Left" Margin="0,0,8,0" />
                                     <Button Name="CopyProjectIdBtn" Classes="Unstyled"
                                             Cursor="Hand"
                                             DockPanel.Dock="Right" HorizontalAlignment="Right"
                                             Margin="8,0,0,0">
-                                        <i:Icon Value="fa-solid fa-copy" FontSize="14" Foreground="{DynamicResource TextMuted}" />
+                                        <i:Icon Value="fa-solid fa-copy" FontSize="14" Foreground="{DynamicResource TextMutedBrush}" />
                                     </Button>
                                     <TextBlock Text="{Binding ProjectId}"
                                                FontSize="13"
                                                FontFamily="Cascadia Code,Consolas,monospace"
-                                               Foreground="{DynamicResource TextStrong}"
+                                               Foreground="{DynamicResource TextStrongBrush}"
                                                TextTrimming="CharacterEllipsis"
                                                VerticalAlignment="Center" />
                                 </DockPanel>
@@ -1117,7 +1117,7 @@
                         <!-- Founder Key -->
                         <StackPanel Spacing="6">
                             <TextBlock Text="Founder Key" FontSize="13" FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             <Border Background="{DynamicResource SurfaceMedium}"
                                     BorderBrush="{DynamicResource Stroke}"
                                     BorderThickness="1"
@@ -1125,18 +1125,18 @@
                                 <DockPanel>
                                     <i:Icon Value="fa-solid fa-key"
                                            FontSize="18"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            DockPanel.Dock="Left" Margin="0,0,8,0" />
                                     <Button Name="CopyFounderKeyBtn" Classes="Unstyled"
                                             Cursor="Hand"
                                             DockPanel.Dock="Right" HorizontalAlignment="Right"
                                             Margin="8,0,0,0">
-                                        <i:Icon Value="fa-solid fa-copy" FontSize="14" Foreground="{DynamicResource TextMuted}" />
+                                        <i:Icon Value="fa-solid fa-copy" FontSize="14" Foreground="{DynamicResource TextMutedBrush}" />
                                     </Button>
                                     <TextBlock Text="{Binding FounderKey}"
                                                FontSize="13"
                                                FontFamily="Cascadia Code,Consolas,monospace"
-                                               Foreground="{DynamicResource TextStrong}"
+                                               Foreground="{DynamicResource TextStrongBrush}"
                                                TextTrimming="CharacterEllipsis"
                                                VerticalAlignment="Center" />
                                 </DockPanel>
@@ -1160,11 +1160,11 @@
                                 <i:Icon Value="fa-solid fa-code"
                                         FontSize="16"
                                         VerticalAlignment="Center"
-                                        Foreground="{DynamicResource TextStrong}" />
+                                        Foreground="{DynamicResource TextStrongBrush}" />
                                 <TextBlock Text="View Project Info JSON"
                                             FontSize="14" FontWeight="SemiBold"
                                             VerticalAlignment="Center"
-                                            Foreground="{DynamicResource TextStrong}" />
+                                            Foreground="{DynamicResource TextStrongBrush}" />
                             </StackPanel>
                         </Button>
                     </StackPanel>
@@ -1189,7 +1189,7 @@
                         <DockPanel>
                             <i:Icon Value="fa-solid fa-comment"
                                    FontSize="24"
-                                   Foreground="{DynamicResource TextStrong}"
+                                   Foreground="{DynamicResource TextStrongBrush}"
                                    DockPanel.Dock="Left" Margin="0,0,12,0" />
                             <Border Name="NostrChevron"
                                     Classes="CollapsibleChevron"
@@ -1197,11 +1197,11 @@
                                     VerticalAlignment="Center">
                                 <i:Icon Value="fa-solid fa-chevron-down"
                                        FontSize="16"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             </Border>
                             <TextBlock Text="Nostr"
                                        FontSize="20" FontWeight="Bold"
-                                       Foreground="{DynamicResource TextStrong}"
+                                       Foreground="{DynamicResource TextStrongBrush}"
                                        VerticalAlignment="Center" />
                         </DockPanel>
                     </Border>
@@ -1211,7 +1211,7 @@
                         <!-- Nostr npub -->
                         <StackPanel Spacing="6">
                             <TextBlock Text="Nostr Public Key (npub)" FontSize="13" FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             <Border Background="{DynamicResource SurfaceMedium}"
                                     BorderBrush="{DynamicResource Stroke}"
                                     BorderThickness="1"
@@ -1219,18 +1219,18 @@
                                 <DockPanel>
                                     <i:Icon Value="fa-solid fa-user"
                                            FontSize="18"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            DockPanel.Dock="Left" Margin="0,0,8,0" />
                                     <Button Name="CopyNpubBtn" Classes="Unstyled"
                                             Cursor="Hand"
                                             DockPanel.Dock="Right" HorizontalAlignment="Right"
                                             Margin="8,0,0,0">
-                                        <i:Icon Value="fa-solid fa-copy" FontSize="14" Foreground="{DynamicResource TextMuted}" />
+                                        <i:Icon Value="fa-solid fa-copy" FontSize="14" Foreground="{DynamicResource TextMutedBrush}" />
                                     </Button>
                                     <TextBlock Text="{Binding NostrNpub}"
                                                FontSize="13"
                                                FontFamily="Cascadia Code,Consolas,monospace"
-                                               Foreground="{DynamicResource TextStrong}"
+                                               Foreground="{DynamicResource TextStrongBrush}"
                                                TextTrimming="CharacterEllipsis"
                                                VerticalAlignment="Center" />
                                 </DockPanel>
@@ -1251,18 +1251,18 @@
                                 <i:Icon Value="fa-solid fa-arrow-up-right-from-square"
                                         FontSize="18"
                                         VerticalAlignment="Center"
-                                        Foreground="{DynamicResource TextStrong}" />
+                                        Foreground="{DynamicResource TextStrongBrush}" />
                                 <TextBlock Text="Open in Angor Projects"
                                             FontSize="14" FontWeight="SemiBold"
                                             VerticalAlignment="Center"
-                                            Foreground="{DynamicResource TextStrong}" />
+                                            Foreground="{DynamicResource TextStrongBrush}" />
                             </StackPanel>
                         </Border>
 
                         <!-- Relays -->
                         <StackPanel Spacing="8">
                             <TextBlock Text="Relays" FontSize="15" FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextStrong}" />
+                                       Foreground="{DynamicResource TextStrongBrush}" />
                             <Border Background="{DynamicResource SurfaceMedium}"
                                     BorderBrush="{DynamicResource Stroke}"
                                     BorderThickness="1"

--- a/src/design/App/UI/Sections/FindProjects/ProjectDetailView.axaml
+++ b/src/design/App/UI/Sections/FindProjects/ProjectDetailView.axaml
@@ -427,6 +427,37 @@
             </Grid>
 
             <!-- ═══════════════════════════════════════ -->
+            <!-- PROJECT DESCRIPTION CARD                -->
+            <!-- Loaded from the project profile content  -->
+            <!-- ═══════════════════════════════════════ -->
+            <Border Background="{DynamicResource Surface}"
+                    BorderBrush="{DynamicResource Stroke}"
+                    BorderThickness="1"
+                    CornerRadius="16"
+                    Padding="24"
+                    BoxShadow="{DynamicResource ItemShadow}"
+                    IsVisible="{Binding HasDisplayDescription}">
+                <StackPanel Spacing="12">
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <i:Icon Value="fa-solid fa-align-left"
+                                FontSize="22"
+                                Foreground="{DynamicResource TextStrong}"
+                                VerticalAlignment="Center" />
+                        <TextBlock Text="Project Description"
+                                   FontSize="20"
+                                   FontWeight="Bold"
+                                   Foreground="{DynamicResource TextStrong}"
+                                   VerticalAlignment="Center" />
+                    </StackPanel>
+                    <TextBlock Text="{Binding DisplayDescription}"
+                               FontSize="15"
+                               LineHeight="23"
+                               Foreground="{DynamicResource TextMuted}"
+                               TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+
+            <!-- ═══════════════════════════════════════ -->
             <!-- PROJECT STATISTICS CARD                  -->
             <!-- Vue: stats-detail-card, orange gradient  -->
             <!-- ═══════════════════════════════════════ -->
@@ -763,6 +794,232 @@
                             </StackPanel>
                         </Border>
                     </Grid>
+                </StackPanel>
+            </Border>
+
+            <!-- ═══════════════════════════════════════ -->
+            <!-- FAQ (collapsible)                        -->
+            <!-- Project profile data from Nostr relays   -->
+            <!-- ═══════════════════════════════════════ -->
+            <Border Name="FaqContainer"
+                    Background="{DynamicResource Surface}"
+                    BorderBrush="{DynamicResource Stroke}"
+                    BorderThickness="1"
+                    CornerRadius="16"
+                    Padding="24"
+                    BoxShadow="{DynamicResource ItemShadow}"
+                    Cursor="Hand"
+                    IsVisible="{Binding ShowProfileAccordions}">
+                <StackPanel Spacing="0">
+                    <Border Name="FaqHeader" Cursor="Hand" Background="Transparent" Padding="0,4">
+                        <DockPanel>
+                            <i:Icon Value="fa-solid fa-circle-question"
+                                   FontSize="24"
+                                   Foreground="{DynamicResource TextStrong}"
+                                   DockPanel.Dock="Left" Margin="0,0,12,0" />
+                            <Border Name="FaqChevron"
+                                    Classes="CollapsibleChevron"
+                                    DockPanel.Dock="Right" HorizontalAlignment="Right"
+                                    VerticalAlignment="Center">
+                                <i:Icon Value="fa-solid fa-chevron-down"
+                                       FontSize="16"
+                                       Foreground="{DynamicResource TextMuted}" />
+                            </Border>
+                            <TextBlock Text="FAQ"
+                                       FontSize="20" FontWeight="Bold"
+                                       Foreground="{DynamicResource TextStrong}"
+                                       VerticalAlignment="Center" />
+                        </DockPanel>
+                    </Border>
+
+                    <StackPanel Name="FaqContent" IsVisible="False" Spacing="12" Margin="0,20,0,0">
+                        <TextBlock Text="Loading FAQ..."
+                                   FontSize="14"
+                                   Foreground="{DynamicResource TextMuted}"
+                                   IsVisible="{Binding IsProfileLoading}" />
+                        <TextBlock Text="No FAQ items have been added for this project yet."
+                                   FontSize="14"
+                                   Foreground="{DynamicResource TextMuted}"
+                                   IsVisible="{Binding ShowFaqEmptyState}" />
+                        <ItemsControl ItemsSource="{Binding FaqItems}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="fp:ProjectFaqItemViewModel">
+                                    <Border Background="{DynamicResource SurfaceMedium}"
+                                            BorderBrush="{DynamicResource Stroke}"
+                                            BorderThickness="1"
+                                            CornerRadius="12"
+                                            Padding="16"
+                                            Margin="0,0,0,12">
+                                        <StackPanel Spacing="8">
+                                            <TextBlock Text="{Binding Question}"
+                                                       FontSize="15"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource TextStrong}"
+                                                       TextWrapping="Wrap" />
+                                            <TextBlock Text="{Binding Answer}"
+                                                       FontSize="14"
+                                                       LineHeight="21"
+                                                       Foreground="{DynamicResource TextMuted}"
+                                                       TextWrapping="Wrap" />
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- ═══════════════════════════════════════ -->
+            <!-- MEMBERS (collapsible)                    -->
+            <!-- ═══════════════════════════════════════ -->
+            <Border Name="MembersContainer"
+                    Background="{DynamicResource Surface}"
+                    BorderBrush="{DynamicResource Stroke}"
+                    BorderThickness="1"
+                    CornerRadius="16"
+                    Padding="24"
+                    BoxShadow="{DynamicResource ItemShadow}"
+                    Cursor="Hand"
+                    IsVisible="{Binding ShowProfileAccordions}">
+                <StackPanel Spacing="0">
+                    <Border Name="MembersHeader" Cursor="Hand" Background="Transparent" Padding="0,4">
+                        <DockPanel>
+                            <i:Icon Value="fa-solid fa-users"
+                                   FontSize="24"
+                                   Foreground="{DynamicResource TextStrong}"
+                                   DockPanel.Dock="Left" Margin="0,0,12,0" />
+                            <Border Name="MembersChevron"
+                                    Classes="CollapsibleChevron"
+                                    DockPanel.Dock="Right" HorizontalAlignment="Right"
+                                    VerticalAlignment="Center">
+                                <i:Icon Value="fa-solid fa-chevron-down"
+                                       FontSize="16"
+                                       Foreground="{DynamicResource TextMuted}" />
+                            </Border>
+                            <TextBlock Text="Members"
+                                       FontSize="20" FontWeight="Bold"
+                                       Foreground="{DynamicResource TextStrong}"
+                                       VerticalAlignment="Center" />
+                        </DockPanel>
+                    </Border>
+
+                    <StackPanel Name="MembersContent" IsVisible="False" Spacing="12" Margin="0,20,0,0">
+                        <TextBlock Text="Loading members..."
+                                   FontSize="14"
+                                   Foreground="{DynamicResource TextMuted}"
+                                   IsVisible="{Binding IsProfileLoading}" />
+                        <TextBlock Text="No members have been added for this project yet."
+                                   FontSize="14"
+                                   Foreground="{DynamicResource TextMuted}"
+                                   IsVisible="{Binding ShowMembersEmptyState}" />
+                        <ItemsControl ItemsSource="{Binding MemberPubkeys}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border Background="{DynamicResource SurfaceMedium}"
+                                            BorderBrush="{DynamicResource Stroke}"
+                                            BorderThickness="1"
+                                            CornerRadius="8"
+                                            Padding="12,10"
+                                            Margin="0,0,0,8">
+                                        <DockPanel>
+                                            <i:Icon Value="fa-solid fa-user"
+                                                   FontSize="16"
+                                                   Foreground="{DynamicResource TextMuted}"
+                                                   DockPanel.Dock="Left"
+                                                   Margin="0,0,8,0" />
+                                            <TextBlock Text="{Binding}"
+                                                       FontSize="13"
+                                                       FontFamily="Cascadia Code,Consolas,monospace"
+                                                       Foreground="{DynamicResource TextStrong}"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       VerticalAlignment="Center" />
+                                        </DockPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- ═══════════════════════════════════════ -->
+            <!-- MEDIA (collapsible)                      -->
+            <!-- ═══════════════════════════════════════ -->
+            <Border Name="MediaContainer"
+                    Background="{DynamicResource Surface}"
+                    BorderBrush="{DynamicResource Stroke}"
+                    BorderThickness="1"
+                    CornerRadius="16"
+                    Padding="24"
+                    BoxShadow="{DynamicResource ItemShadow}"
+                    Cursor="Hand"
+                    IsVisible="{Binding ShowProfileAccordions}">
+                <StackPanel Spacing="0">
+                    <Border Name="MediaHeader" Cursor="Hand" Background="Transparent" Padding="0,4">
+                        <DockPanel>
+                            <i:Icon Value="fa-solid fa-photo-film"
+                                   FontSize="24"
+                                   Foreground="{DynamicResource TextStrong}"
+                                   DockPanel.Dock="Left" Margin="0,0,12,0" />
+                            <Border Name="MediaChevron"
+                                    Classes="CollapsibleChevron"
+                                    DockPanel.Dock="Right" HorizontalAlignment="Right"
+                                    VerticalAlignment="Center">
+                                <i:Icon Value="fa-solid fa-chevron-down"
+                                       FontSize="16"
+                                       Foreground="{DynamicResource TextMuted}" />
+                            </Border>
+                            <TextBlock Text="Media"
+                                       FontSize="20" FontWeight="Bold"
+                                       Foreground="{DynamicResource TextStrong}"
+                                       VerticalAlignment="Center" />
+                        </DockPanel>
+                    </Border>
+
+                    <StackPanel Name="MediaContent" IsVisible="False" Spacing="12" Margin="0,20,0,0">
+                        <TextBlock Text="Loading media..."
+                                   FontSize="14"
+                                   Foreground="{DynamicResource TextMuted}"
+                                   IsVisible="{Binding IsProfileLoading}" />
+                        <TextBlock Text="No media has been added for this project yet."
+                                   FontSize="14"
+                                   Foreground="{DynamicResource TextMuted}"
+                                   IsVisible="{Binding ShowMediaEmptyState}" />
+                        <ItemsControl ItemsSource="{Binding MediaItems}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="fp:ProjectMediaItemViewModel">
+                                    <Border Background="{DynamicResource SurfaceMedium}"
+                                            BorderBrush="{DynamicResource Stroke}"
+                                            BorderThickness="1"
+                                            CornerRadius="8"
+                                            Padding="12,10"
+                                            Margin="0,0,0,8">
+                                        <DockPanel>
+                                            <Border DockPanel.Dock="Left"
+                                                    Background="{DynamicResource SurfaceLow}"
+                                                    BorderBrush="{DynamicResource Stroke}"
+                                                    BorderThickness="1"
+                                                    CornerRadius="6"
+                                                    Padding="8,4"
+                                                    Margin="0,0,10,0">
+                                                <TextBlock Text="{Binding DisplayType}"
+                                                           FontSize="12"
+                                                           FontWeight="SemiBold"
+                                                           Foreground="{DynamicResource TextMuted}" />
+                                            </Border>
+                                            <TextBlock Text="{Binding Url}"
+                                                       FontSize="13"
+                                                       Foreground="{DynamicResource Brand}"
+                                                       TextDecorations="Underline"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       VerticalAlignment="Center" />
+                                        </DockPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
                 </StackPanel>
             </Border>
 

--- a/src/design/App/UI/Sections/FindProjects/ProjectDetailView.axaml.cs
+++ b/src/design/App/UI/Sections/FindProjects/ProjectDetailView.axaml.cs
@@ -20,6 +20,9 @@ public partial class ProjectDetailView : UserControl
 {
     private bool _detailsExpanded = false;
     private bool _nostrExpanded = false;
+    private bool _faqExpanded;
+    private bool _membersExpanded;
+    private bool _mediaExpanded;
     private bool _navCtaVisible;
     private IDisposable? _layoutSubscription;
 
@@ -38,6 +41,18 @@ public partial class ProjectDetailView : UserControl
     private Border? _nostrHeader;
     private StackPanel? _nostrContent;
     private Control? _nostrChevron;
+    private Border? _faqContainer;
+    private Border? _faqHeader;
+    private StackPanel? _faqContent;
+    private Control? _faqChevron;
+    private Border? _membersContainer;
+    private Border? _membersHeader;
+    private StackPanel? _membersContent;
+    private Control? _membersChevron;
+    private Border? _mediaContainer;
+    private Border? _mediaHeader;
+    private StackPanel? _mediaContent;
+    private Control? _mediaChevron;
 
     // Responsive layout controls
     private Grid? _topSectionGrid;
@@ -78,6 +93,18 @@ public partial class ProjectDetailView : UserControl
         _nostrHeader = this.FindControl<Border>("NostrHeader");
         _nostrContent = this.FindControl<StackPanel>("NostrContent");
         _nostrChevron = this.FindControl<Control>("NostrChevron");
+        _faqContainer = this.FindControl<Border>("FaqContainer");
+        _faqHeader = this.FindControl<Border>("FaqHeader");
+        _faqContent = this.FindControl<StackPanel>("FaqContent");
+        _faqChevron = this.FindControl<Control>("FaqChevron");
+        _membersContainer = this.FindControl<Border>("MembersContainer");
+        _membersHeader = this.FindControl<Border>("MembersHeader");
+        _membersContent = this.FindControl<StackPanel>("MembersContent");
+        _membersChevron = this.FindControl<Control>("MembersChevron");
+        _mediaContainer = this.FindControl<Border>("MediaContainer");
+        _mediaHeader = this.FindControl<Border>("MediaHeader");
+        _mediaContent = this.FindControl<StackPanel>("MediaContent");
+        _mediaChevron = this.FindControl<Control>("MediaChevron");
 
         // Back button
         if (_backBtn != null)
@@ -108,6 +135,15 @@ public partial class ProjectDetailView : UserControl
 
         if (_nostrContainer != null)
             _nostrContainer.PointerPressed += OnCollapsibleContainerPressed;
+
+        if (_faqContainer != null)
+            _faqContainer.PointerPressed += OnCollapsibleContainerPressed;
+
+        if (_membersContainer != null)
+            _membersContainer.PointerPressed += OnCollapsibleContainerPressed;
+
+        if (_mediaContainer != null)
+            _mediaContainer.PointerPressed += OnCollapsibleContainerPressed;
 
         // Copy buttons — Vue: copyToClipboard() on project ID, founder key, npub
         var copyProjectIdBtn = this.FindControl<Button>("CopyProjectIdBtn");
@@ -398,6 +434,7 @@ public partial class ProjectDetailView : UserControl
     {
         _scroller?.ScrollToHome();
         _navCtaVisible = false;
+        ResetProfileAccordions();
         if (_navCta != null)
         {
             _navCta.Opacity = 0;
@@ -522,6 +559,27 @@ public partial class ProjectDetailView : UserControl
             ToggleCollapsible(ref _detailsExpanded, _detailsContainer, _detailsHeader, _detailsContent, _detailsChevron, e);
         else if (sender == _nostrContainer)
             ToggleCollapsible(ref _nostrExpanded, _nostrContainer, _nostrHeader, _nostrContent, _nostrChevron, e);
+        else if (sender == _faqContainer)
+            ToggleCollapsible(ref _faqExpanded, _faqContainer, _faqHeader, _faqContent, _faqChevron, e);
+        else if (sender == _membersContainer)
+            ToggleCollapsible(ref _membersExpanded, _membersContainer, _membersHeader, _membersContent, _membersChevron, e);
+        else if (sender == _mediaContainer)
+            ToggleCollapsible(ref _mediaExpanded, _mediaContainer, _mediaHeader, _mediaContent, _mediaChevron, e);
+    }
+
+    private void ResetProfileAccordions()
+    {
+        ResetCollapsible(ref _faqExpanded, _faqContainer, _faqContent, _faqChevron);
+        ResetCollapsible(ref _membersExpanded, _membersContainer, _membersContent, _membersChevron);
+        ResetCollapsible(ref _mediaExpanded, _mediaContainer, _mediaContent, _mediaChevron);
+    }
+
+    private static void ResetCollapsible(ref bool expanded, Border? container, StackPanel? content, Control? chevron)
+    {
+        expanded = false;
+        if (content != null) content.IsVisible = false;
+        chevron?.Classes.Set("ChevronExpanded", false);
+        if (container != null) container.Cursor = new Cursor(StandardCursorType.Hand);
     }
 
     /// <summary>

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectView.axaml.cs
@@ -31,6 +31,7 @@ public partial class CreateProjectView : UserControl
     private Border? _navFooter;
     private StackPanel? _stepContentPanel;
     private Border? _strokeOverlay;
+    private ScrollViewer? _stepScrollViewer;
 
     private IDisposable? _deploySubscription;
     private IDisposable? _stepSubscription;
@@ -56,6 +57,7 @@ public partial class CreateProjectView : UserControl
         _navFooter = this.FindControl<Border>("NavFooter");
         _stepContentPanel = this.FindControl<StackPanel>("StepContentPanel");
         _strokeOverlay = this.FindControl<Border>("StrokeOverlay");
+        _stepScrollViewer = this.FindControl<ScrollViewer>("StepScrollViewer");
 
         // Cache progress bar segments
         _progressSegments =
@@ -95,6 +97,7 @@ public partial class CreateProjectView : UserControl
                 {
                     UpdateStepper();
                     UpdateMobileHeader();
+                    ScrollContentToTop();
                 });
 
             _typeSubscription = vm.WhenAnyValue(x => x.ProjectType)
@@ -340,6 +343,22 @@ public partial class CreateProjectView : UserControl
 
     private CreateProjectViewModel? Vm => DataContext as CreateProjectViewModel;
 
+    /// <summary>
+    /// Reset the wizard's scrollable step content to the top whenever the user
+    /// changes step. Step content is reused across steps (visibility toggles),
+    /// so without this the previous step's scroll offset persists.
+    /// Posted at Loaded priority so it runs after the new step's content has
+    /// laid out and the ScrollViewer has its updated Extent.
+    /// </summary>
+    private void ScrollContentToTop()
+    {
+        if (_stepScrollViewer == null) return;
+
+        Avalonia.Threading.Dispatcher.UIThread.Post(
+            () => _stepScrollViewer?.ScrollToHome(),
+            Avalonia.Threading.DispatcherPriority.Loaded);
+    }
+
     private void OnButtonClick(object? sender, RoutedEventArgs e)
     {
         if (e.Source is not Button btn) return;
@@ -488,6 +507,7 @@ public partial class CreateProjectView : UserControl
         // Reset stepper
         UpdateStepper();
         UpdateMobileHeader();
+        ScrollContentToTop();
 
         // Delegate to child step UCs
         this.FindControl<CreateProjectStep1View>("Step1View")?.ResetVisualState();

--- a/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep3View.axaml
+++ b/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep3View.axaml
@@ -16,15 +16,26 @@
         <TextBlock Text="Add a banner and profile image for your project. Enter a URL or upload a file to a Blossom server."
                    FontSize="14" Foreground="{DynamicResource TextMuted}" TextWrapping="Wrap" />
 
-        <!-- Preview card — shows the images from the URLs entered below -->
+        <!-- Preview card — shows the images from the URLs entered below.
+             Banner area and avatar circle are click-targets for Pick & Upload. -->
         <Border CornerRadius="10" BorderBrush="{DynamicResource Stroke}" BorderThickness="2"
                 Background="{DynamicResource Surface}" ClipToBounds="True">
             <StackPanel>
-                <!-- Banner area -->
-                <Panel Height="180">
+                <!-- Banner area (click to upload) -->
+                <Panel Name="BannerPreviewClickTarget" Height="180" Cursor="Hand"
+                       Background="Transparent" ToolTip.Tip="Click to upload banner image">
                     <Rectangle Fill="{DynamicResource SurfaceMedium}" />
                     <Rectangle Fill="{DynamicResource TiledLogoBrush}" />
                     <Image Name="BannerPreviewImage" Stretch="UniformToFill" IsVisible="False" />
+                    <!-- Hover overlay -->
+                    <Border Name="BannerPreviewOverlay" Background="#80000000" IsVisible="False">
+                        <StackPanel Orientation="Horizontal" Spacing="8"
+                                    HorizontalAlignment="Center" VerticalAlignment="Center">
+                            <i:Icon Value="fa-solid fa-cloud-arrow-up" FontSize="20" Foreground="White" />
+                            <TextBlock Text="Click to upload banner" FontSize="14" FontWeight="SemiBold"
+                                       Foreground="White" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Border>
                     <Border Background="#80000000" CornerRadius="6" Padding="10,5"
                             HorizontalAlignment="Right" VerticalAlignment="Top" Margin="12">
                         <TextBlock Text="820x312px recommended" FontSize="11" Foreground="White" />
@@ -33,11 +44,14 @@
 
                 <!-- Avatar + project info -->
                 <StackPanel Margin="24,-56,24,20" Spacing="12">
-                    <Border Width="112" Height="112" CornerRadius="56"
+                    <Border Name="AvatarPreviewClickTarget"
+                            Width="112" Height="112" CornerRadius="56"
                             Background="{DynamicResource SurfaceMedium}"
                             BorderBrush="White" BorderThickness="4"
                             BoxShadow="0 10 30 0 #22000000" ClipToBounds="True"
-                            HorizontalAlignment="Left">
+                            HorizontalAlignment="Left"
+                            Cursor="Hand"
+                            ToolTip.Tip="Click to upload profile picture">
                         <Panel>
                             <Image Name="AvatarPreviewImage" Stretch="UniformToFill"
                                    Width="104" Height="104" IsVisible="False">
@@ -48,6 +62,16 @@
                             <i:Icon Value="fa-solid fa-user" FontSize="36"
                                     Foreground="{DynamicResource TextMuted}"
                                     HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            <!-- Hover overlay -->
+                            <Border Name="AvatarPreviewOverlay" Background="#80000000" IsVisible="False">
+                                <StackPanel Spacing="2"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <i:Icon Value="fa-solid fa-cloud-arrow-up" FontSize="20" Foreground="White"
+                                            HorizontalAlignment="Center" />
+                                    <TextBlock Text="Upload" FontSize="11" FontWeight="SemiBold"
+                                               Foreground="White" HorizontalAlignment="Center" />
+                                </StackPanel>
+                            </Border>
                         </Panel>
                     </Border>
                     <StackPanel Spacing="4">
@@ -100,56 +124,38 @@
                              Text="https://blossom.angor.io"
                              Watermark="Blossom server URL"
                              Padding="12,10" FontSize="14" CornerRadius="8" />
-                    <DockPanel>
-                        <Button Name="BannerUploadBtn"
-                                DockPanel.Dock="Right"
-                                Padding="16,10"
-                                CornerRadius="8"
-                                Cursor="Hand"
-                                Background="{DynamicResource PrimaryGreenBrush}"
-                                Foreground="White"
-                                FontSize="14" FontWeight="SemiBold"
-                                Margin="8,0,0,0">
-                            <StackPanel Orientation="Horizontal" Spacing="6">
-                                <i:Icon Name="BannerUploadIcon" Value="fa-solid fa-cloud-arrow-up"
-                                        FontSize="13" Foreground="White" IsVisible="True" />
-                                <i:Icon Name="BannerUploadSpinner" Value="fa-solid fa-spinner"
-                                        FontSize="13" Foreground="White" IsVisible="False"
-                                        RenderTransformOrigin="50%,50%">
-                                    <i:Icon.RenderTransform><RotateTransform /></i:Icon.RenderTransform>
-                                    <i:Icon.Styles>
-                                        <Style Selector="i|Icon[IsVisible=True]">
-                                            <Style.Animations>
-                                                <Animation Duration="0:0:1" IterationCount="INFINITE">
-                                                    <KeyFrame Cue="0%"><Setter Property="RotateTransform.Angle" Value="0" /></KeyFrame>
-                                                    <KeyFrame Cue="100%"><Setter Property="RotateTransform.Angle" Value="360" /></KeyFrame>
-                                                </Animation>
-                                            </Style.Animations>
-                                        </Style>
-                                    </i:Icon.Styles>
-                                </i:Icon>
-                                <TextBlock Name="BannerUploadBtnText" Text="Upload"
-                                           FontSize="14" FontWeight="SemiBold"
-                                           Foreground="White" VerticalAlignment="Center" />
-                            </StackPanel>
-                        </Button>
-                        <Button Name="BannerBrowseBtn"
-                                DockPanel.Dock="Right"
-                                Content="Browse…"
-                                Padding="14,10"
-                                CornerRadius="8"
-                                Cursor="Hand"
-                                FontSize="14"
-                                Background="{DynamicResource SurfaceMedium}"
-                                Foreground="{DynamicResource TextStrong}" />
-                        <TextBlock Name="BannerFileNameText"
-                                   Text="No file selected"
-                                   FontSize="13"
-                                   Foreground="{DynamicResource TextMuted}"
-                                   VerticalAlignment="Center"
-                                   TextTrimming="CharacterEllipsis"
-                                   Margin="0,0,8,0" />
-                    </DockPanel>
+                    <Button Name="BannerUploadBtn"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Center"
+                            Padding="16,10"
+                            CornerRadius="8"
+                            Cursor="Hand"
+                            Background="{DynamicResource PrimaryGreenBrush}"
+                            Foreground="White"
+                            FontSize="14" FontWeight="SemiBold">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <i:Icon Name="BannerUploadIcon" Value="fa-solid fa-cloud-arrow-up"
+                                    FontSize="13" Foreground="White" IsVisible="True" />
+                            <i:Icon Name="BannerUploadSpinner" Value="fa-solid fa-spinner"
+                                    FontSize="13" Foreground="White" IsVisible="False"
+                                    RenderTransformOrigin="50%,50%">
+                                <i:Icon.RenderTransform><RotateTransform /></i:Icon.RenderTransform>
+                                <i:Icon.Styles>
+                                    <Style Selector="i|Icon[IsVisible=True]">
+                                        <Style.Animations>
+                                            <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                <KeyFrame Cue="0%"><Setter Property="RotateTransform.Angle" Value="0" /></KeyFrame>
+                                                <KeyFrame Cue="100%"><Setter Property="RotateTransform.Angle" Value="360" /></KeyFrame>
+                                            </Animation>
+                                        </Style.Animations>
+                                    </Style>
+                                </i:Icon.Styles>
+                            </i:Icon>
+                            <TextBlock Name="BannerUploadBtnText" Text="Upload image"
+                                       FontSize="14" FontWeight="SemiBold"
+                                       Foreground="White" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
                     <TextBlock Name="BannerStatusText"
                                IsVisible="False"
                                FontSize="12"
@@ -197,56 +203,38 @@
                              Text="https://blossom.angor.io"
                              Watermark="Blossom server URL"
                              Padding="12,10" FontSize="14" CornerRadius="8" />
-                    <DockPanel>
-                        <Button Name="ProfileUploadBtn"
-                                DockPanel.Dock="Right"
-                                Padding="16,10"
-                                CornerRadius="8"
-                                Cursor="Hand"
-                                Background="{DynamicResource PrimaryGreenBrush}"
-                                Foreground="White"
-                                FontSize="14" FontWeight="SemiBold"
-                                Margin="8,0,0,0">
-                            <StackPanel Orientation="Horizontal" Spacing="6">
-                                <i:Icon Name="ProfileUploadIcon" Value="fa-solid fa-cloud-arrow-up"
-                                        FontSize="13" Foreground="White" IsVisible="True" />
-                                <i:Icon Name="ProfileUploadSpinner" Value="fa-solid fa-spinner"
-                                        FontSize="13" Foreground="White" IsVisible="False"
-                                        RenderTransformOrigin="50%,50%">
-                                    <i:Icon.RenderTransform><RotateTransform /></i:Icon.RenderTransform>
-                                    <i:Icon.Styles>
-                                        <Style Selector="i|Icon[IsVisible=True]">
-                                            <Style.Animations>
-                                                <Animation Duration="0:0:1" IterationCount="INFINITE">
-                                                    <KeyFrame Cue="0%"><Setter Property="RotateTransform.Angle" Value="0" /></KeyFrame>
-                                                    <KeyFrame Cue="100%"><Setter Property="RotateTransform.Angle" Value="360" /></KeyFrame>
-                                                </Animation>
-                                            </Style.Animations>
-                                        </Style>
-                                    </i:Icon.Styles>
-                                </i:Icon>
-                                <TextBlock Name="ProfileUploadBtnText" Text="Upload"
-                                           FontSize="14" FontWeight="SemiBold"
-                                           Foreground="White" VerticalAlignment="Center" />
-                            </StackPanel>
-                        </Button>
-                        <Button Name="ProfileBrowseBtn"
-                                DockPanel.Dock="Right"
-                                Content="Browse…"
-                                Padding="14,10"
-                                CornerRadius="8"
-                                Cursor="Hand"
-                                FontSize="14"
-                                Background="{DynamicResource SurfaceMedium}"
-                                Foreground="{DynamicResource TextStrong}" />
-                        <TextBlock Name="ProfileFileNameText"
-                                   Text="No file selected"
-                                   FontSize="13"
-                                   Foreground="{DynamicResource TextMuted}"
-                                   VerticalAlignment="Center"
-                                   TextTrimming="CharacterEllipsis"
-                                   Margin="0,0,8,0" />
-                    </DockPanel>
+                    <Button Name="ProfileUploadBtn"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Center"
+                            Padding="16,10"
+                            CornerRadius="8"
+                            Cursor="Hand"
+                            Background="{DynamicResource PrimaryGreenBrush}"
+                            Foreground="White"
+                            FontSize="14" FontWeight="SemiBold">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <i:Icon Name="ProfileUploadIcon" Value="fa-solid fa-cloud-arrow-up"
+                                    FontSize="13" Foreground="White" IsVisible="True" />
+                            <i:Icon Name="ProfileUploadSpinner" Value="fa-solid fa-spinner"
+                                    FontSize="13" Foreground="White" IsVisible="False"
+                                    RenderTransformOrigin="50%,50%">
+                                <i:Icon.RenderTransform><RotateTransform /></i:Icon.RenderTransform>
+                                <i:Icon.Styles>
+                                    <Style Selector="i|Icon[IsVisible=True]">
+                                        <Style.Animations>
+                                            <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                <KeyFrame Cue="0%"><Setter Property="RotateTransform.Angle" Value="0" /></KeyFrame>
+                                                <KeyFrame Cue="100%"><Setter Property="RotateTransform.Angle" Value="360" /></KeyFrame>
+                                            </Animation>
+                                        </Style.Animations>
+                                    </Style>
+                                </i:Icon.Styles>
+                            </i:Icon>
+                            <TextBlock Name="ProfileUploadBtnText" Text="Upload image"
+                                       FontSize="14" FontWeight="SemiBold"
+                                       Foreground="White" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
                     <TextBlock Name="ProfileStatusText"
                                IsVisible="False"
                                FontSize="12"

--- a/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep3View.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/Steps/CreateProjectStep3View.axaml.cs
@@ -21,26 +21,16 @@ public partial class CreateProjectStep3View : UserControl
     private readonly ILogger<CreateProjectStep3View> _logger;
     private readonly BlossomUploadService _blossomService;
 
-    // Stored bytes from Browse for upload
-    private byte[]? _bannerFileBytes;
-    private string _bannerContentType = "image/jpeg";
-    private byte[]? _profileFileBytes;
-    private string _profileContentType = "image/jpeg";
-
     private IDisposable? _bannerUrlSub;
     private IDisposable? _profileUrlSub;
 
     // Cached control references
-    private TextBlock? _bannerFileNameText;
     private TextBlock? _bannerStatusText;
-    private TextBlock? _profileFileNameText;
     private TextBlock? _profileStatusText;
     private TextBox? _bannerBlossomServerTextBox;
     private TextBox? _profileBlossomServerTextBox;
     private Button? _bannerUploadBtn;
     private Button? _profileUploadBtn;
-    private Avalonia.Controls.Shapes.Path? _bannerUploadIcon;
-    private Avalonia.Controls.Shapes.Path? _profileUploadIcon;
 
     public CreateProjectStep3View()
     {
@@ -53,29 +43,22 @@ public partial class CreateProjectStep3View : UserControl
     {
         base.OnLoaded(e);
 
-        _bannerFileNameText = this.FindControl<TextBlock>("BannerFileNameText");
         _bannerStatusText = this.FindControl<TextBlock>("BannerStatusText");
-        _profileFileNameText = this.FindControl<TextBlock>("ProfileFileNameText");
         _profileStatusText = this.FindControl<TextBlock>("ProfileStatusText");
         _bannerBlossomServerTextBox = this.FindControl<TextBox>("BannerBlossomServerTextBox");
         _profileBlossomServerTextBox = this.FindControl<TextBox>("ProfileBlossomServerTextBox");
         _bannerUploadBtn = this.FindControl<Button>("BannerUploadBtn");
         _profileUploadBtn = this.FindControl<Button>("ProfileUploadBtn");
 
-        // Wire browse buttons
-        var bannerBrowseBtn = this.FindControl<Button>("BannerBrowseBtn");
-        if (bannerBrowseBtn != null)
-            bannerBrowseBtn.Click += (_, _) => _ = BrowseFileAsync(true);
-
-        var profileBrowseBtn = this.FindControl<Button>("ProfileBrowseBtn");
-        if (profileBrowseBtn != null)
-            profileBrowseBtn.Click += (_, _) => _ = BrowseFileAsync(false);
-
-        // Wire upload buttons
+        // Wire combined pick-and-upload buttons
         if (_bannerUploadBtn != null)
-            _bannerUploadBtn.Click += (_, _) => _ = UploadToBlossomAsync(true);
+            _bannerUploadBtn.Click += (_, _) => _ = PickAndUploadAsync(true);
         if (_profileUploadBtn != null)
-            _profileUploadBtn.Click += (_, _) => _ = UploadToBlossomAsync(false);
+            _profileUploadBtn.Click += (_, _) => _ = PickAndUploadAsync(false);
+
+        // Wire preview click-targets (banner panel + avatar circle) — same Pick & Upload flow
+        WirePreviewClickTarget("BannerPreviewClickTarget", "BannerPreviewOverlay", isBanner: true);
+        WirePreviewClickTarget("AvatarPreviewClickTarget", "AvatarPreviewOverlay", isBanner: false);
 
         // Watch ViewModel URL changes to update the preview
         if (DataContext is CreateProjectViewModel vm)
@@ -134,13 +117,50 @@ public partial class CreateProjectStep3View : UserControl
 
     #endregion
 
-    #region File Browse
+    #region Preview click-targets
 
-    private async Task BrowseFileAsync(bool isBanner)
+    private void WirePreviewClickTarget(string targetName, string overlayName, bool isBanner)
+    {
+        var target = this.FindControl<Control>(targetName);
+        var overlay = this.FindControl<Border>(overlayName);
+        if (target == null) return;
+
+        target.PointerPressed += (_, e) =>
+        {
+            if (e.GetCurrentPoint(target).Properties.IsLeftButtonPressed)
+                _ = PickAndUploadAsync(isBanner);
+        };
+
+        if (overlay != null)
+        {
+            target.PointerEntered += (_, _) => overlay.IsVisible = true;
+            target.PointerExited += (_, _) => overlay.IsVisible = false;
+        }
+    }
+
+    #endregion
+
+    #region Pick & Upload
+
+    private async Task PickAndUploadAsync(bool isBanner)
     {
         var topLevel = TopLevel.GetTopLevel(this);
         if (topLevel == null) return;
 
+        var serverUrl = isBanner
+            ? _bannerBlossomServerTextBox?.Text?.Trim()
+            : _profileBlossomServerTextBox?.Text?.Trim();
+
+        if (string.IsNullOrWhiteSpace(serverUrl) || !Uri.TryCreate(serverUrl, UriKind.Absolute, out _))
+        {
+            SetStatus(isBanner, "Please enter a valid Blossom server URL.", isError: true);
+            return;
+        }
+
+        // Step 1 — file picker
+        byte[] fileBytes;
+        string contentType;
+        string fileName;
         try
         {
             var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
@@ -157,81 +177,41 @@ public partial class CreateProjectStep3View : UserControl
                 }
             });
 
-            if (files.Count == 0) return;
+            if (files.Count == 0) return; // user cancelled — no error
 
             var file = files[0];
             await using var stream = await file.OpenReadAsync();
             using var ms = new MemoryStream();
             await stream.CopyToAsync(ms);
 
-            var bytes = ms.ToArray();
+            fileBytes = ms.ToArray();
+            fileName = file.Name;
             var ext = Path.GetExtension(file.Name).ToLowerInvariant();
-            var contentType = ext switch
+            contentType = ext switch
             {
                 ".png" => "image/png",
                 ".gif" => "image/gif",
                 ".webp" => "image/webp",
                 _ => "image/jpeg"
             };
-
-            if (isBanner)
-            {
-                _bannerFileBytes = bytes;
-                _bannerContentType = contentType;
-                if (_bannerFileNameText != null)
-                    _bannerFileNameText.Text = $"{file.Name} ({bytes.Length / 1024} KB)";
-                SetStatus(true, $"Ready to upload: {file.Name}", isError: false);
-            }
-            else
-            {
-                _profileFileBytes = bytes;
-                _profileContentType = contentType;
-                if (_profileFileNameText != null)
-                    _profileFileNameText.Text = $"{file.Name} ({bytes.Length / 1024} KB)";
-                SetStatus(false, $"Ready to upload: {file.Name}", isError: false);
-            }
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "File browse failed");
-        }
-    }
-
-    #endregion
-
-    #region Blossom Upload
-
-    private async Task UploadToBlossomAsync(bool isBanner)
-    {
-        var fileBytes = isBanner ? _bannerFileBytes : _profileFileBytes;
-        var contentType = isBanner ? _bannerContentType : _profileContentType;
-        var serverUrl = isBanner
-            ? _bannerBlossomServerTextBox?.Text?.Trim()
-            : _profileBlossomServerTextBox?.Text?.Trim();
-
-        if (fileBytes == null || fileBytes.Length == 0)
-        {
-            SetStatus(isBanner, "Please browse and select a file first.", isError: true);
+            _logger.LogWarning(ex, "File pick failed");
+            SetStatus(isBanner, $"Could not read file: {ex.Message}", isError: true);
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(serverUrl) || !Uri.TryCreate(serverUrl, UriKind.Absolute, out _))
-        {
-            SetStatus(isBanner, "Please enter a valid Blossom server URL.", isError: true);
-            return;
-        }
-
+        // Step 2 — upload
         SetUploadInProgress(isBanner, true);
-        SetStatus(isBanner, $"Uploading to {serverUrl}…", isError: false);
+        SetStatus(isBanner, $"Uploading {fileName} to {serverUrl}…", isError: false);
 
         try
         {
-            // Get the Nostr private key for BUD-02 auth from the selected wallet
             var nostrKeyHex = await GetNostrPrivateKeyHexAsync();
             if (nostrKeyHex == null)
             {
                 SetStatus(isBanner, "No wallet selected or unable to access wallet keys.", isError: true);
-                SetUploadInProgress(isBanner, false);
                 return;
             }
 
@@ -252,23 +232,11 @@ public partial class CreateProjectStep3View : UserControl
                     vm.ProfileUrl = result.Value;
             }
 
-            SetStatus(isBanner, "Upload successful!", isError: false);
-
-            // Clear stored bytes after a successful upload
-            if (isBanner)
-            {
-                _bannerFileBytes = null;
-                if (_bannerFileNameText != null) _bannerFileNameText.Text = "No file selected";
-            }
-            else
-            {
-                _profileFileBytes = null;
-                if (_profileFileNameText != null) _profileFileNameText.Text = "No file selected";
-            }
+            SetStatus(isBanner, $"Uploaded {fileName} — click again to replace.", isError: false);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "UploadToBlossomAsync failed");
+            _logger.LogError(ex, "PickAndUploadAsync failed");
             SetStatus(isBanner, $"Upload error: {ex.Message}", isError: true);
         }
         finally
@@ -357,11 +325,6 @@ public partial class CreateProjectStep3View : UserControl
     /// </summary>
     public void ResetVisualState()
     {
-        _bannerFileBytes = null;
-        _profileFileBytes = null;
-
-        if (_bannerFileNameText != null) _bannerFileNameText.Text = "No file selected";
-        if (_profileFileNameText != null) _profileFileNameText.Text = "No file selected";
         if (_bannerStatusText != null) _bannerStatusText.IsVisible = false;
         if (_profileStatusText != null) _profileStatusText.IsVisible = false;
 

--- a/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml
@@ -81,13 +81,13 @@
                     <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                         <Viewbox Width="10" Height="16">
                             <Path Data="{StaticResource ChevronLeftThick}"
-                                  Fill="{DynamicResource TextStrong}"
+                                  Fill="{DynamicResource TextStrongBrush}"
                                   Width="320" Height="512" Stretch="Uniform" />
                         </Viewbox>
                         <TextBlock Text="Back"
                                    FontSize="14"
                                    FontWeight="Medium"
-                                   Foreground="{DynamicResource TextStrong}"
+                                   Foreground="{DynamicResource TextStrongBrush}"
                                    VerticalAlignment="Center" />
                     </StackPanel>
                 </Button>
@@ -113,17 +113,17 @@
                                     IsVisible="{Binding !IsProcessing}">
                             <i:Icon Value="fa-solid fa-arrows-rotate"
                                    FontSize="14"
-                                   Foreground="{DynamicResource TextStrong}" />
+                                   Foreground="{DynamicResource TextStrongBrush}" />
                             <TextBlock Text="Refresh"
                                        FontSize="14"
                                        FontWeight="Medium"
-                                       Foreground="{DynamicResource TextStrong}"
+                                       Foreground="{DynamicResource TextStrongBrush}"
                                        VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center"
                                     IsVisible="{Binding IsProcessing}">
                             <i:Icon Value="fa-solid fa-spinner" FontSize="14"
-                                    Foreground="{DynamicResource TextStrong}"
+                                    Foreground="{DynamicResource TextStrongBrush}"
                                     RenderTransformOrigin="50%,50%">
                                 <i:Icon.RenderTransform>
                                     <RotateTransform />
@@ -144,7 +144,7 @@
                                 </i:Icon.Styles>
                             </i:Icon>
                             <TextBlock Text="Refresh" FontSize="14" FontWeight="Medium"
-                                       Foreground="{DynamicResource TextStrong}"
+                                       Foreground="{DynamicResource TextStrongBrush}"
                                        VerticalAlignment="Center" />
                         </StackPanel>
                     </Panel>
@@ -240,13 +240,13 @@
                                     <TextBlock Text="2"
                                                FontSize="14"
                                                FontWeight="Bold"
-                                               Foreground="{DynamicResource TextMuted}"
+                                               Foreground="{DynamicResource TextMutedBrush}"
                                                HorizontalAlignment="Center"
                                                VerticalAlignment="Center" />
                                 </Border>
                                 <TextBlock FontSize="14"
                                            FontWeight="Medium"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            VerticalAlignment="Center">
                                     <Run Text="Preview " /><Run Text="{Binding AmountNoun, Mode=OneWay}" />
                                 </TextBlock>
@@ -306,14 +306,14 @@
                                     <TextBlock Text="3"
                                                FontSize="14"
                                                FontWeight="Bold"
-                                               Foreground="{DynamicResource TextMuted}"
+                                               Foreground="{DynamicResource TextMutedBrush}"
                                                HorizontalAlignment="Center"
                                                VerticalAlignment="Center" />
                                 </Border>
                                 <TextBlock Text="Funds Transferred"
                                            FontSize="14"
                                            FontWeight="Medium"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            VerticalAlignment="Center" />
                             </StackPanel>
                         </Border>
@@ -358,7 +358,7 @@
                                     Background="{DynamicResource SurfaceLow}"
                                     IsVisible="{Binding IsStep1}">
                                 <TextBlock Text="1" FontSize="14" FontWeight="Bold"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            HorizontalAlignment="Center" VerticalAlignment="Center" />
                             </Border>
                         </Panel>
@@ -389,12 +389,12 @@
                                     Background="{DynamicResource SurfaceLow}"
                                     IsVisible="{Binding IsStep1}">
                                 <TextBlock Text="2" FontSize="14" FontWeight="Bold"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            HorizontalAlignment="Center" VerticalAlignment="Center" />
                             </Border>
                         </Panel>
                         <TextBlock FontSize="14" FontWeight="SemiBold"
-                                   Foreground="{DynamicResource TextMuted}"
+                                   Foreground="{DynamicResource TextMutedBrush}"
                                    VerticalAlignment="Center">
                             <Run Text="Preview " /><Run Text="{Binding AmountNoun, Mode=OneWay}" />
                         </TextBlock>
@@ -421,13 +421,13 @@
                                     Background="{DynamicResource SurfaceLow}"
                                     IsVisible="{Binding !IsStep3}">
                                 <TextBlock Text="3" FontSize="14" FontWeight="Bold"
-                                           Foreground="{DynamicResource TextMuted}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
                                            HorizontalAlignment="Center" VerticalAlignment="Center" />
                             </Border>
                         </Panel>
                         <TextBlock Text="Funds Transferred"
                                    FontSize="14" FontWeight="SemiBold"
-                                   Foreground="{DynamicResource TextMuted}"
+                                   Foreground="{DynamicResource TextMutedBrush}"
                                    VerticalAlignment="Center" />
                     </StackPanel>
                 </Border>
@@ -483,11 +483,11 @@
                             <TextBlock Text="{Binding ProjectName}"
                                        FontSize="24"
                                        FontWeight="Bold"
-                                       Foreground="{DynamicResource TextStrong}" />
+                                       Foreground="{DynamicResource TextStrongBrush}" />
                             <!-- Description — Vue: .project-description-compact 15px, color:#666 dark:#a0a0a0 -->
                             <TextBlock Text="{Binding ShortDescription}"
                                        FontSize="15"
-                                       Foreground="{DynamicResource TextMuted}"
+                                       Foreground="{DynamicResource TextMutedBrush}"
                                        TextWrapping="Wrap"
                                        MaxLines="3" />
                         </StackPanel>
@@ -1013,11 +1013,11 @@
                     <StackPanel Orientation="Horizontal" Spacing="12">
                         <i:Icon Value="fa-brands fa-bitcoin"
                                FontSize="22"
-                               Foreground="{DynamicResource TextMuted}"
+                               Foreground="{DynamicResource TextMutedBrush}"
                                VerticalAlignment="Center" />
                         <TextBlock FontSize="20"
                                    FontWeight="Bold"
-                                   Foreground="{DynamicResource TextStrong}"
+                                   Foreground="{DynamicResource TextStrongBrush}"
                                    VerticalAlignment="Center">
                             <Run Text="{Binding AmountNoun, Mode=OneWay}" /><Run Text=" Information" />
                         </TextBlock>
@@ -1036,19 +1036,19 @@
                             <StackPanel Spacing="8">
                                 <DockPanel>
                                     <TextBlock FontSize="13" FontWeight="SemiBold"
-                                               Foreground="{DynamicResource TextMuted}"
+                                               Foreground="{DynamicResource TextMutedBrush}"
                                                DockPanel.Dock="Left" VerticalAlignment="Center">
                                         <Run Text="{Binding AmountNoun, Mode=OneWay}" /><Run Text=" Start Date" />
                                     </TextBlock>
-                                    <i:Icon Value="fa-solid fa-calendar"
-                                           FontSize="16"
-                                           Foreground="{DynamicResource TextMuted}"
-                                           HorizontalAlignment="Right" VerticalAlignment="Center" />
+                                     <i:Icon Value="fa-solid fa-calendar"
+                                            FontSize="16"
+                                            Foreground="{DynamicResource TextMutedBrush}"
+                                            HorizontalAlignment="Right" VerticalAlignment="Center" />
                                 </DockPanel>
                                 <TextBlock Text="{Binding StartDate}"
                                            FontSize="18"
                                            FontWeight="Bold"
-                                           Foreground="{DynamicResource TextStrong}" />
+                                           Foreground="{DynamicResource TextStrongBrush}" />
                             </StackPanel>
                         </Border>
 
@@ -1063,19 +1063,19 @@
                             <StackPanel Spacing="8">
                                 <DockPanel>
                                     <TextBlock FontSize="13" FontWeight="SemiBold"
-                                               Foreground="{DynamicResource TextMuted}"
+                                               Foreground="{DynamicResource TextMutedBrush}"
                                                DockPanel.Dock="Left" VerticalAlignment="Center">
                                         <Run Text="{Binding AmountNoun, Mode=OneWay}" /><Run Text=" End Date" />
                                     </TextBlock>
-                                    <i:Icon Value="fa-solid fa-calendar"
-                                           FontSize="16"
-                                           Foreground="{DynamicResource TextMuted}"
-                                           HorizontalAlignment="Right" VerticalAlignment="Center" />
+                                     <i:Icon Value="fa-solid fa-calendar"
+                                            FontSize="16"
+                                            Foreground="{DynamicResource TextMutedBrush}"
+                                            HorizontalAlignment="Right" VerticalAlignment="Center" />
                                 </DockPanel>
                                 <TextBlock Text="{Binding EndDate}"
                                            FontSize="18"
                                            FontWeight="Bold"
-                                           Foreground="{DynamicResource TextStrong}" />
+                                           Foreground="{DynamicResource TextStrongBrush}" />
                             </StackPanel>
                         </Border>
 
@@ -1091,17 +1091,17 @@
                                 <DockPanel>
                                     <TextBlock Text="Transaction Date"
                                                FontSize="13" FontWeight="SemiBold"
-                                               Foreground="{DynamicResource TextMuted}"
+                                               Foreground="{DynamicResource TextMutedBrush}"
                                                DockPanel.Dock="Left" VerticalAlignment="Center" />
-                                    <i:Icon Value="fa-solid fa-clock"
-                                           FontSize="16"
-                                           Foreground="{DynamicResource TextMuted}"
-                                           HorizontalAlignment="Right" VerticalAlignment="Center" />
+                                     <i:Icon Value="fa-solid fa-clock"
+                                            FontSize="16"
+                                            Foreground="{DynamicResource TextMutedBrush}"
+                                            HorizontalAlignment="Right" VerticalAlignment="Center" />
                                 </DockPanel>
                                 <TextBlock Text="{Binding TransactionDate}"
                                            FontSize="18"
                                            FontWeight="Bold"
-                                           Foreground="{DynamicResource TextStrong}" />
+                                           Foreground="{DynamicResource TextStrongBrush}" />
                             </StackPanel>
                         </Border>
 
@@ -1116,14 +1116,14 @@
                             <StackPanel Spacing="8">
                                 <DockPanel>
                                     <TextBlock FontSize="13" FontWeight="SemiBold"
-                                               Foreground="{DynamicResource TextMuted}"
+                                               Foreground="{DynamicResource TextMutedBrush}"
                                                DockPanel.Dock="Left" VerticalAlignment="Center">
                                         <Run Text="{Binding AmountNoun, Mode=OneWay}" /><Run Text=" Status" />
                                     </TextBlock>
-                                    <i:Icon Value="fa-regular fa-circle-check"
-                                           FontSize="16"
-                                           Foreground="{DynamicResource TextMuted}"
-                                           HorizontalAlignment="Right" VerticalAlignment="Center" />
+                                     <i:Icon Value="fa-regular fa-circle-check"
+                                            FontSize="16"
+                                            Foreground="{DynamicResource TextMutedBrush}"
+                                            HorizontalAlignment="Right" VerticalAlignment="Center" />
                                 </DockPanel>
                                 <!-- Status value — green if Approved, orange if Pending -->
                                 <TextBlock Text="{Binding ApprovalStatus}"
@@ -1153,7 +1153,7 @@
                         <StackPanel Orientation="Horizontal" Spacing="12" DockPanel.Dock="Left">
                             <Viewbox Width="24" Height="24" VerticalAlignment="Center">
                                 <Path Data="{StaticResource NavIconDocument}"
-                                      Stroke="{DynamicResource TextMuted}"
+                                      Stroke="{DynamicResource TextMutedBrush}"
                                       StrokeThickness="1.5"
                                       StrokeLineCap="Round"
                                       StrokeJoin="Round"
@@ -1162,7 +1162,7 @@
                             <TextBlock Text="{Binding ScheduleTitle}"
                                        FontSize="20"
                                        FontWeight="Bold"
-                                       Foreground="{DynamicResource TextStrong}"
+                                       Foreground="{DynamicResource TextStrongBrush}"
                                        VerticalAlignment="Center" />
                         </StackPanel>
                         <!-- Recover Funds button — Vue: .recover-funds-button-light bg:#F7931A -->
@@ -1196,27 +1196,27 @@
                                        Text="{Binding StageLabel}"
                                        FontSize="13"
                                        FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             <TextBlock Grid.Column="1"
                                        Text="Stage %"
                                        FontSize="13"
                                        FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             <TextBlock Grid.Column="2"
                                        Text="Release Date"
                                        FontSize="13"
                                        FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             <TextBlock Grid.Column="3"
                                        Text="Status"
                                        FontSize="13"
                                        FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextMuted}" />
+                                       Foreground="{DynamicResource TextMutedBrush}" />
                             <TextBlock Grid.Column="4"
                                        Text="Amount"
                                        FontSize="13"
                                        FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextMuted}"
+                                       Foreground="{DynamicResource TextMutedBrush}"
                                        HorizontalAlignment="Right" />
                         </Grid>
                     </Border>
@@ -1235,7 +1235,7 @@
                                                    FontSize="14"
                                                    FontWeight="SemiBold"
                                                    VerticalAlignment="Center"
-                                                   Foreground="{DynamicResource TextStrong}">
+                                                   Foreground="{DynamicResource TextStrongBrush}">
                                             <Run Text="{Binding StagePrefix, Mode=OneWay}" /><Run Text=" " /><Run Text="{Binding StageNumber, Mode=OneWay}" />
                                         </TextBlock>
 
@@ -1244,14 +1244,14 @@
                                                    Text="{Binding Percentage}"
                                                    FontSize="14"
                                                    VerticalAlignment="Center"
-                                                   Foreground="{DynamicResource TextStrong}" />
+                                                   Foreground="{DynamicResource TextStrongBrush}" />
 
                                         <!-- Release Date -->
                                         <TextBlock Grid.Column="2"
                                                    Text="{Binding ReleaseDate}"
                                                    FontSize="14"
                                                    VerticalAlignment="Center"
-                                                   Foreground="{DynamicResource TextStrong}" />
+                                                   Foreground="{DynamicResource TextStrongBrush}" />
 
                                         <!-- Status Badge — per-status colors -->
                                         <!-- Vue: .status-badge padding:6px 14px, border-radius:16px, font-size:12px, font-weight:600, border:1px -->
@@ -1341,7 +1341,7 @@
                                         <!-- Row 1: Stage number + Status badge -->
                                         <DockPanel>
                                             <TextBlock FontSize="15" FontWeight="SemiBold"
-                                                       Foreground="{DynamicResource TextStrong}"
+                                                       Foreground="{DynamicResource TextStrongBrush}"
                                                        VerticalAlignment="Center">
                                                 <Run Text="{Binding StagePrefix, Mode=OneWay}" /><Run Text=" " /><Run Text="{Binding StageNumber, Mode=OneWay}" />
                                             </TextBlock>
@@ -1382,10 +1382,10 @@
                                         </DockPanel>
                                         <!-- Row 2: Percentage + Release Date -->
                                         <DockPanel>
-                                            <TextBlock FontSize="12" Foreground="{DynamicResource TextMuted}">
+                                            <TextBlock FontSize="12" Foreground="{DynamicResource TextMutedBrush}">
                                                 <Run Text="Stage: " /><Run Text="{Binding Percentage, Mode=OneWay}" />
                                             </TextBlock>
-                                            <TextBlock FontSize="12" Foreground="{DynamicResource TextMuted}"
+                                            <TextBlock FontSize="12" Foreground="{DynamicResource TextMutedBrush}"
                                                        HorizontalAlignment="Right"
                                                        Text="{Binding ReleaseDate}" />
                                         </DockPanel>

--- a/src/design/App/UI/Sections/Portfolio/PortfolioView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioView.axaml
@@ -423,8 +423,8 @@
                                         <StackPanel Spacing="12" Margin="20,48,20,20">
 
                                             <!-- Type + Status pills — using shared Pill style classes -->
-                                            <!-- Vue: .investment-pills gap:8px -->
-                                            <WrapPanel>
+                                            <!-- 4px horizontal gap between pills; 4px vertical when they wrap to a new line -->
+                                            <WrapPanel ItemSpacing="4" LineSpacing="4">
                                                 <!-- Type pill: Investment (blue), Funding (amber), Subscription (pink) -->
                                                 <ContentControl Classes="Pill Blue"
                                                                 Content="{Binding TypeLabel}"

--- a/src/design/App/UI/Sections/Settings/SettingsView.axaml
+++ b/src/design/App/UI/Sections/Settings/SettingsView.axaml
@@ -150,12 +150,11 @@
                                               Classes="Widget"
                                               IsChecked="{Binding IsDarkThemeEnabled, Mode=TwoWay}"
                                               VerticalAlignment="Center">
-                                    <ToggleButton.Content>
-                                        <i:Icon Value="fa-solid fa-sun"
-                                                FontSize="16"
-                                                Foreground="{DynamicResource TextMuted}" />
-                                    </ToggleButton.Content>
-                                </ToggleButton>
+                                     <ToggleButton.Content>
+                                         <i:Icon Value="fa-solid fa-sun"
+                                                FontSize="16" />
+                                     </ToggleButton.Content>
+                                 </ToggleButton>
                                 <StackPanel Spacing="4" VerticalAlignment="Center">
                                     <TextBlock Text="Dark Mode"
                                                FontSize="14"

--- a/src/design/App/UI/Shared/Controls/ProjectCard.axaml
+++ b/src/design/App/UI/Shared/Controls/ProjectCard.axaml
@@ -129,7 +129,10 @@
 
                                 <!-- Status pill — always green -->
                                 <ContentControl Classes="Pill Green"
-                                                Content="{TemplateBinding Status}" />
+                                                 Content="{TemplateBinding Status}" />
+                                <ContentControl Classes="Pill Blue"
+                                                Content="Invested"
+                                                IsVisible="{TemplateBinding HasInvested}" />
                             </StackPanel>
 
                             <!-- 2. Title — Vue: 18px, font-weight 700, single line -->

--- a/src/design/App/UI/Shared/Controls/ProjectCard.axaml.cs
+++ b/src/design/App/UI/Shared/Controls/ProjectCard.axaml.cs
@@ -83,6 +83,9 @@ public class ProjectCard : TemplatedControl
     public static readonly StyledProperty<string?> StatusProperty =
         AvaloniaProperty.Register<ProjectCard, string?>(nameof(Status), "Open");
 
+    public static readonly StyledProperty<bool> HasInvestedProperty =
+        AvaloniaProperty.Register<ProjectCard, bool>(nameof(HasInvested));
+
     /// <summary>
     /// When true, shows "Manage Project" + Share buttons at the bottom of the card.
     /// Vue: showManageFunds prop on ProjectCard — only set on My Projects page.
@@ -186,6 +189,12 @@ public class ProjectCard : TemplatedControl
     {
         get => GetValue(StatusProperty);
         set => SetValue(StatusProperty, value);
+    }
+
+    public bool HasInvested
+    {
+        get => GetValue(HasInvestedProperty);
+        set => SetValue(HasInvestedProperty, value);
     }
 
     public bool ShowManageFunds

--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowView.axaml
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowView.axaml
@@ -13,11 +13,11 @@
     <!-- Reusable payment flow modals: Wallet Selector → Invoice/QR → Success.
          DataContext = PaymentFlowViewModel (set by the hosting view). -->
     <UserControl.Styles>
-        <Style Selector="Border.WalletCard">
+        <Style Selector="Button.WalletCard">
             <Setter Property="Background" Value="{DynamicResource DeployWalletItemBg}" />
             <Setter Property="BorderBrush" Value="{DynamicResource DeployWalletItemBorder}" />
         </Style>
-        <Style Selector="Border.WalletCard.WalletSelected">
+        <Style Selector="Button.WalletCard.WalletSelected">
             <Setter Property="Background" Value="{DynamicResource DeployWalletSelectedBg}" />
             <Setter Property="BorderBrush" Value="{DynamicResource DeployWalletSelectedBorder}" />
         </Style>

--- a/src/design/App/UI/Shell/ShellView.axaml
+++ b/src/design/App/UI/Shell/ShellView.axaml
@@ -172,7 +172,7 @@
                     </Button>
                     <ToggleButton Classes="Widget" IsChecked="{Binding IsDarkThemeEnabled, Mode=TwoWay}">
                         <ToggleButton.Content>
-                            <i:Icon Value="fa-solid fa-sun" FontSize="16" Foreground="{DynamicResource TextMuted}" />
+                            <i:Icon Value="fa-solid fa-sun" FontSize="16" />
                         </ToggleButton.Content>
                     </ToggleButton>
                     <Button Classes="Widget" Name="SettingsButton" Click="OnSettingsClick"

--- a/src/design/App/UI/Themes/V2/Resources/Colors.Core.axaml
+++ b/src/design/App/UI/Themes/V2/Resources/Colors.Core.axaml
@@ -48,6 +48,8 @@
             <Color x:Key="Stroke">#19000000</Color>
             <Color x:Key="TextMuted">#6B7280</Color>           <!-- = Labels -->
             <Color x:Key="TextStrong">#0A0A0A</Color>          <!-- ≈ PrimaryBlackHover -->
+            <SolidColorBrush x:Key="TextMutedBrush" Color="{StaticResource TextMuted}" />
+            <SolidColorBrush x:Key="TextStrongBrush" Color="{StaticResource TextStrong}" />
             <Color x:Key="Brand">#2D5A3D</Color>               <!-- = PrimaryGreenDark -->
             <Color x:Key="Highlight">#2D5A3D</Color>           <!-- = PrimaryGreenDark -->
             <Color x:Key="BitcoinAccent">#F7931A</Color>       <!-- = BitcoinOrange -->
@@ -232,6 +234,8 @@
             <Color x:Key="Stroke">#19FFFFFF</Color>
             <Color x:Key="TextMuted">#A0A0A0</Color>
             <Color x:Key="TextStrong">#FAFAFA</Color>          <!-- = BodyText (Dark) -->
+            <SolidColorBrush x:Key="TextMutedBrush" Color="{StaticResource TextMuted}" />
+            <SolidColorBrush x:Key="TextStrongBrush" Color="{StaticResource TextStrong}" />
             <Color x:Key="Brand">#5FAF78</Color>
             <Color x:Key="Highlight">#E5E8E1</Color>
             <Color x:Key="BitcoinAccent">#F7931A</Color>       <!-- = BitcoinOrange -->

--- a/src/design/App/UI/Themes/V2/Styles/Icons.axaml
+++ b/src/design/App/UI/Themes/V2/Styles/Icons.axaml
@@ -7,7 +7,7 @@
 
     <!-- Defaults: all i:Icon elements in UserControls get TextMuted color -->
     <Style Selector=":is(UserControl) i|Icon">
-        <Setter Property="Foreground" Value="{DynamicResource TextMuted}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}" />
     </Style>
 
     <!-- Sizes -->
@@ -26,7 +26,7 @@
         <Setter Property="Foreground" Value="White" />
     </Style>
     <Style Selector="i|Icon.Icon-Fill-Muted">
-        <Setter Property="Foreground" Value="{DynamicResource TextMuted}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}" />
     </Style>
     <Style Selector="i|Icon.Icon-Fill-Green">
         <Setter Property="Foreground" Value="{DynamicResource Brand}" />

--- a/src/design/App/UI/Themes/V2/Styles/ToggleButtons.axaml
+++ b/src/design/App/UI/Themes/V2/Styles/ToggleButtons.axaml
@@ -17,6 +17,10 @@
         <Setter Property="Padding" Value="0" />
         <Setter Property="Background" Value="{DynamicResource Surface}" />
         <Setter Property="BorderBrush" Value="{DynamicResource Stroke}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextMuted}" />
+    </Style>
+    <Style Selector="ToggleButton.Widget i|Icon">
+        <Setter Property="Foreground" Value="{DynamicResource TextMuted}" />
     </Style>
 
     <Design.PreviewWith>


### PR DESCRIPTION
## Summary

Two small UX polish fixes for the **Create Project** wizard, focused on the mobile flow but applied to all surfaces.

### 1. Single-tap image upload (Step 3)

Replaces the two-button `Browse` + `Upload` flow with a single full-width **Upload image** button that picks the file and uploads it to Blossom in one action. Tapping again replaces it.

The banner panel and avatar circle are also clickable now (with hover overlays) so the previews themselves act as upload targets, matching the previous UX before the dual-button refactor.

Behind the scenes:
- Collapsed `_bannerFileBytes` / `_profileFileBytes` / `_*ContentType` / `_*FileNameText` / `_*UploadIcon` fields into a single `PickAndUploadAsync(bool isBanner)` flow
- Added `WirePreviewClickTarget` helper for the preview-click hover/upload wiring
- Pruned `ResetVisualState` of the removed fields

### 2. Scroll position reset on step change

The wizard reuses a single `ScrollViewer` across all six steps (visibility toggles on each step `UserControl`), so navigating Next/Previous or jumping via the stepper carried the previous step's scroll offset into the new step.

Fix: cache `StepScrollViewer` in the constructor and call `ScrollToHome()` whenever `CurrentStep` changes or `ResetVisualState()` runs. Posted at `Loaded` priority so it executes after the new step's layout pass.

## Test plan

Tested on both surfaces:
- macOS desktop (`App.Desktop` Debug)
- USB-connected Android device (`io.angor.app`, `net10.0-android`)

Verified:
- [x] Upload image button picks + uploads in a single action (logcat confirms `Blossom upload successful` for both banner and profile)
- [x] Tapping banner panel / avatar circle triggers the same upload flow
- [x] Tapping again replaces the existing image
- [x] Next / Previous always lands at the top of the new step
- [x] Stepper-circle jumps reset scroll
- [x] Reopening the wizard fresh (`ResetVisualState`) starts at the top

## Out of scope

- Spinner overlay on preview-click upload state (button has one; previews don't yet — possible follow-up if the ~1s upload feels frozen)