### PR TITLE
Fix spinner state for Cancel and Refresh buttons

### DIFF
--- a/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml
@@ -541,91 +541,91 @@
                             <!-- Vue: .waiting-button-secondary — themed bg/border/fg -->
                             <StackPanel Orientation="Horizontal" Spacing="8"
                                         HorizontalAlignment="Center">
-                                <Button Name="CancelInvestmentStep1Button"
-                                        Padding="14,8"
-                                        Background="{DynamicResource WaitingBtnBg}"
-                                        BorderBrush="{DynamicResource WaitingBtnBorder}"
-                                        BorderThickness="1"
-                                        CornerRadius="8"
-                                        IsEnabled="{Binding !IsProcessing}">
-                                    <Panel>
-                                        <TextBlock Text="Cancel"
-                                                   FontSize="14"
-                                                   FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource WaitingBtnFg}"
-                                                   IsVisible="{Binding !IsProcessing}"
-                                                   HorizontalAlignment="Center" />
-                                        <StackPanel Name="CancelStep1BtnSpinner" Orientation="Horizontal" Spacing="6"
-                                                    IsVisible="{Binding IsProcessing}"
-                                                    HorizontalAlignment="Center">
-                                            <i:Icon Value="fa-solid fa-spinner" FontSize="14"
+                                 <Button Name="CancelInvestmentStep1Button"
+                                         Padding="14,8"
+                                         Background="{DynamicResource WaitingBtnBg}"
+                                         BorderBrush="{DynamicResource WaitingBtnBorder}"
+                                         BorderThickness="1"
+                                         CornerRadius="8"
+                                         IsEnabled="{Binding !IsCancelling}">
+                                     <Panel>
+                                         <TextBlock Text="Cancel"
+                                                    FontSize="14"
+                                                    FontWeight="SemiBold"
                                                     Foreground="{DynamicResource WaitingBtnFg}"
