### PR TITLE
Quiet log noise from foreign non-Angor kind-3030 Nostr events

### DIFF
--- a/src/shared/Angor.Shared.Tests/Services/RelayServiceTests.cs
+++ b/src/shared/Angor.Shared.Tests/Services/RelayServiceTests.cs
@@ -1,0 +1,59 @@
+using Angor.Shared.Models;
+using Angor.Shared.Services;
+using FluentAssertions;
+
+namespace Angor.Test.Services;
+
+/// <summary>
+/// Kind 3030 is a draft/custom Nostr kind, not officially reserved, so public relays can contain
+/// unrelated non-JSON content published by other applications under the same kind number.
+/// <see cref="RelayService.LookupLatestProjects{T}"/> uses <see cref="RelayService.LooksLikeJsonObject"/>
+/// to cheaply skip that noise (logged at Debug) instead of attempting a full JSON parse that fails
+/// with a JsonException on every such event (previously logged at Warning with a full stack trace).
+/// </summary>
+public class RelayServiceTests
+{
+    [Fact]
+    public void LooksLikeJsonObject_ReturnsTrue_ForSerializedProjectInfo()
+    {
+        var serializer = new Serializer();
+        var json = serializer.Serialize(new ProjectInfo
+        {
+            FounderKey = "founder",
+            FounderRecoveryKey = "recovery",
+            ProjectIdentifier = "angor1test",
+            NostrPubKey = "abc123",
+            NetworkName = "Testnet"
+        });
+
+        RelayService.LooksLikeJsonObject(json).Should().BeTrue();
+    }
+
+    [Fact]
+    public void LooksLikeJsonObject_ReturnsTrue_WhenContentHasLeadingWhitespace()
+    {
+        RelayService.LooksLikeJsonObject("  \n{\"version\":2}").Should().BeTrue();
+    }
+
+    [Fact]
+    public void LooksLikeJsonObject_ReturnsFalse_ForForeignHexBlobContent()
+    {
+        // Real content observed from an unrelated Nostr event that reused kind 3030 on a public relay
+        // (0x-prefixed hex blob), which previously threw a JsonException at byte position 1.
+        const string foreignContent =
+            "0xdf71595bf0776ae54a15c87844c79d0cff46f6fab1739a084cf04f50d4a700b6dbe5978a67ccfd02451918e5e1747939b8936fef48f37ac439e6d878af7b6de";
+
+        RelayService.LooksLikeJsonObject(foreignContent).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("[1,2,3]")]
+    [InlineData("\"just a string\"")]
+    [InlineData("12345")]
+    public void LooksLikeJsonObject_ReturnsFalse_ForNonObjectContent(string content)
+    {
+        RelayService.LooksLikeJsonObject(content).Should().BeFalse();
+    }
+}

--- a/src/shared/Angor.Shared/Services/RelayService.cs
+++ b/src/shared/Angor.Shared/Services/RelayService.cs
@@ -324,6 +324,17 @@ namespace Angor.Shared.Services
                   if (ev?.Content == null || ev.Id == null)
                       return;
 
+                  // Kind 3030 is a draft/custom kind, not an officially-reserved Nostr event kind, so
+                  // other applications on shared public relays (e.g. relay.damus.io, nos.lol) can and do
+                  // reuse the same kind number for unrelated, non-JSON payloads. Skip those quietly
+                  // instead of logging a warning for every foreign event; only genuinely JSON-shaped
+                  // content that still fails to map to T is worth a warning.
+                  if (!LooksLikeJsonObject(ev.Content))
+                  {
+                      _logger.LogDebug("Skipping non-JSON content for Nostr event {EventId} (kind {Kind} reused by another application)", ev.Id, (int)Nip3030NostrKind);
+                      return;
+                  }
+
                   try
                   {
                       var projectInfo = _serializer.Deserialize<T>(ev.Content);
@@ -460,6 +471,18 @@ namespace Angor.Shared.Services
             nostrClient.Send(new NostrEventRequest(signed));
 
             return Task.FromResult(signed.Id);
+        }
+
+        /// <summary>
+        /// Cheaply checks whether content is shaped like a JSON object (starts with '{') without
+        /// attempting a full parse. Kind 3030 is not an officially-reserved Nostr event kind, so relays
+        /// can contain unrelated, non-JSON content published by other applications under the same kind
+        /// number; this lets us skip that noise without the cost/verbosity of a failed deserialization.
+        /// </summary>
+        internal static bool LooksLikeJsonObject(string content)
+        {
+            var span = content.AsSpan().Trim();
+            return span.Length > 0 && span[0] == '{';
         }
 
         private static NostrEvent GetNip3030NostrEvent(string content, string? projectIdentifier = null)


### PR DESCRIPTION
## Problem

RelayService.LookupLatestProjects<T> (used by `Find Projects` -> latest-from-Nostr flow) subscribes to **all** events of kind 3030 across every configured relay, including public general-purpose relays (elay.damus.io, 
os.lol). This produced warnings like:

```
warn: Angor.Shared.Services.RelayService[0]
      Failed to deserialize project info from Nostr event 467c7e83fedc1e90eb5463ea86bba604246660925777d3d625688a65fcf3504a
      System.Text.Json.JsonException: 'x' is an invalid end of a number. Expected a delimiter.
```

## Root cause

Kind 3030 is Angor's own draft/custom Nostr kind and is **not officially reserved** in the canonical Nostr NIPs registry, so other unrelated applications can reuse the same kind number. I fetched the exact event directly from elay.damus.io and confirmed:

- content is a 