### PR TITLE
ci: add portable (no-install) Windows exe to release artifacts

### DIFF
--- a/.github/workflows/release-avalonia.yml
+++ b/.github/workflows/release-avalonia.yml
@@ -99,6 +99,16 @@ jobs:
             --appId ${{ env.APP_ID }} `
             --version ${{ needs.prepare.outputs.version }} `
             --vendor "${{ env.VENDOR }}"
+
+      - name: Create Windows x64 Portable
+        run: |
+          dotnet publish ${{ env.DESKTOP_PROJECT }} -c Release -r win-x64 --self-contained -p:Version=${{ needs.prepare.outputs.version }} -o publish-win-x64
+          Copy-Item publish-win-x64/Angor2.exe artifacts/Angor-${{ needs.prepare.outputs.version }}-win-x64-Portable.exe
+
+      - name: Create Windows arm64 Portable
+        run: |
+          dotnet publish ${{ env.DESKTOP_PROJECT }} -c Release -r win-arm64 --self-contained -p:Version=${{ needs.prepare.outputs.version }} -o publish-win-arm64
+          Copy-Item publish-win-arm64/Angor2.exe artifacts/Angor-${{ needs.prepare.outputs.version }}-win-arm64-Portable.exe
       
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
﻿Adds standalone portable exe builds for Windows x64 and arm64 alongside the existing Setup installers.

## What this does

Each release will now produce two additional Windows artifacts:

- `Angor-{version}-win-x64-Portable.exe` - single self-contained exe, no install needed
- `Angor-{version}-win-arm64-Portable.exe` - single self-contained exe, no install needed

These use `dotnet publish` with `--self-contained` and the project's existing `PublishSingleFile`/`PublishTrimmed` settings, so users just download and double-click - no setup wizard required.

## Context

Currently only Setup installers are produced. Having a no-install portable option is useful for users who prefer not to run a setup wizard.
