### PR TITLE
Fix debug-mode stage date validation in project creation flow

### DIFF
--- a/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
@@ -1201,8 +1201,8 @@ public partial class CreateProjectViewModel : ReactiveObject
                 continue;
             }
 
-            // Rule 1: must be on or after funding end date
-            if (endDate.HasValue && stage.ReleaseDateValue < endDate.Value)
+            // Rule 1: must be on or after funding end date (skipped in debug mode)
+            if (!IsDebugMode && endDate.HasValue && stage.ReleaseDateValue < endDate.Value)
             {
                 stage.ReleaseDateError = $"Must be on or after {endDate.Value:dd MMM yyyy}";
                 continue;


### PR DESCRIPTION
## Bug

In debug mode, the **Create New Project** wizard (Stages step) rejects stage dates that are before the funding end date, showing:

> *Please fix the stage date errors before proceeding. Each stage release date must be after the funding end date.*

This blocks testers from setting near-future stage dates (e.g. June 30, 2026) needed to verify funding flows immediately. The **Fund Subscription** flow correctly bypasses this validation in debug mode, but the investment/project creation flow does not.

## Root Cause

`UpdateAllStageDateErrors()` in `CreateProjectViewModel.cs` unconditionally enforces that every stage release date must be on or after the funding end date (Rule 1), with no `IsDebugMode` check. All other validations in the flow (target amount, penalty days, funding end date, stage release dates in `ProjectValidator`) correctly skip strict checks when debug mode is enabled.

## Fix

Added `!IsDebugMode` guard to the Rule 1 check in `UpdateAllStageDateErrors()`, consistent with all other debug-mode bypasses in the codebase. In debug mode, stages can now be set to any date regardless of the funding end date.