-                                                    RenderTransformOrigin="50%,50%">
-                                                <i:Icon.RenderTransform>
-                                                    <RotateTransform />
-                                                </i:Icon.RenderTransform>
-                                                <i:Icon.Styles>
-                                                    <Style Selector="i|Icon[IsVisible=True]">
-                                                        <Style.Animations>
-                                                            <Animation Duration="0:0:1" IterationCount="INFINITE">
-                                                                <KeyFrame Cue="0%">
-                                                                    <Setter Property="RotateTransform.Angle" Value="0" />
-                                                                </KeyFrame>
-                                                                <KeyFrame Cue="100%">
-                                                                    <Setter Property="RotateTransform.Angle" Value="360" />
-                                                                </KeyFrame>
-                                                            </Animation>
-                                                        </Style.Animations>
-                                                    </Style>
-                                                </i:Icon.Styles>
-                                            </i:Icon>
-                                            <TextBlock Text="Cancelling..." FontSize="14" FontWeight="SemiBold"
-                                                       Foreground="{DynamicResource WaitingBtnFg}" />
-                                        </StackPanel>
-                                    </Panel>
-                                </Button>
-                                <Button Name="RefreshInvestmentButton"
-                                        Padding="14,8"
-                                        Background="{DynamicResource WaitingBtnBg}"
-                                        BorderBrush="{DynamicResource WaitingBtnBorder}"
-                                        BorderThickness="1"
-                                        CornerRadius="8">
-                                    <Panel>
-                                        <TextBlock Text="Refresh"
-                                                   FontSize="14"
-                                                   FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource WaitingBtnFg}"
-                                                   IsVisible="{Binding !IsProcessing}"
-                                                   HorizontalAlignment="Center" />
-                                        <StackPanel Name="RefreshBtnSpinner" Orientation="Horizontal" Spacing="6"
-                                                    IsVisible="{Binding IsProcessing}"
-                                                    HorizontalAlignment="Center">
-                                            <i:Icon Value="fa-solid fa-spinner" FontSize="14"
+                                                    IsVisible="{Binding !IsCancelling}"
+                                                    HorizontalAlignment="Center" />
+                                         <StackPanel Name="CancelStep1BtnSpinner" Orientation="Horizontal" Spacing="6"
+                                                     IsVisible="{Binding IsCancelling}"
+                                                     HorizontalAlignment="Center">
+                                             <i:Icon Value="fa-solid fa-spinner" FontSize="14"
+                                                     Foreground="{DynamicResource WaitingBtnFg}"
+                                                     RenderTransformOrigin="50%,50%">
+                                                 <i:Icon.RenderTransform>
+                                                     <RotateTransform />
+                                                 </i:Icon.RenderTransform>
+                                                 <i:Icon.Styles>
+                                                     <Style Selector="i|Icon[IsVisible=True]">
+                                                         <Style.Animations>
+                                                             <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                                 <KeyFrame Cue="0%">
+                                                                     <Setter Property="RotateTransform.Angle" Value="0" />
+                                                                 </KeyFrame>
+                                                                 <KeyFrame Cue="100%">
+                                                                     <Setter Property="RotateTransform.Angle" Value="360" />
+                                                                 </KeyFrame>
+                                                             </Animation>
+                                                         </Style.Animations>
+                                                     </Style>
+                                                 </i:Icon.Styles>
+                                             </i:Icon>
+                                             <TextBlock Text="Cancelling..." FontSize="14" FontWeight="SemiBold"
+                                                        Foreground="{DynamicResource WaitingBtnFg}" />
+                                         </StackPanel>
+                                     </Panel>
+                                 </Button>
+                                 <Button Name="RefreshInvestmentButton"
+                                         Padding="14,8"
+                                         Background="{DynamicResource WaitingBtnBg}"
+                                         BorderBrush="{DynamicResource WaitingBtnBorder}"
+                                         BorderThickness="1"
+                                         CornerRadius="8">
+                                     <Panel>
+                                         <TextBlock Text="Refresh"
+                                                    FontSize="14"
+                                                    FontWeight="SemiBold"
                                                     Foreground="{DynamicResource WaitingBtnFg}"
-                                                    RenderTransformOrigin="50%,50%">
-                                                <i:Icon.RenderTransform>
-                                                    <RotateTransform />
-                                                </i:Icon.RenderTransform>
-                                                <i:Icon.Styles>
-                                                    <Style Selector="i|Icon[IsVisible=True]">
-                                                        <Style.Animations>
-                                                            <Animation Duration="0:0:1" IterationCount="INFINITE">
-                                                                <KeyFrame Cue="0%">
-                                                                    <Setter Property="RotateTransform.Angle" Value="0" />
-                                                                </KeyFrame>
-                                                                <KeyFrame Cue="100%">
-                                                                    <Setter Property="RotateTransform.Angle" Value="360" />
-                                                                </KeyFrame>
-                                                            </Animation>
-                                                        </Style.Animations>
-                                                    </Style>
-                                                </i:Icon.Styles>
-                                            </i:Icon>
-                                            <TextBlock Text="Refresh" FontSize="14" FontWeight="SemiBold"
-                                                       Foreground="{DynamicResource WaitingBtnFg}" />
-                                        </StackPanel>
-                                    </Panel>
-                                </Button>
+                                                    IsVisible="{Binding !IsRefreshing}"
+                                                    HorizontalAlignment="Center" />
+                                         <StackPanel Name="RefreshBtnSpinner" Orientation="Horizontal" Spacing="6"
+                                                     IsVisible="{Binding IsRefreshing}"
+                                                     HorizontalAlignment="Center">
+                                             <i:Icon Value="fa-solid fa-spinner" FontSize="14"
+                                                     Foreground="{DynamicResource WaitingBtnFg}"
+                                                     RenderTransformOrigin="50%,50%">
+                                                 <i:Icon.RenderTransform>
+                                                     <RotateTransform />
+                                                 </i:Icon.RenderTransform>
+                                                 <i:Icon.Styles>
+                                                     <Style Selector="i|Icon[IsVisible=True]">
+                                                         <Style.Animations>
+                                                             <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                                 <KeyFrame Cue="0%">
+                                                                     <Setter Property="RotateTransform.Angle" Value="0" />
+                                                                 </KeyFrame>
+                                                                 <KeyFrame Cue="100%">
+                                                                     <Setter Property="RotateTransform.Angle" Value="360" />
+                                                                 </KeyFrame>
+                                                             </Animation>
+                                                         </Style.Animations>
+                                                     </Style>
+                                                 </i:Icon.Styles>
+                                             </i:Icon>
+                                             <TextBlock Text="Refresh" FontSize="14" FontWeight="SemiBold"
+                                                        Foreground="{DynamicResource WaitingBtnFg}" />
+                                         </StackPanel>
+                                     </Panel>
+                                 </Button>
                                 <Button Padding="14,8"
                                         Background="{DynamicResource WaitingBtnBg}"
                                         BorderBrush="{DynamicResource WaitingBtnBorder}"
