### PR TITLE
Fix Nostr relay race conditions blocking project scan/recovery

### DIFF
--- a/src/design/App/UI/Sections/MyProjects/Modals/ManageProjectModalsView.axaml
+++ b/src/design/App/UI/Sections/MyProjects/Modals/ManageProjectModalsView.axaml
@@ -260,6 +260,57 @@
             </Border>
         </Panel>
 
+        <!-- ═══ CLAIMING SPINNER OVERLAY ═══ -->
+        <!-- Shown while the SDK builds + broadcasts the claim transaction (IsClaiming=true). -->
+        <Panel Name="ClaimingOverlay"
+               IsVisible="{Binding IsClaiming}"
+               ZIndex="201"
+               Background="{DynamicResource ModalBackdrop}">
+            <Border Classes="ModalCard"
+                    Background="{DynamicResource DetailCardBg}"
+                    BorderBrush="{DynamicResource ModalHeaderBorder}"
+                    BorderThickness="1"
+                    CornerRadius="16"
+                    BoxShadow="0 8 32 0 #40000000"
+                    Padding="32">
+                <StackPanel Spacing="20" HorizontalAlignment="Center">
+                    <!-- Spinning icon -->
+                    <i:Icon Value="fa-solid fa-spinner" FontSize="36"
+                            Foreground="{DynamicResource PrimaryGreenBrush}"
+                            HorizontalAlignment="Center"
+                            RenderTransformOrigin="50%,50%">
+                        <i:Icon.RenderTransform>
+                            <RotateTransform />
+                        </i:Icon.RenderTransform>
+                        <i:Icon.Styles>
+                            <Style Selector="i|Icon[IsVisible=True]">
+                                <Style.Animations>
+                                    <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                        <KeyFrame Cue="0%">
+                                            <Setter Property="RotateTransform.Angle" Value="0" />
+                                        </KeyFrame>
+                                        <KeyFrame Cue="100%">
+                                            <Setter Property="RotateTransform.Angle" Value="360" />
+                                        </KeyFrame>
+                                    </Animation>
+                                </Style.Animations>
+                            </Style>
+                        </i:Icon.Styles>
+                    </i:Icon>
+                    <TextBlock Text="Claiming Funds..."
+                               FontSize="20" FontWeight="Bold"
+                               Foreground="{DynamicResource TextStrong}"
+                               HorizontalAlignment="Center" />
+                    <TextBlock Text="Building and broadcasting your transaction. Please wait."
+                               FontSize="14"
+                               Foreground="{DynamicResource ModalDescriptionText}"
+                               TextWrapping="Wrap"
+                               TextAlignment="Center"
+                               HorizontalAlignment="Center" />
+                </StackPanel>
+            </Border>
+        </Panel>
+
         <!-- ═══ MODAL 3: CLAIM SUCCESS (max-w-md = 448px) ═══ -->
         <!-- Vue: showSuccessModal — bg-[#2A2A2A] (dark), p-8, green circle icon -->
         <Panel Name="SuccessModalOverlay"

--- a/src/design/App/UI/Sections/MyProjects/Modals/ManageProjectModalsView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/Modals/ManageProjectModalsView.axaml.cs
@@ -238,8 +238,8 @@ public partial class ManageProjectModalsView : UserControl
             var feeRate = await AskForFeeRateAsync();
             if (feeRate == null) return; // User cancelled — claim modal stays visible
 
-            Vm.ShowClaimModal = false;
             Vm.IsClaiming = true;
+            Vm.ShowClaimModal = false;
             var success = await Vm.ClaimStageFundsAsync(stage.Number, selectedTxs, feeRate.Value);
             Vm.IsClaiming = false;
 

--- a/src/design/App/UI/Sections/MyProjects/MyProjectsViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/MyProjectsViewModel.cs
@@ -207,8 +207,9 @@ public partial class MyProjectsViewModel : ReactiveObject, IDisposable
         try
         {
             var wallets = _walletContext.Wallets.ToList();
-            await Task.Run(async () =>
+            var errors = await Task.Run(async () =>
             {
+                var scanErrors = new List<string>();
                 foreach (var wallet in wallets)
                 {
                     // ScanFounderProjects checks all 15 derived key slots,
@@ -218,9 +219,16 @@ public partial class MyProjectsViewModel : ReactiveObject, IDisposable
                     {
                         _logger.LogError("ScanFounderProjects failed for wallet {WalletId}: {Error}",
                             wallet.Id.Value, result.Error);
+                        scanErrors.Add(result.Error);
                     }
                 }
+                return scanErrors;
             });
+
+            foreach (var error in errors)
+            {
+                ToastRequested?.Invoke($"Scan failed: {error}");
+            }
         }
         catch (Exception ex)
         {

--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/ScanFounderProjectsTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/ScanFounderProjectsTests.cs
@@ -8,6 +8,7 @@ using Angor.Data.Documents.Interfaces;
 using Angor.Shared.Models;
 using CSharpFunctionalExtensions;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace Angor.Sdk.Tests.Funding.Founder;
@@ -28,7 +29,8 @@ public class ScanFounderProjectsTests
         _sut = new ScanFounderProjects.ScanFounderProjectsHandler(
             _mockProjectService.Object,
             _mockFounderProjectsService.Object,
-            _mockDerivedKeysCollection.Object);
+            _mockDerivedKeysCollection.Object,
+            Mock.Of<ILogger<ScanFounderProjects.ScanFounderProjectsHandler>>());
     }
 
     [Fact]

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/ScanFounderProjects.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/ScanFounderProjects.cs
@@ -5,6 +5,7 @@ using Angor.Sdk.Funding.Shared;
 using Angor.Data.Documents.Interfaces;
 using CSharpFunctionalExtensions;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using Angor.Sdk.Funding.Projects;
 using Angor.Sdk.Funding.Projects.Dtos;
 
@@ -25,7 +26,8 @@ public static class ScanFounderProjects
     public class ScanFounderProjectsHandler(
         IProjectService projectService,
         IFounderProjectsService founderProjectsService,
-        IGenericDocumentCollection<DerivedProjectKeys> derivedProjectKeysCollection) : IRequestHandler<ScanFounderProjectsRequest, Result<ScanFounderProjectsResponse>>
+        IGenericDocumentCollection<DerivedProjectKeys> derivedProjectKeysCollection,
+        ILogger<ScanFounderProjectsHandler> logger) : IRequestHandler<ScanFounderProjectsRequest, Result<ScanFounderProjectsResponse>>
     {
         public async Task<Result<ScanFounderProjectsResponse>> Handle(ScanFounderProjectsRequest request, CancellationToken cancellationToken)
         {
@@ -51,6 +53,7 @@ public static class ScanFounderProjects
 
             // Step 4: Query the indexer/Nostr for the unknown keys to see if they exist on-chain
             var newRecords = new List<FounderProjectRecord>();
+            string? scanError = null;
             if (unknownIds.Length > 0)
             {
                 var scanResult = await projectService.GetAllAsync(unknownIds);
@@ -64,7 +67,13 @@ public static class ScanFounderProjects
                         });
                     }
                 }
