### PR TITLE
fix: retry loops for submit button and wallet ID lookup in UAT automation

### DIFF
--- a/src/design/App/Automation/AutomationFlows.cs
+++ b/src/design/App/Automation/AutomationFlows.cs
@@ -69,15 +69,28 @@ public static class AutomationFlows
                 seedWords = await CreateWalletViaGenerateAsync(window);
             }
 
-            var walletId = await Dispatcher.UIThread.InvokeAsync(() =>
+            // Wait for the wallet to appear in SeedGroups. The RebuildSeedGroups action is posted
+            // to the dispatcher via WalletsUpdated → Post(RebuildSeedGroups), so we may need
+            // to wait a few UI cycles for it to execute.
+            string? walletId = null;
+            var walletDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+            while (DateTime.UtcNow < walletDeadline)
             {
-                // Flush any pending UI jobs (e.g. RebuildSeedGroups posted via WalletsUpdated)
-                Dispatcher.UIThread.RunJobs();
-                var allWallets = fundsVm.SeedGroups.SelectMany(g => g.Wallets).ToList();
-                // Return the newly created wallet (not in existing set), or the first one
-                var newWallet = allWallets.FirstOrDefault(w => !existingIds.Contains(w.Id.Value));
-                return (newWallet ?? allWallets.FirstOrDefault())?.Id.Value;
-            });
+                walletId = await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    // Flush any pending UI jobs (e.g. RebuildSeedGroups posted via WalletsUpdated)
+                    Dispatcher.UIThread.RunJobs();
+                    var allWallets = fundsVm.SeedGroups.SelectMany(g => g.Wallets).ToList();
+                    // Return the newly created wallet (not in existing set), or the first one
+                    var newWallet = allWallets.FirstOrDefault(w => !existingIds.Contains(w.Id.Value));
+                    return (newWallet ?? allWallets.FirstOrDefault())?.Id.Value;
+                });
+
+                if (!string.IsNullOrWhiteSpace(walletId))
+                    break;
+
+                await Task.Delay(300);
+            }
 
             if (string.IsNullOrWhiteSpace(walletId))
             {
@@ -534,24 +547,40 @@ public static class AutomationFlows
                 await ClickFundPatternByStageCountAsync(window, req.TargetPatternStageCount);
             }
 
-            // Type investment amount into AmountInput TextBox, then click SubmitButton
-            await TypeTextByNameAsync(window, "AmountInput", req.AmountBtc);
-            await ClickByNameAsync(window, "SubmitButton");
-
-            // Wait for payment flow modal to appear (SubmitButton triggers shell modal)
-            await Task.Delay(500);
-
-            // Wait for PaymentFlow VM to be created
-            var pfDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
-            while (DateTime.UtcNow < pfDeadline)
+            // Type investment amount into AmountInput TextBox, then click SubmitButton.
+            // Retry if the UI stays on InvestForm (e.g. CanSubmit was false due to binding
+            // race condition where the amount wasn't yet propagated to the VM).
+            var maxSubmitAttempts = 5;
+            for (var submitAttempt = 1; submitAttempt <= maxSubmitAttempts; submitAttempt++)
             {
-                var ready = await Dispatcher.UIThread.InvokeAsync(() =>
+                await TypeTextByNameAsync(window, "AmountInput", req.AmountBtc);
+                await ClickByNameAsync(window, "SubmitButton");
+
+                // Wait for PaymentFlow VM to be created (SubmitButton triggers shell modal)
+                var pfDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+                while (DateTime.UtcNow < pfDeadline)
                 {
-                    Dispatcher.UIThread.RunJobs();
-                    return investVm.PaymentFlow != null;
-                });
-                if (ready) break;
-                await Task.Delay(200);
+                    var ready = await Dispatcher.UIThread.InvokeAsync(() =>
+                    {
+                        Dispatcher.UIThread.RunJobs();
+                        return investVm.PaymentFlow != null;
+                    });
+                    if (ready) break;
+                    await Task.Delay(200);
+                }
+
+                if (investVm.PaymentFlow != null)
+                    break;
+
+                // Still on InvestForm — the submit likely didn't advance. Retry.
+                var screen = await Dispatcher.UIThread.InvokeAsync(() => investVm.CurrentScreen);
+                Log(req.ProjectIdentifier, $"Submit attempt {submitAttempt}/{maxSubmitAttempts} did not advance (screen={screen}); retrying...");
+                await Task.Delay(1000);
+            }
+
+            if (investVm.PaymentFlow == null)
+            {
+                return new InvestResponse { Success = false, Error = "Payment flow did not appear after submitting investment amount" };
             }
 
             var maxPayAttempts = 3;


### PR DESCRIPTION
Adds retry logic to two places in UAT automation flows that were causing flaky timeouts in BigFundTest/BigInvestTest:

**1. SubmitButton retry** (InvestInProjectAsync): If the PaymentFlow doesn't appear after clicking Submit (because `CanSubmit` was false due to a binding race where the amount text wasn't propagated), retries typing the amount and clicking Submit up to 5 times.

**2. Wallet ID lookup retry** (CreateWalletAndFundAsync): After wallet creation, `RebuildSeedGroups` is posted to the dispatcher via `WalletsUpdated → Post(RebuildSeedGroups)`. The retry loop waits up to 15s for the wallet to appear in `SeedGroups` instead of querying once.

Both tests verified passing with the fix.