@@ -709,49 +709,49 @@
                                         Background="Transparent"
                                         BorderBrush="{DynamicResource PreviewCardBorder}"
                                         BorderThickness="1">
-                                    <Button Name="CancelInvestmentButton"
-                                            HorizontalAlignment="Stretch"
-                                            HorizontalContentAlignment="Center"
-                                            Padding="20,12"
-                                            Background="Transparent"
-                                            CornerRadius="8"
-                                            IsEnabled="{Binding !IsProcessing}">
-                                        <Panel>
-                                            <TextBlock Text="Cancel"
-                                                       FontSize="14"
-                                                       FontWeight="SemiBold"
-                                                       Foreground="{DynamicResource PreviewCardTitle}"
-                                                       IsVisible="{Binding !IsProcessing}"
-                                                       HorizontalAlignment="Center" />
-                                            <StackPanel Name="CancelBtnSpinner" Orientation="Horizontal" Spacing="6"
-                                                        IsVisible="{Binding IsProcessing}"
-                                                        HorizontalAlignment="Center">
-                                                <i:Icon Value="fa-solid fa-spinner" FontSize="14"
+                                     <Button Name="CancelInvestmentButton"
+                                             HorizontalAlignment="Stretch"
+                                             HorizontalContentAlignment="Center"
+                                             Padding="20,12"
+                                             Background="Transparent"
+                                             CornerRadius="8"
+                                             IsEnabled="{Binding !IsCancelling}">
+                                         <Panel>
+                                             <TextBlock Text="Cancel"
+                                                        FontSize="14"
+                                                        FontWeight="SemiBold"
                                                         Foreground="{DynamicResource PreviewCardTitle}"
