### PR TITLE
perf: improve Lightning payment flow speed on mobile

### DIFF
--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowView.axaml
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowView.axaml
@@ -319,7 +319,7 @@
                             Name="QrCodePlaceholder">
                         <Panel>
                             <Image Width="192" Height="192" Stretch="UniformToFill"
-                                   Source="{Binding QrCodeContent, Converter={x:Static shared:QRCodeConverter.Instance}}"
+                                   Source="{Binding QrCodeImage}"
                                    IsVisible="{Binding QrCodeContent, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                             <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8"
                                         IsVisible="{Binding QrCodeContent, Converter={x:Static StringConverters.IsNullOrEmpty}}">

--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Reactive;
 using System.Threading;
 using Angor.Sdk.Common;
@@ -11,8 +12,10 @@ using Angor.Sdk.Funding.Shared;
 using Angor.Sdk.Wallet.Domain;
 using App.UI.Shared.Services;
 using App.UI.Shell;
+using Avalonia.Media.Imaging;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
+using QRCoder;
 using ReactiveUI;
 using MonitorOp = Angor.Sdk.Funding.Investor.Operations.MonitorAddressForFunds;
 
@@ -68,6 +71,7 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
     [Reactive] private bool isGeneratingLightningInvoice;
     [Reactive] private string? errorMessage;
     [Reactive] private long selectedFeeRate;
+    [Reactive] private Bitmap? qrCodeImage;
 
     // ── Derived visibility ──
     public bool IsWalletSelector => CurrentScreen == PaymentFlowScreen.WalletSelector;
@@ -226,6 +230,21 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
                 this.RaisePropertyChanged(nameof(InvoiceString));
                 this.RaisePropertyChanged(nameof(QrCodeContent));
             }).DisposeWith(_disposables);
+
+        // Generate QR code on background thread to avoid blocking the UI,
+        // especially on mobile where large lightning invoices (~270 chars)
+        // produce complex QR codes that take hundreds of ms to generate.
+        this.WhenAnyValue(x => x.QrCodeContent)
+            .ObserveOn(RxApp.TaskpoolScheduler)
+            .Select(GenerateQrBitmap)
+            .ObserveOn(RxApp.MainThreadScheduler)
+            .Subscribe(image =>
+            {
+                var old = QrCodeImage;
+                QrCodeImage = image;
+                old?.Dispose();
+            })
+            .DisposeWith(_disposables);
 
         SelectWallet(GetInitialWalletSelection());
 
@@ -894,4 +913,22 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
     }
 
     public void Dispose() => _disposables.Dispose();
+
+    /// <summary>
+    /// Generates a QR code bitmap from a string. CPU-intensive for long inputs
+    /// (e.g. lightning invoices) — always call from a background thread.
+    /// </summary>
+    private static Bitmap? GenerateQrBitmap(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return null;
+
+        var qrGenerator = new QRCodeGenerator();
+        var qrCodeData = qrGenerator.CreateQrCode(content, QRCodeGenerator.ECCLevel.Q);
+        var qrCode = new PngByteQRCode(qrCodeData);
+        // 10 px/module is plenty for a 192x192 display area and keeps the bitmap small
+        var pngBytes = qrCode.GetGraphic(10);
+        var stream = new MemoryStream(pngBytes);
+        return new Bitmap(stream);
+    }
 }

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/CreateLightningSwap.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/CreateLightningSwap.cs
@@ -77,26 +77,44 @@ public static class CreateLightningSwap
                     "Total on-chain amount needed: {Total} sats (amount: {Amount} + angorFee: {AngorFee} + spendTxFee: {SpendTxFee} [{SpendVbytes} vB] + claimTxFee: {ClaimTxFee} [{ClaimVbytes} vB] @ {FeeRate} sat/vb, {Stages} stages)",
                     totalOnChainNeeded, investmentAmount, angorFee, estimatedSpendingTxFee, estimatedSpendingTxVbytes, estimatedClaimTxFee, EstimatedClaimTxVbytes, request.EstimatedFeeRateSatsPerVbyte, request.StageCount);
 
-                // Step 2: Ensure the amount meets Boltz minimum. If below, bump up —
-                // the excess stays in the wallet as change after the spending transaction.
+                // Step 2: Fetch fees once and reuse for both min-amount check and invoice calculation.
+                // Previously this called GetReverseSwapFeesAsync twice (once here, once inside
+                // CalculateInvoiceAmountAsync), adding an extra round-trip on mobile networks.
                 var feesResult = await boltzSwapService.GetReverseSwapFeesAsync();
-                if (feesResult.IsSuccess && totalOnChainNeeded < feesResult.Value.MinAmount)
+                if (feesResult.IsFailure)
+                {
+                    logger.LogError("Failed to get swap fees: {Error}", feesResult.Error);
+                    return Result.Failure<CreateLightningSwapResponse>(feesResult.Error);
+                }
+
+                var fees = feesResult.Value;
+
+                if (totalOnChainNeeded < fees.MinAmount)
                 {
                     logger.LogInformation(
                         "Amount {Total} sats is below Boltz minimum {Min} sats — bumping up",
-                        totalOnChainNeeded, feesResult.Value.MinAmount);
-                    totalOnChainNeeded = feesResult.Value.MinAmount;
+                        totalOnChainNeeded, fees.MinAmount);
+                    totalOnChainNeeded = fees.MinAmount;
                 }
 