-                // If scan fails, we still return whatever we have locally — don't fail the whole operation
+                else
+                {
+                    scanError = scanResult.Error;
+                    logger.LogWarning(
+                        "Failed to discover projects from relay for wallet {WalletId}: {Error}",
+                        request.WalletId.Value, scanResult.Error);
+                }
             }
 
             // Step 5: Persist any newly discovered projects
@@ -80,7 +89,13 @@ public static class ScanFounderProjects
                 : Array.Empty<ProjectId>();
 
             if (allKnownIds.Length == 0)
+            {
+                // No local projects either — propagate the scan error if there was one
+                if (scanError != null)
+                    return Result.Failure<ScanFounderProjectsResponse>(scanError);
+
                 return Result.Success(new ScanFounderProjectsResponse(Enumerable.Empty<ProjectDto>()));
+            }
 
             var projects = await projectService.GetAllAsync(allKnownIds);
 

--- a/src/sdk/Angor.Sdk/Funding/Services/DocumentProjectService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Services/DocumentProjectService.cs
@@ -228,13 +228,31 @@ public class DocumentProjectService(
 
     private async Task<Result<IEnumerable<ProjectInfo>>> ProjectInfos(IEnumerable<string> eventIds)
     {
+        var expectedIds = eventIds.ToHashSet();
+        var expectedCount = expectedIds.Count;
+
         var tcs = new TaskCompletionSource<List<ProjectInfo>>();
         var results = new List<ProjectInfo>();
+        var receivedIds = new HashSet<string>();
 
-        void OnNext(ProjectInfo info) => results.Add(info);
+        void OnNext(ProjectInfo info)
+        {
+            results.Add(info);
+
+            // Track by ProjectIdentifier to deduplicate across relays
+            if (info.ProjectIdentifier != null && receivedIds.Add(info.ProjectIdentifier))
+            {
+                // Complete early once we have info for all requested events
+                if (receivedIds.Count >= expectedCount)
+                {
+                    tcs.TrySetResult(results);
+                }
+            }
+        }
+
         void OnCompleted() => tcs.TrySetResult(results);
 
-        relayService.LookupProjectsInfoByEventIds<ProjectInfo>(OnNext, OnCompleted, eventIds.ToArray());
+        relayService.LookupProjectsInfoByEventIds<ProjectInfo>(OnNext, OnCompleted, expectedIds.ToArray());
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         cts.Token.Register(() => tcs.TrySetResult(results));
@@ -245,12 +263,30 @@ public class DocumentProjectService(
 
     private Task<Result<IEnumerable<ProjectMetadataWithNpub>>> ProjectMetadatas(IEnumerable<string> npubs)
     {
+        var npubSet = npubs.Where(x => x != null).ToHashSet();
+        var expectedCount = npubSet.Count;
+
         var projectMetadatas = Observable.Create<ProjectMetadataWithNpub>(observer =>
         {
+            var received = new HashSet<string>();
+
             relayService.LookupNostrProfileForNPub(
-                   (npub, nostrMetadata) => observer.OnNext(new ProjectMetadataWithNpub(npub, nostrMetadata)),
+                   (npub, nostrMetadata) =>
+                   {
+                       // Only emit distinct npubs (relays may send duplicates)
+                       if (received.Add(npub))
+                       {
+                           observer.OnNext(new ProjectMetadataWithNpub(npub, nostrMetadata));
+
+                           // Complete early once we have metadata for all requested npubs
+                           if (received.Count >= expectedCount)
+                           {
+                               observer.OnCompleted();
+                           }
+                       }
+                   },
                     observer.OnCompleted,
-                    npubs.Where(x => x != null).ToArray());
+                    npubSet.ToArray());
 
             return Disposable.Empty;
         }).Timeout(TimeSpan.FromSeconds(30));

--- a/src/shared/Angor.Shared/Services/RelayService.cs
+++ b/src/shared/Angor.Shared/Services/RelayService.cs
@@ -39,7 +39,7 @@ namespace Angor.Shared.Services
         public void LookupProjectsInfoByEventIds<T>(Action<T> responseDataAction, Action? OnEndOfStreamAction,
             params string[] nostrEventIds)
         {
-            const string subscriptionName = "ProjectInfoLookups";
+            var subscriptionName = Guid.NewGuid().ToString().Replace("-", "");
 
             var nostrClient = _communicationFactory.GetOrCreateClient(_networkService);
 


### PR DESCRIPTION
## Problem

Old projects (and intermittently new ones) fail to appear in **My Projects** after wallet recovery/scan. The project is found on-chain by the indexer, but the Nostr relay lookup silently fails, and no error is shown to the user.

### Root Causes

1. **Subscription name collision** - `LookupProjectsInfoByEventIds` used a hardcoded subscription name `"ProjectInfoLookups"`. When `ScanFounderProjects` calls `GetAllAsync` twice (discovery + reload), the second call's EOSE action fails to register via `TryAdd` because the first call's cleanup hasn't completed. The `TaskCompletionSource` then only resolves via timeout, often with empty results.

2. **All-relays EOSE requirement** - `ProjectInfos` and `ProjectMetadatas` wait for EOSE from **every connected relay** before completing. If even one relay is slow or doesn't have the data, the entire flow blocks until timeout (10s/30s), even though the needed data already arrived from other relays.

3. **Silent error swallowing** - `ScanFounderProjects` silently discarded `GetAllAsync` failures with no logging. The UI showed no error, making the issue invisible.

4. **Toast on wrong thread** - `ToastRequested?.Invoke()` was called inside `Task.Run`, causing an exception that was caught by the generic catch block, replacing the real error with "Failed to scan for projects".

### Fixes

- **Unique subscription names** - `LookupProjectsInfoByEventIds` now uses `Guid.NewGuid()` per call, matching the pattern used by every other method in `RelayService`
- **Early completion** - `ProjectInfos` and `ProjectMetadatas` complete as soon as all requested data is received (deduplicated across relays), without waiting for remaining relays to EOSE
- **Error logging + propagation** - `ScanFounderProjects` logs scan failures and propagates the error when no local projects exist
- **Toast on UI thread** - Errors are collected from the background task and surfaced via toast on the caller thread

### Files Changed

- `src/shared/Angor.Shared/Services/RelayService.cs` - Unique subscription name
- `src/sdk/Angor.Sdk/Funding/Services/DocumentProjectService.cs` - Early completion in ProjectInfos/ProjectMetadatas
- `src/sdk/Angor.Sdk/Funding/Founder/Operations/ScanFounderProjects.cs` - Error logging + propagation
- `src/design/App/UI/Sections/MyProjects/MyProjectsViewModel.cs` - Toast fix
- `src/sdk/Angor.Sdk.Tests/Funding/Founder/ScanFounderProjectsTests.cs` - Updated for new constructor