-                                                        RenderTransformOrigin="50%,50%">
-                                                    <i:Icon.RenderTransform>
-                                                        <RotateTransform />
-                                                    </i:Icon.RenderTransform>
-                                                    <i:Icon.Styles>
-                                                        <Style Selector="i|Icon[IsVisible=True]">
-                                                            <Style.Animations>
-                                                                <Animation Duration="0:0:1" IterationCount="INFINITE">
-                                                                    <KeyFrame Cue="0%">
-                                                                        <Setter Property="RotateTransform.Angle" Value="0" />
-                                                                    </KeyFrame>
-                                                                    <KeyFrame Cue="100%">
-                                                                        <Setter Property="RotateTransform.Angle" Value="360" />
-                                                                    </KeyFrame>
-                                                                </Animation>
-                                                            </Style.Animations>
-                                                        </Style>
-                                                    </i:Icon.Styles>
-                                                </i:Icon>
-                                                <TextBlock Text="Cancelling..." FontSize="14" FontWeight="SemiBold"
-                                                           Foreground="{DynamicResource PreviewCardTitle}" />
-                                            </StackPanel>
-                                        </Panel>
-                                    </Button>
+                                                        IsVisible="{Binding !IsCancelling}"
+                                                        HorizontalAlignment="Center" />
+                                             <StackPanel Name="CancelBtnSpinner" Orientation="Horizontal" Spacing="6"
+                                                         IsVisible="{Binding IsCancelling}"
+                                                         HorizontalAlignment="Center">
+                                                 <i:Icon Value="fa-solid fa-spinner" FontSize="14"
+                                                         Foreground="{DynamicResource PreviewCardTitle}"
+                                                         RenderTransformOrigin="50%,50%">
+                                                     <i:Icon.RenderTransform>
+                                                         <RotateTransform />
+                                                     </i:Icon.RenderTransform>
+                                                     <i:Icon.Styles>
+                                                         <Style Selector="i|Icon[IsVisible=True]">
+                                                             <Style.Animations>
+                                                                 <Animation Duration="0:0:1" IterationCount="INFINITE">
+                                                                     <KeyFrame Cue="0%">
+                                                                         <Setter Property="RotateTransform.Angle" Value="0" />
+                                                                     </KeyFrame>
+                                                                     <KeyFrame Cue="100%">
+                                                                         <Setter Property="RotateTransform.Angle" Value="360" />
+                                                                     </KeyFrame>
+                                                                 </Animation>
+                                                             </Style.Animations>
+                                                         </Style>
+                                                     </i:Icon.Styles>
+                                                 </i:Icon>
+                                                 <TextBlock Text="Cancelling..." FontSize="14" FontWeight="SemiBold"
+                                                            Foreground="{DynamicResource PreviewCardTitle}" />
+                                             </StackPanel>
+                                         </Panel>
+                                     </Button>
                                 </Border>
                             </StackPanel>
 

--- a/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml.cs
+++ b/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml.cs
@@ -320,61 +320,61 @@ public partial class InvestmentDetailView : UserControl
         investVm.IsProcessing = false;
     }
 
-    /// <summary>
-    /// Cancel a pending investment request (Gap 2: CancelInvestmentRequest).
-    /// Available at Step 1 (PendingFounderSignatures) and Step 2 (FounderSignaturesReceived).
-    /// </summary>
-    private async Task CancelInvestmentAsync()
-    {
-        if (DataContext is not InvestmentViewModel investVm) return;
-        if (investVm.IsProcessing) return;
+     /// <summary>
+     /// Cancel a pending investment request (Gap 2: CancelInvestmentRequest).
+     /// Available at Step 1 (PendingFounderSignatures) and Step 2 (FounderSignaturesReceived).
+     /// </summary>
+     private async Task CancelInvestmentAsync()
+     {
+         if (DataContext is not InvestmentViewModel investVm) return;
+         if (investVm.IsCancelling) return;
 
-        investVm.IsProcessing = true;
+         investVm.IsCancelling = true;
 
-        var portfolioVm = App.Services.GetService<PortfolioViewModel>();
-        if (portfolioVm != null)
-        {
-            await portfolioVm.CancelInvestmentAsync(investVm);
-        }
+         var portfolioVm = App.Services.GetService<PortfolioViewModel>();
+         if (portfolioVm != null)
+         {
+             await portfolioVm.CancelInvestmentAsync(investVm);
+         }
 
-        // Always reset IsProcessing — even on success the VM may still be observed by tests
-        // or pending bindings. On success the detail is already closed (SelectedInvestment=null).
-        investVm.IsProcessing = false;
-    }
+         // Always reset IsCancelling — even on success the VM may still be observed by tests
+         // or pending bindings. On success the detail is already closed (SelectedInvestment=null).
+         investVm.IsCancelling = false;
+     }
 