-                // Step 3: Calculate the invoice amount (accounts for Boltz fees)
-                var invoiceAmountResult = await boltzSwapService.CalculateInvoiceAmountAsync(totalOnChainNeeded);
-                if (invoiceAmountResult.IsFailure)
+                // Step 3: Calculate the invoice amount using the already-fetched fees
+                var invoiceAmount = fees.CalculateInvoiceAmount(totalOnChainNeeded);
+
+                if (invoiceAmount < fees.MinAmount)
                 {
-                    logger.LogError("Failed to calculate invoice amount: {Error}", invoiceAmountResult.Error);
-                    return Result.Failure<CreateLightningSwapResponse>(invoiceAmountResult.Error);
+                    logger.LogError("Invoice amount {Amount} sats is below minimum {Min} sats",
+                        invoiceAmount, fees.MinAmount);
+                    return Result.Failure<CreateLightningSwapResponse>(
+                        $"Invoice amount {invoiceAmount} sats is below minimum {fees.MinAmount} sats");
+                }
+                if (invoiceAmount > fees.MaxAmount)
+                {
+                    logger.LogError("Invoice amount {Amount} sats exceeds maximum {Max} sats",
+                        invoiceAmount, fees.MaxAmount);
+                    return Result.Failure<CreateLightningSwapResponse>(
+                        $"Invoice amount {invoiceAmount} sats exceeds maximum {fees.MaxAmount} sats");
                 }
 
-                var invoiceAmount = invoiceAmountResult.Value;
                 var boltzFees = invoiceAmount - totalOnChainNeeded;
 
                 logger.LogInformation(

--- a/src/shared/Angor.Shared/Integration/Lightning/BoltzSwapService.cs
+++ b/src/shared/Angor.Shared/Integration/Lightning/BoltzSwapService.cs
@@ -21,6 +21,14 @@ public class BoltzSwapService : IBoltzSwapService
     private readonly ILogger<BoltzSwapService> _logger;
     private readonly JsonSerializerOptions _jsonOptions;
 
+    // Short-lived cache for fee lookups. During a single Lightning swap flow
+    // GetReverseSwapFeesAsync is called up to 3 times in quick succession
+    // (constructor prefetch, handler min-amount check, CalculateInvoiceAmountAsync).
+    // A 30-second TTL collapses those into a single HTTP round-trip.
+    private BoltzSwapFees? _cachedFees;
+    private DateTime _feesCachedAt;
+    private static readonly TimeSpan FeesCacheTtl = TimeSpan.FromSeconds(30);
+
     public BoltzSwapService(
         HttpClient httpClient,
         BoltzConfiguration configuration,
@@ -347,6 +355,14 @@ public class BoltzSwapService : IBoltzSwapService
 
     public async Task<Result<BoltzSwapFees>> GetReverseSwapFeesAsync()
     {
+        // Return cached result if still fresh
+        if (_cachedFees != null && DateTime.UtcNow - _feesCachedAt < FeesCacheTtl)
+        {
+            _logger.LogDebug("Returning cached reverse swap fees ({Age:F1}s old)",
+                (DateTime.UtcNow - _feesCachedAt).TotalSeconds);
+            return Result.Success(_cachedFees);
+        }
+
         try
         {
             _logger.LogDebug("Fetching reverse swap fee information from Boltz");
@@ -383,6 +399,9 @@ public class BoltzSwapService : IBoltzSwapService
             _logger.LogDebug(
                 "Reverse swap fees: {Percentage}% + {MinerFees} sats, limits: {Min}-{Max}",
                 fees.Percentage, fees.MinerFees, fees.MinAmount, fees.MaxAmount);
+
+            _cachedFees = fees;
+            _feesCachedAt = DateTime.UtcNow;
 
             return Result.Success(fees);
         }


### PR DESCRIPTION
## Problem

Lightning invoice generation on mobile was noticeably slow. A ~270 char BOLT11 invoice (e.g. \lntbs2166060n1p4pm9h5...\) caused:

1. **UI freeze** — QR code generation ran synchronously on the UI thread via \IValueConverter\, blocking for hundreds of ms on mobile CPUs
2. **3 redundant HTTP calls** — \GetReverseSwapFeesAsync()\ was called 3 times during a single Lightning tab switch (constructor prefetch, handler min-amount check, and inside \CalculateInvoiceAmountAsync\)
3. **Extra network round-trip** — \CreateLightningSwapHandler\ called \CalculateInvoiceAmountAsync()\ which internally re-fetched fees that were already available

## Changes

### QR code off UI thread (\PaymentFlowViewModel.cs\, \PaymentFlowView.axaml\)
- Generate QR as PNG bitmap on \TaskpoolScheduler\, push result to UI via \MainThreadScheduler\
- Uses \PngByteQRCode\ (pure .NET, thread-safe) at 10px/module instead of SVG at 20px/module
- Properly disposes old bitmaps on replacement

### Fee cache (\BoltzSwapService.cs\)
- Added 30-second TTL cache in \GetReverseSwapFeesAsync()\
- The 3 calls during a single flow now collapse into 1 HTTP round-trip

### Eliminated double-fetch (\CreateLightningSwap.cs\)
- Replaced \CalculateInvoiceAmountAsync()\ (which re-fetched fees) with direct \ees.CalculateInvoiceAmount()\ using fees already in hand
- Added proper early-return on fee fetch failure
- Inlined min/max validation

## Net effect
- **Before**: 3 serial HTTP calls + synchronous QR blocking UI
- **After**: 1 HTTP call (cached), QR on background thread, UI stays responsive