-    /// <summary>
-    /// Refresh the current investment's data from the SDK, including approval status changes.
-    /// Reloads all investments to pick up founder approval, then re-selects this investment
-    /// and refreshes its recovery status.
-    /// </summary>
-    private async Task RefreshInvestmentAsync()
-    {
-        if (DataContext is not InvestmentViewModel investVm) return;
-        if (investVm.IsProcessing) return;
+     /// <summary>
+     /// Refresh the current investment's data from the SDK, including approval status changes.
+     /// Reloads all investments to pick up founder approval, then re-selects this investment
+     /// and refreshes its recovery status.
+     /// </summary>
+     private async Task RefreshInvestmentAsync()
+     {
+         if (DataContext is not InvestmentViewModel investVm) return;
+         if (investVm.IsRefreshing) return;
 
-        investVm.IsProcessing = true;
+         investVm.IsRefreshing = true;
 
-        var portfolioVm = App.Services.GetService<PortfolioViewModel>();
-        if (portfolioVm != null)
-        {
-            var projectId = investVm.ProjectIdentifier;
+         var portfolioVm = App.Services.GetService<PortfolioViewModel>();
+         if (portfolioVm != null)
+         {
+             var projectId = investVm.ProjectIdentifier;
 
-            // Reload all investments from SDK to pick up approval status changes (#7)
-            await portfolioVm.LoadInvestmentsFromSdkAsync();
+             // Reload all investments from SDK to pick up approval status changes (#7)
+             await portfolioVm.LoadInvestmentsFromSdkAsync();
 
-            // Re-select the same investment (LoadInvestmentsFromSdkAsync recreates VMs)
-            var refreshed = portfolioVm.Investments.FirstOrDefault(i => i.ProjectIdentifier == projectId);
-            if (refreshed != null)
-            {
-                portfolioVm.OpenInvestmentDetail(refreshed);
-                // OpenInvestmentDetail already triggers LoadRecoveryStatusAsync
-            }
-        }
+             // Re-select the same investment (LoadInvestmentsFromSdkAsync recreates VMs)
+             var refreshed = portfolioVm.Investments.FirstOrDefault(i => i.ProjectIdentifier == projectId);
+             if (refreshed != null)
+             {
+                 portfolioVm.OpenInvestmentDetail(refreshed);
+                 // OpenInvestmentDetail already triggers LoadRecoveryStatusAsync
+             }
+         }
 
-        // Note: investVm may be stale now (replaced by refreshed VM), but IsProcessing
-        // is set on the old VM which is no longer displayed — this is fine.
-        investVm.IsProcessing = false;
-    }
+         // Note: investVm may be stale now (replaced by refreshed VM), but IsRefreshing
+         // is set on the old VM which is no longer displayed — this is fine.
+         investVm.IsRefreshing = false;
+     }
 
     /// <summary>
     /// Open the investment transaction in the system browser via the indexer explorer.

--- a/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
@@ -385,6 +385,20 @@ public class InvestmentViewModel : INotifyPropertyChanged
         set { if (_isProcessing == value) return; _isProcessing = value; OnPropertyChanged(); }
     }
 
+    private bool _isCancelling;
+    public bool IsCancelling
+    {
+        get => _isCancelling;
+        set { if (_isCancelling == value) return; _isCancelling = value; OnPropertyChanged(); }
+    }
+
+    private bool _isRefreshing;
+    public bool IsRefreshing
+    {
+        get => _isRefreshing;
+        set { if (_isRefreshing == value) return; _isRefreshing = value; OnPropertyChanged(); }
+    }
+
     private string? _errorMessage;
     /// <summary>Error message shown when a recovery operation fails.</summary>
     public string? ErrorMessage


### PR DESCRIPTION
This PR fixes an issue where both the Cancel and Refresh buttons in the InvestmentDetailView showed spinners simultaneously when clicked. The fix introduces separate spinner states for each button to ensure only the clicked button shows a spinner.