### PR TITLE
Security audit fixes: harden key derivation, demote sensitive logs, version-gate protocol changes

### DIFF
--- a/src/shared/Angor.Shared.Tests/DataBuilders/InvestmentOperations.cs
+++ b/src/shared/Angor.Shared.Tests/DataBuilders/InvestmentOperations.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using Angor.Shared;
 using Angor.Shared.Models;
 using Blockcore.NBitcoin.DataEncoders;
@@ -88,18 +88,18 @@ public class InvestmentOperations
         //var nbitcoinNetwork = NetworkMapper.Map(network);
         //var trx = NBitcoin.Transaction.Parse(transaction.ToHex(), nbitcoinNetwork);
 
-        var coins = _walletOperations.GetUnspentOutputsForTransaction(walletWords, utxoDataWithPaths);
+        var signingCoins = _walletOperations.GetUnspentOutputsForTransaction(walletWords, utxoDataWithPaths);
 
         // var fees = _walletOperations.GetFeeEstimationAsync().GetAwaiter().GetResult();
         // var fee = fees.First(f => f.Confirmations == 1);
 
 
-        //var incoins = coins.coins.Select(c => new NBitcoin.Coin(OutPoint.Parse(c.Outpoint.ToString()), new NBitcoin.TxOut(NBitcoin.Money.Satoshis(c.Amount.Satoshi), new NBitcoin.Script(c.ScriptPubKey.ToBytes()))));
-        //var inKeys = coins.keys.Select(k => new Key(k.ToBytes())).ToArray();
+        //var incoins = signingCoins.Select(sc => new NBitcoin.Coin(OutPoint.Parse(sc.Coin.Outpoint.ToString()), new NBitcoin.TxOut(NBitcoin.Money.Satoshis(sc.Coin.Amount.Satoshi), new NBitcoin.Script(sc.Coin.ScriptPubKey.ToBytes()))));
+        //var inKeys = signingCoins.Select(sc => new Key(sc.Key.ToBytes())).ToArray();
 
         var builder = new TransactionBuilder(network) // nbitcoinNetwork.CreateTransactionBuilder()
-            .AddCoins(coins.coins)
-            .AddKeys(coins.keys.ToArray())
+            .AddCoins(signingCoins.Select(sc => sc.Coin).ToList())
+            .AddKeys(signingCoins.Select(sc => sc.Key).ToArray())
             .SetChange(BitcoinAddress.Create(changeAddress, network))
             .ContinueToBuild(transaction)
             .SendEstimatedFees(new FeeRate(Money.Satoshis(feeRate.FeeRate)))

--- a/src/shared/Angor.Shared.Tests/InvestmentOperationsTest.cs
+++ b/src/shared/Angor.Shared.Tests/InvestmentOperationsTest.cs
@@ -50,7 +50,7 @@ namespace Angor.Test
 
                     var coins = keys.Select(key => new Coin(fakeInputTrx, fakeTxout)).ToList();
 
-                    return (coins, keys);
+                    return coins.Zip(keys, (c, k) => new SigningCoin(c, k)).ToList();
                 });
 
             _networkConfiguration = new Mock<INetworkConfiguration>();

--- a/src/shared/Angor.Shared.Tests/Protocol/FounderTransactionActionTest.cs
+++ b/src/shared/Angor.Shared.Tests/Protocol/FounderTransactionActionTest.cs
@@ -45,7 +45,7 @@ public class FounderTransactionActionTest : AngorTestData
 
                 var coins = keys.Select(key => new Blockcore.NBitcoin.Coin(fakeInputTrx, fakeTxout)).ToList();
 
-                return (coins, keys);
+                return coins.Zip(keys, (c, k) => new SigningCoin(c, k)).ToList();
             });
 
 

--- a/src/shared/Angor.Shared.Tests/Protocol/InvestmentIntegrationsTests.cs
+++ b/src/shared/Angor.Shared.Tests/Protocol/InvestmentIntegrationsTests.cs
@@ -57,7 +57,7 @@ namespace Angor.Test.Protocol
 
                     var coins = keys.Select(key => new Coin(fakeInputTrx, fakeTxout)).ToList();
 
-                    return (coins, keys);
+                    return coins.Zip(keys, (c, k) => new SigningCoin(c, k)).ToList();
                 });
 
             _networkConfiguration = new Mock<INetworkConfiguration>();

--- a/src/shared/Angor.Shared.Tests/WalletOperationsTest.cs
+++ b/src/shared/Angor.Shared.Tests/WalletOperationsTest.cs
@@ -365,13 +365,12 @@ public class WalletOperationsTest : AngorTestData
         var walletOperations = new WalletOperations(null, mockHdOperations.Object, null, null);
 
         // Act
-        var (coins, keys) = walletOperations.GetUnspentOutputsForTransaction(walletWords, utxos);
+        var signingCoins = walletOperations.GetUnspentOutputsForTransaction(walletWords, utxos);
 
         // Assert
-        Assert.Single(coins);
-        Assert.Single(keys);
-        Assert.Equal((uint)0, coins[0].Outpoint.N);
-        Assert.Equal(1500000, coins[0].Amount.Satoshi);
-        Assert.Equal(expectedExtKey.Derive(new KeyPath("m/0/0")).PrivateKey, keys[0]);
+        Assert.Single(signingCoins);
+        Assert.Equal((uint)0, signingCoins[0].Coin.Outpoint.N);
+        Assert.Equal(1500000, signingCoins[0].Coin.Amount.Satoshi);
+        Assert.Equal(expectedExtKey.Derive(new KeyPath("m/0/0")).PrivateKey, signingCoins[0].Key);
     }
 }

--- a/src/shared/Angor.Shared/DerivationOperations.cs
+++ b/src/shared/Angor.Shared/DerivationOperations.cs
@@ -81,28 +81,51 @@ public class DerivationOperations : IDerivationOperations
 
     public string DeriveLeadInvestorSecretHash(WalletWords walletWords, string founderKey)
     {
+        return DeriveLeadInvestorSecretHash(walletWords, founderKey, projectVersion: 1);
+    }
+
+    public string DeriveLeadInvestorSecretHash(WalletWords walletWords, string founderKey, int projectVersion)
+    {
         ExtKey extendedKey = GetExtendedKey(walletWords);
 
-        var upi = this.DeriveUniqueProjectIdentifier(founderKey);
-
-        var path = $"m/5'/0'/{upi}'/2'";
+        var subPath = BuildProjectSubPath(founderKey, projectVersion);
+        var path = $"m/5'/0'/{subPath}/2'";
 
         ExtPubKey extPubKey = _hdOperations.GetExtendedPublicKey(extendedKey.PrivateKey, extendedKey.ChainCode, path);
 
+        if (projectVersion >= 3)
+        {
+            // V3+: Hash only the public key (deterministic, doesn't expose private key bytes)
+            var pubKeyBytes = extPubKey.PubKey.ToBytes();
+            var hash = Hashes.Hash256(pubKeyBytes).ToString();
+            return hash;
+        }
+
+        // V1/V2 legacy: hash full ExtKey serialization (backward compat)
         var derivedSecret = extendedKey.Derive(new KeyPath(path));
-
-        var hash = Hashes.Hash256(derivedSecret.ToBytes()).ToString();
-
-        return hash;
+        var secretBytes = derivedSecret.ToBytes();
+        try
+        {
+            var hash = Hashes.Hash256(secretBytes).ToString();
+            return hash;
+        }
+        finally
+        {
+            System.Security.Cryptography.CryptographicOperations.ZeroMemory(secretBytes);
+        }
     }
 
     public string DeriveInvestorKey(WalletWords walletWords, string founderKey)
     {
+        return DeriveInvestorKey(walletWords, founderKey, projectVersion: 1);
+    }
+
+    public string DeriveInvestorKey(WalletWords walletWords, string founderKey, int projectVersion)
+    {
         ExtKey extendedKey = GetExtendedKey(walletWords);
 
-        var upi = this.DeriveUniqueProjectIdentifier(founderKey);
-
-        var path = $"m/5'/0'/{upi}'/3'";
+        var subPath = BuildProjectSubPath(founderKey, projectVersion);
+        var path = $"m/5'/0'/{subPath}/3'";
 
         ExtPubKey extPubKey = _hdOperations.GetExtendedPublicKey(extendedKey.PrivateKey, extendedKey.ChainCode, path);
 
@@ -111,11 +134,15 @@ public class DerivationOperations : IDerivationOperations
 
     public AngorKey DeriveInvestorPrivateKey(WalletWords walletWords, string founderKey)
     {
+        return DeriveInvestorPrivateKey(walletWords, founderKey, projectVersion: 1);
+    }
+
+    public AngorKey DeriveInvestorPrivateKey(WalletWords walletWords, string founderKey, int projectVersion)
+    {
         ExtKey extendedKey = GetExtendedKey(walletWords);
 
-        var upi = this.DeriveUniqueProjectIdentifier(founderKey);
-
-        var path = $"m/5'/0'/{upi}'/3'";
+        var subPath = BuildProjectSubPath(founderKey, projectVersion);
+        var path = $"m/5'/0'/{subPath}/3'";
 
         ExtPubKey extPubKey = _hdOperations.GetExtendedPublicKey(extendedKey.PrivateKey, extendedKey.ChainCode, path);
 
@@ -137,11 +164,15 @@ public class DerivationOperations : IDerivationOperations
     
     public string DeriveNostrPubKey(WalletWords walletWords, string founderKey)
     {
+        return DeriveNostrPubKey(walletWords, founderKey, projectVersion: 1);
+    }
+
+    public string DeriveNostrPubKey(WalletWords walletWords, string founderKey, int projectVersion)
+    {
         ExtKey extendedKey = GetExtendedKey(walletWords);
 
-        var upi = this.DeriveUniqueProjectIdentifier(founderKey);
-
-        var path = $"m/44'/1237'/{upi}'/0/0";
+        var subPath = BuildProjectSubPath(founderKey, projectVersion);
+        var path = $"m/44'/1237'/{subPath}/0/0";
 
         ExtKey extKey = extendedKey.Derive(new KeyPath(path));
 
@@ -150,11 +181,15 @@ public class DerivationOperations : IDerivationOperations
 
     public string DeriveFounderRecoveryKey(WalletWords walletWords, string founderKey)
     {
+        return DeriveFounderRecoveryKey(walletWords, founderKey, projectVersion: 1);
+    }
+
+    public string DeriveFounderRecoveryKey(WalletWords walletWords, string founderKey, int projectVersion)
+    {
         ExtKey extendedKey = GetExtendedKey(walletWords);
 
-        var upi = this.DeriveUniqueProjectIdentifier(founderKey);
-
-        var path = $"m/5'/0'/{upi}'/1'";
+        var subPath = BuildProjectSubPath(founderKey, projectVersion);
+        var path = $"m/5'/0'/{subPath}/1'";
 
         ExtPubKey extPubKey = _hdOperations.GetExtendedPublicKey(extendedKey.PrivateKey, extendedKey.ChainCode, path);
 
@@ -174,11 +209,15 @@ public class DerivationOperations : IDerivationOperations
 
     public AngorKey DeriveFounderRecoveryPrivateKey(WalletWords walletWords, string founderKey)
     {
+        return DeriveFounderRecoveryPrivateKey(walletWords, founderKey, projectVersion: 1);
+    }
+
+    public AngorKey DeriveFounderRecoveryPrivateKey(WalletWords walletWords, string founderKey, int projectVersion)
+    {
         ExtKey extendedKey = GetExtendedKey(walletWords);
 
-        var upi = this.DeriveUniqueProjectIdentifier(founderKey);
-
-        var path = $"m/5'/0'/{upi}'/1'";
+        var subPath = BuildProjectSubPath(founderKey, projectVersion);
+        var path = $"m/5'/0'/{subPath}/1'";
 
         ExtKey extKey = extendedKey.Derive(new KeyPath(path));
 
@@ -187,11 +226,15 @@ public class DerivationOperations : IDerivationOperations
 
     public AngorKey DeriveProjectNostrPrivateKey(WalletWords walletWords, string founderKey)
     {
+        return DeriveProjectNostrPrivateKey(walletWords, founderKey, projectVersion: 1);
+    }
+
+    public AngorKey DeriveProjectNostrPrivateKey(WalletWords walletWords, string founderKey, int projectVersion)
+    {
         ExtKey extendedKey = GetExtendedKey(walletWords);
 
-        var upi = this.DeriveUniqueProjectIdentifier(founderKey);
-
-        var path = $"m/44'/1237'/{upi}'/0/0";
+        var subPath = BuildProjectSubPath(founderKey, projectVersion);
+        var path = $"m/44'/1237'/{subPath}/0/0";
 
         ExtKey extKey = extendedKey.Derive(new KeyPath(path));
 
@@ -200,11 +243,15 @@ public class DerivationOperations : IDerivationOperations
     
     public async Task<AngorKey> DeriveProjectNostrPrivateKeyAsync(WalletWords walletWords, string founderKey)
     {
+        return await DeriveProjectNostrPrivateKeyAsync(walletWords, founderKey, projectVersion: 1);
+    }
+
+    public async Task<AngorKey> DeriveProjectNostrPrivateKeyAsync(WalletWords walletWords, string founderKey, int projectVersion)
+    {
         ExtKey extendedKey = GetExtendedKey(walletWords);
        
-        var upi = this.DeriveUniqueProjectIdentifier(founderKey);
-
-        var path = $"m/44'/1237'/{upi}'/0/0";
+        var subPath = BuildProjectSubPath(founderKey, projectVersion);
+        var path = $"m/44'/1237'/{subPath}/0/0";
 
         var extKey = await Task.Run(() => extendedKey.Derive(new KeyPath(path)));
         
@@ -222,12 +269,46 @@ public class DerivationOperations : IDerivationOperations
 
         var upi = (uint)(hashOfid.GetLow64() & int.MaxValue);
         
-        _logger.LogInformation($"Unique Project Identifier - founderKey = {founderKey}, hashOfFounderKey = {hashOfid}, hashOfFounderKeyCastToInt = {upi}");
+        _logger.LogDebug("UPI derived: {Upi} for founderKey={FounderKey}", upi, founderKey);
         
         if (upi >= 2_147_483_648)
             throw new Exception();
         
         return upi;
+    }
+
+    /// <summary>
+    /// Derives a two-level project sub-path with 62 bits of entropy (two 31-bit indices).
+    /// Used for Version 3+ projects to reduce collision probability from ~46k to ~2 billion projects.
+    /// </summary>
+    public (uint Hi, uint Lo) DeriveProjectIndicesV2(string founderKey)
+    {
+        var key = new PubKey(founderKey);
+        var hashOfid = Hashes.Hash256(key.ToBytes());
+        var low64 = hashOfid.GetLow64();
+
+        // Split 62 bits into two 31-bit indices (each valid for BIP-32 hardened derivation)
+        var hi = (uint)(low64 & int.MaxValue);                   // bits 0-30
+        var lo = (uint)((low64 >> 31) & int.MaxValue);           // bits 31-61
+
+        return (hi, lo);
+    }
+
+    /// <summary>
+    /// Returns the project derivation sub-path component based on the project version.
+    /// V1/V2: single level "{upi}'" (31-bit entropy)
+    /// V3+:   two levels "{hi}'/{lo}'" (62-bit entropy)
+    /// </summary>
+    private string BuildProjectSubPath(string founderKey, int projectVersion = 1)
+    {
+        if (projectVersion >= 3)
+        {
+            var (hi, lo) = DeriveProjectIndicesV2(founderKey);
+            return $"{hi}'/{lo}'";
+        }
+
+        var upi = DeriveUniqueProjectIdentifier(founderKey);
+        return $"{upi}'";
     }
 
     public string DeriveNostrStoragePubKeyHex(WalletWords walletWords)
@@ -283,33 +364,52 @@ public class DerivationOperations : IDerivationOperations
     {
         var key = DeriveNostrStorageKey(walletWords);
 
-         var privateKeyBytes = key.ToBytes();
+        var privateKeyBytes = key.ToBytes();
+        try
+        {
+            var hashedKey = Hashes.Hash256(new Span<byte>(privateKeyBytes));
 
-        var hashedKey = Hashes.Hash256(new Span<byte>(privateKeyBytes));
-
-        // the hex of the hash of the private key is the password
-        var hex = Encoders.Hex.EncodeData(hashedKey.ToArray()).Replace("-", "").ToLower();
-
-        return hex;
+            // Hex-encoded double-SHA256 of the private key serves as the Nostr storage password
+            return Encoders.Hex.EncodeData(hashedKey.ToArray());
+        }
+        finally
+        {
+            System.Security.Cryptography.CryptographicOperations.ZeroMemory(privateKeyBytes);
+        }
     }
 
     public string DeriveAngorKey(string angorRootKey, string founderKey)
+    {
+        return DeriveAngorKey(angorRootKey, founderKey, projectVersion: 1);
+    }
+
+    public string DeriveAngorKey(string angorRootKey, string founderKey, int projectVersion)
     {
         Network network = _networkConfiguration.GetNetwork();
 
         var extKey = new BitcoinExtPubKey(angorRootKey, network).ExtPubKey;
 
+        if (projectVersion >= 3)
+        {
+            var (hi, lo) = DeriveProjectIndicesV2(founderKey);
+            var angorKey = extKey.Derive(hi).Derive(lo).PubKey;
+
+            var encoder = new Bech32Encoder("angor");
+            var address = encoder.Encode(0, angorKey.WitHash.ToBytes());
+
+            _logger.LogDebug("DeriveAngorKey V2 - founderKey={FounderKey}, hi={Hi}, lo={Lo}, address={Address}", founderKey, hi, lo, address);
+            return address;
+        }
+
         var upi = this.DeriveUniqueProjectIdentifier(founderKey);
-
-        var angorKey = extKey.Derive(upi).PubKey;
+        var legacyAngorKey = extKey.Derive(upi).PubKey;
         
-        var encoder = new Bech32Encoder("angor");
+        var legacyEncoder = new Bech32Encoder("angor");
+        var legacyAddress = legacyEncoder.Encode(0, legacyAngorKey.WitHash.ToBytes());
 
-        var address = encoder.Encode(0, angorKey.WitHash.ToBytes());
+        _logger.LogDebug("DeriveAngorKey - founderKey={FounderKey}, upi={Upi}, address={Address}", founderKey, upi, legacyAddress);
 
-        _logger.LogInformation($"DeriveAngorKey - angorRootKey = {angorRootKey}, founderKey = {founderKey}, upi = {upi}, angorKey = {angorKey}, angorKeyWitHash = {angorKey.WitHash}, address = {address}");
-
-        return address;
+        return legacyAddress;
     }
 
     public Script AngorKeyToScript(string angorKey)
@@ -335,7 +435,7 @@ public class DerivationOperations : IDerivationOperations
         var networkEncoder = network.Bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS];
         var bitcoinAddress = networkEncoder.Encode(witnessVersion, data);
 
-        _logger.LogInformation($"ConvertAngorKeyToBitcoinAddress - projectId = {projectId}, witnessVersion = {witnessVersion}, bitcoinAddress = {bitcoinAddress}");
+        _logger.LogDebug("ConvertAngorKeyToBitcoinAddress - projectId={ProjectId}, address={Address}", projectId, bitcoinAddress);
 
         return bitcoinAddress;
     }

--- a/src/shared/Angor.Shared/IDerivationOperations.cs
+++ b/src/shared/Angor.Shared/IDerivationOperations.cs
@@ -10,6 +10,7 @@ public interface IDerivationOperations
     string DeriveFounderKey(WalletWords walletWords, int index);
     string DeriveFounderRecoveryKey(WalletWords walletWords, string founderKey);
     uint DeriveUniqueProjectIdentifier(string founderKey);
+    (uint Hi, uint Lo) DeriveProjectIndicesV2(string founderKey);
     string DeriveAngorKey(string angorRootKey, string founderKey);
     Script AngorKeyToScript(string angorKey);
     string DeriveInvestorKey(WalletWords walletWords, string founderKey);

--- a/src/shared/Angor.Shared/IWalletOperations.cs
+++ b/src/shared/Angor.Shared/IWalletOperations.cs
@@ -4,6 +4,12 @@ using Blockcore.NBitcoin;
 
 namespace Angor.Shared;
 
+/// <summary>
+/// A coin paired with its signing key, ensuring they cannot be mismatched.
+/// Replaces the unsafe parallel List&lt;Coin&gt;/List&lt;Key&gt; pattern.
+/// </summary>
+public record SigningCoin(Coin Coin, Key Key);
+
 public interface IWalletOperations
 {
     string GenerateWalletWords();
@@ -15,7 +21,7 @@ public interface IWalletOperations
     List<UtxoDataWithPath> FindOutputsForTransaction(long sendAmountat, AccountInfo accountInfo);
     Task<IEnumerable<FeeEstimation>> GetFeeEstimationAsync();
     Transaction CreateSendTransaction(SendInfo sendInfo, AccountInfo accountInfo);
-    (List<Coin>? coins, List<Key> keys) GetUnspentOutputsForTransaction(WalletWords walletWords, List<UtxoDataWithPath> utxoDataWithPaths);
+    List<SigningCoin> GetUnspentOutputsForTransaction(WalletWords walletWords, List<UtxoDataWithPath> utxoDataWithPaths);
 
     TransactionInfo AddInputsAndSignTransaction(string changeAddress, Transaction transaction,
         WalletWords walletWords, AccountInfo accountInfo, long feeRate);

--- a/src/shared/Angor.Shared/Models/WalletWords.cs
+++ b/src/shared/Angor.Shared/Models/WalletWords.cs
@@ -18,7 +18,13 @@ public class WalletWords : IDisposable
     private ExtKey? cachedExtKey;
     private bool disposed;
 
-    /// <summary>The BIP-39 mnemonic words (space-separated).</summary>
+    /// <summary>
+    /// The BIP-39 mnemonic words (space-separated).
+    /// SECURITY: Each access creates a new immutable string on the managed heap that
+    /// cannot be zeroed by the GC. Prefer <see cref="GetOrDeriveExtKey"/> which caches
+    /// the derived key and only calls this once. Use <see cref="WordsMemory"/> for
+    /// read-only access without allocating a new string.
+    /// </summary>
     public string Words
     {
         get
@@ -34,6 +40,20 @@ public class WalletWords : IDisposable
         }
     }
 
+    /// <summary>
+    /// Read-only access to the mnemonic characters without allocating a new string.
+    /// The backing memory is zeroed on <see cref="Dispose"/>.
+    /// </summary>
+    [JsonIgnore]
+    public ReadOnlyMemory<char> WordsMemory
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            return wordsChars.AsMemory();
+        }
+    }
+
     /// <summary>Optional BIP-39 passphrase.</summary>
     public string? Passphrase
     {
@@ -43,6 +63,20 @@ public class WalletWords : IDisposable
             return passphraseChars != null ? new string(passphraseChars) : null;
         }
         set => passphraseChars = value?.ToCharArray();
+    }
+
+    /// <summary>
+    /// Read-only access to the passphrase characters without allocating a new string.
+    /// The backing memory is zeroed on <see cref="Dispose"/>.
+    /// </summary>
+    [JsonIgnore]
+    public ReadOnlyMemory<char>? PassphraseMemory
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            return passphraseChars?.AsMemory();
+        }
     }
 
     /// <summary>

--- a/src/shared/Angor.Shared/Protocol/FounderTransactionActions.cs
+++ b/src/shared/Angor.Shared/Protocol/FounderTransactionActions.cs
@@ -70,7 +70,7 @@ public class FounderTransactionActions : IFounderTransactionActions
 
             var hashHex = Encoders.Hex.EncodeData(hash.ToBytes());
 
-            _logger.LogInformation($"creating sig for project={projectInfo.ProjectIdentifier}; founder-recovery-pubkey={key.PubKey.ToHex()}; stage={stageIndex}");
+            _logger.LogDebug("Creating recovery signature for project={ProjectId}, stage={Stage}", projectInfo.ProjectIdentifier, stageIndex);
 
             var result = new TaprootPubKey(
                 Angor.Shared.Protocol.Scripts.TaprootKeyHelper.GetTaprootOutputKeyBytes(key.PubKey))
@@ -156,7 +156,7 @@ public class FounderTransactionActions : IFounderTransactionActions
 
         spendingTransaction.Outputs[0].Value -= appliedFee;
 
-        _logger.LogInformation($"Unsigned spendingTransaction hex {spendingTransaction.ToHex()}");
+        _logger.LogDebug("Unsigned spending transaction prepared with {InputCount} inputs", spendingTransaction.Inputs.Count);
 
         // Step 4 - sign the taproot inputs
         var trxData = spendingTransaction.PrecomputeTransactionData(stageOutputs.Select(_ => _.TxOut).ToArray());
@@ -183,12 +183,12 @@ public class FounderTransactionActions : IFounderTransactionActions
                 Op.GetPushOp(scriptToExecute.ToBytes()),
                 Op.GetPushOp(controlBlock));
 
-            _logger.LogInformation($"WitScript of inputIndex {inputIndex} spendingTransaction hex {input.WitScript.ToString()}");
+            _logger.LogDebug("Signed input {InputIndex}", inputIndex);
 
             inputIndex++;
         }
 
-        _logger.LogInformation($"signed spendingTransaction hex {spendingTransaction.ToHex()}");
+        _logger.LogDebug("Spending transaction signed successfully");
 
         var finalTrx = network.CreateTransaction(spendingTransaction.ToHex());
 

--- a/src/shared/Angor.Shared/Protocol/InvestorTransactionActions.cs
+++ b/src/shared/Angor.Shared/Protocol/InvestorTransactionActions.cs
@@ -142,7 +142,16 @@ public class InvestorTransactionActions : IInvestorTransactionActions
 
         // sign the inputs (replace fake WitScript with real one)
         // Convert AngorKey (NBitcoin.Key) to Blockcore Key for P2WSH signing
-        var key = new Key(investorPrivateKey.ToBytes());
+        var keyBytes = investorPrivateKey.ToBytes();
+        Key key;
+        try
+        {
+            key = new Key(keyBytes);
+        }
+        finally
+        {
+            System.Security.Cryptography.CryptographicOperations.ZeroMemory(keyBytes);
+        }
 
         foreach (var intput in transaction.Inputs)
         {
@@ -335,7 +344,7 @@ public class InvestorTransactionActions : IInvestorTransactionActions
 
             var hash = nbitcoinRecoveryTransaction.GetSignatureHashTaproot(outputs, execData);
 
-            _logger.LogInformation($"project={projectInfo.ProjectIdentifier}; investor-pubkey={key.PubKey.ToHex()}; stage={stageIndex}");
+            _logger.LogDebug("Signing recovery for project={ProjectId}, stage={Stage}", projectInfo.ProjectIdentifier, stageIndex);
 
             var investorSignature = key.SignTaprootKeySpend(hash, sigHash);
 
@@ -382,7 +391,7 @@ public class InvestorTransactionActions : IInvestorTransactionActions
 
             var result = pubkey.VerifySignature(hash, TaprootSignature.Parse(sig).SchnorrSignature);
 
-            _logger.LogInformation($"verifying sig for project={projectInfo.ProjectIdentifier}; success = {result}; founder-recovery-pubkey={projectInfo.FounderRecoveryKey}; stage={stageIndex}");
+            _logger.LogDebug("Signature verification for project={ProjectId}, stage={Stage}: {Result}", projectInfo.ProjectIdentifier, stageIndex, result);
 
             // if even one sig failed we fail all the validation
             if (result == false)

--- a/src/shared/Angor.Shared/Protocol/Scripts/ProjectScriptsBuilder.cs
+++ b/src/shared/Angor.Shared/Protocol/Scripts/ProjectScriptsBuilder.cs
@@ -32,8 +32,15 @@ public class ProjectScriptsBuilder : IProjectScriptsBuilder
         var ops = new List<Op>
         {
             OpcodeType.OP_RETURN,
-            Op.GetPushOp(new PubKey(parameters.InvestorKey).ToBytes())
         };
+
+        // V3+: prepend a 1-byte protocol version marker for unambiguous parsing
+        if (projectInfo.Version >= 3)
+        {
+            ops.Add(Op.GetPushOp(new byte[] { (byte)projectInfo.Version }));
+        }
+
+        ops.Add(Op.GetPushOp(new PubKey(parameters.InvestorKey).ToBytes()));
 
         // For Fund/Subscribe projects, add dynamic stage info
         if (projectInfo.ProjectType == ProjectType.Fund || projectInfo.ProjectType == ProjectType.Subscribe)
@@ -61,9 +68,16 @@ public class ProjectScriptsBuilder : IProjectScriptsBuilder
         var ops = new List<Op>
         {
             OpcodeType.OP_RETURN,
-            Op.GetPushOp(new PubKey(parameters.InvestorKey).ToBytes()),
-            Op.GetPushOp((parameters.HashOfSecret ?? new uint256(0)).ToBytes())
         };
+
+        // V3+: prepend a 1-byte protocol version marker for unambiguous parsing
+        if (projectInfo.Version >= 3)
+        {
+            ops.Add(Op.GetPushOp(new byte[] { (byte)projectInfo.Version }));
+        }
+
+        ops.Add(Op.GetPushOp(new PubKey(parameters.InvestorKey).ToBytes()));
+        ops.Add(Op.GetPushOp((parameters.HashOfSecret ?? new uint256(0)).ToBytes()));
 
         // For Fund/Subscribe projects, add dynamic stage info
         if (projectInfo.ProjectType == ProjectType.Fund || projectInfo.ProjectType == ProjectType.Subscribe)
@@ -91,57 +105,72 @@ public class ProjectScriptsBuilder : IProjectScriptsBuilder
         if (ops.Count < 2 || ops[1].PushData == null)
             throw new Exception($"Unexpected OP_RETURN format: expected at least 2 operations with push data, got {ops.Count}");
 
-        // Validate investor key is a valid compressed public key (33 bytes)
-        if (ops[1].PushData.Length != 33)
-            throw new Exception($"Invalid investor key length in OP_RETURN: expected 33 bytes (compressed pubkey), got {ops[1].PushData.Length}");
-
-        if (ops.Count == 2)
+        // Detect V3+ format: first push after OP_RETURN is a 1-byte version marker
+        int dataStartIndex = 1; // default: data starts at ops[1]
+        if (ops[1].PushData.Length == 1 && ops[1].PushData[0] >= 3)
         {
-            // Invest project: investor key only
-            return (new PubKey(ops[1].PushData).ToHex(), null);
+            // V3+ protocol: skip the version byte
+            dataStartIndex = 2;
+            if (ops.Count < 3 || ops[2].PushData == null)
+                throw new Exception($"V3 OP_RETURN: expected investor key after version byte, got {ops.Count - 1} data pushes");
         }
 
-        if (ops.Count == 3)
+        // Validate investor key is a valid compressed public key (33 bytes)
+        if (ops[dataStartIndex].PushData.Length != 33)
+            throw new Exception($"Invalid investor key length in OP_RETURN: expected 33 bytes (compressed pubkey), got {ops[dataStartIndex].PushData.Length}");
+
+        var remainingOps = ops.Count - dataStartIndex;
+
+        if (remainingOps == 1)
+        {
+            // Invest project: investor key only
+            return (new PubKey(ops[dataStartIndex].PushData).ToHex(), null);
+        }
+
+        if (remainingOps == 2)
         {
             // Could be:
             // 1. Invest project with seeder: investor key + secret hash (32 bytes)
             // 2. Fund/Subscribe project: investor key + dynamic info (4 bytes)
 
-            if (ops[2].PushData == null)
-                throw new Exception("Unexpected OP_RETURN format: third operation has no push data");
+            var nextIdx = dataStartIndex + 1;
+            if (ops[nextIdx].PushData == null)
+                throw new Exception("Unexpected OP_RETURN format: push data is null after investor key");
 
-            if (ops[2].PushData.Length == 32)
+            if (ops[nextIdx].PushData.Length == 32)
             {
                 // Seeder with secret hash
-                PubKey pubKey = new PubKey(ops[1].PushData);
-                uint256 secretHash = new uint256(ops[2].PushData);
+                PubKey pubKey = new PubKey(ops[dataStartIndex].PushData);
+                uint256 secretHash = new uint256(ops[nextIdx].PushData);
                 return (pubKey.ToHex(), secretHash);
             }
-            else if (ops[2].PushData.Length == 4)
+            else if (ops[nextIdx].PushData.Length == 4)
             {
                 // Dynamic stage info (no secret hash)
-                return (new PubKey(ops[1].PushData).ToHex(), null);
+                return (new PubKey(ops[dataStartIndex].PushData).ToHex(), null);
             }
             else
             {
-                throw new Exception($"Unexpected OP_RETURN format: third push data has unrecognized length {ops[2].PushData.Length} (expected 32 for secret hash or 4 for dynamic info)");
+                throw new Exception($"Unexpected OP_RETURN format: push data has unrecognized length {ops[nextIdx].PushData.Length} (expected 32 for secret hash or 4 for dynamic info)");
             }
         }
 
-        if (ops.Count == 4)
+        if (remainingOps == 3)
         {
             // Fund/Subscribe seeder: investor key + secret hash + dynamic info
-            if (ops[2].PushData?.Length != 32)
-                throw new Exception($"Unexpected OP_RETURN format: expected 32-byte secret hash at position 2, got {ops[2].PushData?.Length}");
-            if (ops[3].PushData?.Length != 4)
-                throw new Exception($"Unexpected OP_RETURN format: expected 4-byte dynamic info at position 3, got {ops[3].PushData?.Length}");
+            var hashIdx = dataStartIndex + 1;
+            var dynIdx = dataStartIndex + 2;
+            if (ops[hashIdx].PushData?.Length != 32)
+                throw new Exception($"Unexpected OP_RETURN format: expected 32-byte secret hash at position {hashIdx}, got {ops[hashIdx].PushData?.Length}");
+            if (ops[dynIdx].PushData?.Length != 4)
+                throw new Exception($"Unexpected OP_RETURN format: expected 4-byte dynamic info at position {dynIdx}, got {ops[dynIdx].PushData?.Length}");
 
-            PubKey pubKey = new PubKey(ops[1].PushData);
-            uint256 secretHash = new uint256(ops[2].PushData);
+            PubKey pubKey = new PubKey(ops[dataStartIndex].PushData);
+            uint256 secretHash = new uint256(ops[hashIdx].PushData);
             return (pubKey.ToHex(), secretHash);
         }
 
-        throw new Exception($"Unexpected OP_RETURN format with {ops.Count} operations");
+        throw new Exception($"Unexpected OP_RETURN format with {ops.Count} operations (data starts at index {dataStartIndex})");
     }
 
     public DynamicStageInfo? GetDynamicStageInfoFromOpReturnScript(Script script)
@@ -153,17 +182,26 @@ public class ProjectScriptsBuilder : IProjectScriptsBuilder
 
         var ops = script.ToOps();
 
-        // Check for dynamic stage info in different positions
-        if (ops.Count == 3 && ops[2].PushData?.Length == 4)
+        // Detect V3+ format: first push after OP_RETURN is a 1-byte version marker
+        int dataStartIndex = 1;
+        if (ops.Count >= 2 && ops[1].PushData?.Length == 1 && ops[1].PushData[0] >= 3)
         {
-            // Investor with dynamic info: [OP_RETURN] [investor key] [dynamic info]
-            return DynamicStageInfo.FromBytes(ops[2].PushData);
+            dataStartIndex = 2; // skip version byte
         }
 
-        if (ops.Count == 4 && ops[3].PushData?.Length == 4)
+        var remainingOps = ops.Count - dataStartIndex;
+
+        // Check for dynamic stage info: last push is 4 bytes
+        if (remainingOps == 2 && ops[dataStartIndex + 1].PushData?.Length == 4)
         {
-            // Seeder with dynamic info: [OP_RETURN] [investor key] [secret hash] [dynamic info]
-            return DynamicStageInfo.FromBytes(ops[3].PushData);
+            // Investor with dynamic info: [investor key] [dynamic info]
+            return DynamicStageInfo.FromBytes(ops[dataStartIndex + 1].PushData);
+        }
+
+        if (remainingOps == 3 && ops[dataStartIndex + 2].PushData?.Length == 4)
+        {
+            // Seeder with dynamic info: [investor key] [secret hash] [dynamic info]
+            return DynamicStageInfo.FromBytes(ops[dataStartIndex + 2].PushData);
         }
 
         return null;

--- a/src/shared/Angor.Shared/Protocol/Scripts/TaprootScriptBuilder.cs
+++ b/src/shared/Angor.Shared/Protocol/Scripts/TaprootScriptBuilder.cs
@@ -87,9 +87,11 @@ public class TaprootScriptBuilder : ITaprootScriptBuilder
         return (new Script(controlBlock.ToBytes()), execute, secretHashes.ToArray());
     }
     
-    private static TaprootSpendInfo BuildTaprootSpendInfo(ProjectScripts scripts)
+    private static TaprootSpendInfo BuildTaprootSpendInfo(ProjectScripts scripts, int projectVersion = 1)
     {
-        var taprootKey = CreateUnspendableInternalKey();
+        var taprootKey = projectVersion >= 3
+            ? CreateUnspendableInternalKeyV2()
+            : CreateUnspendableInternalKey();
 
         var scriptWeights = BuildTaprootScripts(scripts);
 
@@ -120,14 +122,30 @@ public class TaprootScriptBuilder : ITaprootScriptBuilder
         return scriptWeights;
     }
 
+    /// <summary>
+    /// BIP-341 recommended provably unspendable NUMS (Nothing Up My Sleeve) internal key.
+    /// This is lift_x(SHA256("unspendable")) = 0x50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0
+    /// Used for new projects (Version 3+). Provably unspendable because nobody knows the discrete log.
+    /// </summary>
+    private static readonly byte[] Bip341NumsPointBytes = Convert.FromHexString(
+        "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0");
+
+    /// <summary>
+    /// Creates the standard BIP-341 unspendable internal key (for new V3+ projects).
+    /// </summary>
+    public static TaprootInternalPubKey CreateUnspendableInternalKeyV2()
+    {
+        return new TaprootInternalPubKey(Bip341NumsPointBytes);
+    }
+
+    /// <summary>
+    /// Legacy unspendable internal key used by V1/V2 projects already on-chain.
+    /// DO NOT use for new projects — use <see cref="CreateUnspendableInternalKeyV2"/> instead.
+    /// Kept for backward compatibility when spending existing taproot outputs.
+    /// </summary>
     public static TaprootInternalPubKey CreateUnspendableInternalKey()
     {
-        // todo: double check this key is unspendable
-        // https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
-        // this is a key that can not be spent, we will always spend a tapscript using scripts
-        //var taprootKey = TaprootInternalPubKey.Parse("0x50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0");
-
-        // 1. Calculate the SHA256 of a known constant
+        // Legacy: SHA256("Angor Unspendable Taproot Key") interpreted directly as x-coordinate
         var sha256 = Hashes.SHA256(Encoding.UTF8.GetBytes("Angor Unspendable Taproot Key"));
 
         if (!TaprootPubKey.TryCreate(sha256, out TaprootPubKey? taprootPubKey))

--- a/src/shared/Angor.Shared/Protocol/SeederTransactionActions.cs
+++ b/src/shared/Angor.Shared/Protocol/SeederTransactionActions.cs
@@ -77,7 +77,16 @@ public class SeederTransactionActions : ISeederTransactionActions
             .Select(_ => _.TxOut)
             .ToArray();
 
-        var key = new Key(privateKey.ToBytes());
+        var keyBytes = privateKey.ToBytes();
+        Key key;
+        try
+        {
+            key = new Key(keyBytes);
+        }
+        finally
+        {
+            System.Security.Cryptography.CryptographicOperations.ZeroMemory(keyBytes);
+        }
         var sigHash = TaprootSigHash.Single | TaprootSigHash.AnyoneCanPay;
 
         for (var stageIndex = 0; stageIndex < projectInfo.Stages.Count; stageIndex++)
@@ -90,7 +99,7 @@ public class SeederTransactionActions : ISeederTransactionActions
             var execData = new TaprootExecutionData(stageIndex, tapScript.LeafHash) { SigHash = sigHash };
             var hash = nbitcoinRecoveryTransaction.GetSignatureHashTaproot(outputs, execData);
 
-            _logger.LogInformation($"project={projectInfo.ProjectIdentifier}; seeder-pubkey={key.PubKey.ToHex()}; stage={stageIndex}");
+            _logger.LogDebug("Signing recovery for project={ProjectId}, stage={Stage}", projectInfo.ProjectIdentifier, stageIndex);
 
             var investorSignature = key.SignTaprootKeySpend(hash, sigHash);
 

--- a/src/shared/Angor.Shared/Protocol/TransactionBuilders/SpendingTransactionBuilder.cs
+++ b/src/shared/Angor.Shared/Protocol/TransactionBuilders/SpendingTransactionBuilder.cs
@@ -118,7 +118,16 @@ public class SpendingTransactionBuilder : ISpendingTransactionBuilder
 
         // Step 4 - sign the taproot inputs
         var trxData = spendingTrx.PrecomputeTransactionData(investmentTrxOutputs.Select(s => s.TxOut).ToArray());
-        var key = new Key(privateKey.ToBytes());
+        var keyBytes = privateKey.ToBytes();
+        Key key;
+        try
+        {
+            key = new Key(keyBytes);
+        }
+        finally
+        {
+            System.Security.Cryptography.CryptographicOperations.ZeroMemory(keyBytes);
+        }
 
         const TaprootSigHash sigHash = TaprootSigHash.All;
         var inputIndex = 0;

--- a/src/shared/Angor.Shared/PsbtOperations.cs
+++ b/src/shared/Angor.Shared/PsbtOperations.cs
@@ -209,7 +209,7 @@ public class PsbtOperations : IPsbtOperations
 
         var psbt = NBitcoin.PSBT.Parse(psbtData.PsbtHex, nbitcoinNetwork);
 
-        ExtKey extendedKey = _hdOperations.GetExtendedKey(walletWords.Words, walletWords.Passphrase);
+        ExtKey extendedKey = walletWords.GetOrDeriveExtKey(_hdOperations);
 
         var nbitcoinExtendedKey = NBitcoin.ExtKey.CreateFromBytes(extendedKey.ToBytes(network.Consensus.ConsensusFactory));
 

--- a/src/shared/Angor.Shared/WalletOperations.cs
+++ b/src/shared/Angor.Shared/WalletOperations.cs
@@ -1,4 +1,5 @@
 using Angor.Shared.Models;
+using Angor.Shared.Protocol;
 using Angor.Shared.Services;
 using Angor.Shared.Utilities;
 using Blockcore.Consensus.ScriptInfo;
@@ -44,13 +45,13 @@ public class WalletOperations : IWalletOperations
         Network network = _networkConfiguration.GetNetwork();
 
         var utxoDataWithPaths = FindOutputsForTransaction((long)transaction.Outputs.Sum(_ => _.Value), accountInfo);
-        var coins = GetUnspentOutputsForTransaction(walletWords, utxoDataWithPaths);
+        var signingCoins = GetUnspentOutputsForTransaction(walletWords, utxoDataWithPaths);
 
-        if (coins.coins == null)
+        if (signingCoins == null || !signingCoins.Any())
             throw new ApplicationException("No coins found");
        
         // did we spend all the coins?
-        var spendAll = coins.coins.Sum(s => s.Amount.Satoshi) == transaction.Outputs.Sum(o => o.Value.Satoshi);
+        var spendAll = signingCoins.Sum(s => s.Coin.Amount.Satoshi) == transaction.Outputs.Sum(o => o.Value.Satoshi);
 
         if (spendAll)
         {
@@ -58,11 +59,11 @@ public class WalletOperations : IWalletOperations
             var clonedTransaction = network.CreateTransaction(transaction.ToHex());
 
             // Step 2: Add inputs and recalculate the transaction size
-            foreach (var coin in coins.coins)
+            foreach (var sc in signingCoins)
             {
-                if (clonedTransaction.Inputs.Any(x => x.PrevOut == coin.Outpoint))
+                if (clonedTransaction.Inputs.Any(x => x.PrevOut == sc.Coin.Outpoint))
                     continue;
-                var txin = new TxIn(coin.Outpoint, null);
+                var txin = new TxIn(sc.Coin.Outpoint, null);
                 txin.WitScript = new WitScript(Op.GetPushOp(new byte[72]), Op.GetPushOp(new byte[33])); // for total size calculation
                 clonedTransaction.AddInput(txin);
             }
@@ -81,19 +82,14 @@ public class WalletOperations : IWalletOperations
             lastOutput.Value -= totalFee;
 
             // Step 6: Sign inputs
-            var index = 0;
-            foreach (var coin in coins.coins)
+            foreach (var sc in signingCoins)
             {
-                var key = coins.keys[index];
+                if (sc.Key.PubKey.WitHash.ScriptPubKey != sc.Coin.ScriptPubKey)
+                    throw new InvalidOperationException($"Derived key does not match coin ScriptPubKey for outpoint {sc.Coin.Outpoint}");
 
-                if (key.PubKey.WitHash.ScriptPubKey != coin.ScriptPubKey)
-                    throw new InvalidOperationException($"Derived key does not match coin ScriptPubKey at index {index}");
-
-                var input = clonedTransaction.Inputs.Single(p => p.PrevOut == coin.Outpoint);
-                var signature = clonedTransaction.SignInput(network, key, coin, SigHash.All);
-                input.WitScript = new WitScript(Op.GetPushOp(signature.ToBytes()), Op.GetPushOp(key.PubKey.ToBytes()));
-
-                index++;
+                var input = clonedTransaction.Inputs.Single(p => p.PrevOut == sc.Coin.Outpoint);
+                var signature = clonedTransaction.SignInput(network, sc.Key, sc.Coin, SigHash.All);
+                input.WitScript = new WitScript(Op.GetPushOp(signature.ToBytes()), Op.GetPushOp(sc.Key.PubKey.ToBytes()));
             }
 
             return new TransactionInfo { Transaction = clonedTransaction, TransactionFee = totalFee };
@@ -102,8 +98,8 @@ public class WalletOperations : IWalletOperations
         {
             TransactionBuilder builder;
             builder = new TransactionBuilder(network)
-                .AddCoins(coins.coins)
-                .AddKeys(coins.keys.ToArray())
+                .AddCoins(signingCoins.Select(sc => sc.Coin))
+                .AddKeys(signingCoins.Select(sc => sc.Key).ToArray())
                 .SetChange(BitcoinAddress.Create(changeAddress, network))
                 .ContinueToBuild(transaction)
                 .SendEstimatedFees(new FeeRate(Money.Satoshis(feeRate)))
@@ -118,9 +114,9 @@ public class WalletOperations : IWalletOperations
 
             foreach (var input in signTransaction.Inputs)
             {
-                var foundInput = coins.coins.First(c => c.Outpoint.ToString() == input.PrevOut.ToString());
+                var foundInput = signingCoins.First(sc => sc.Coin.Outpoint.ToString() == input.PrevOut.ToString());
 
-                totaInInputs += foundInput.Amount.Satoshi;
+                totaInInputs += foundInput.Coin.Amount.Satoshi;
             }
 
             var minerFee = totaInInputs - totaInOutputs;
@@ -172,20 +168,20 @@ public class WalletOperations : IWalletOperations
             throw new ApplicationException(
                 $"Insufficient funds in address {fundingAddress}. Required: {requiredAmount} sats ({Money.Satoshis(requiredAmount).ToUnit(MoneyUnit.BTC):F8} BTC), Available: {totalAvailable} sats ({Money.Satoshis(totalAvailable).ToUnit(MoneyUnit.BTC):F8} BTC)");
 
-        var coins = GetUnspentOutputsForTransaction(walletWords, availableUtxos);
+        var signingCoins = GetUnspentOutputsForTransaction(walletWords, availableUtxos);
 
-        if (coins.coins == null || !coins.coins.Any())
+        if (signingCoins == null || !signingCoins.Any())
             throw new ApplicationException("Failed to get coins for the funding address");
 
         // Clone transaction
         var clonedTransaction = network.CreateTransaction(transaction.ToHex());
 
         // Add inputs
-        foreach (var coin in coins.coins)
+        foreach (var sc in signingCoins)
         {
-            if (clonedTransaction.Inputs.Any(x => x.PrevOut == coin.Outpoint))
+            if (clonedTransaction.Inputs.Any(x => x.PrevOut == sc.Coin.Outpoint))
                 continue;
-            var txin = new TxIn(coin.Outpoint, null);
+            var txin = new TxIn(sc.Coin.Outpoint, null);
             txin.WitScript = new WitScript(Op.GetPushOp(new byte[72]), Op.GetPushOp(new byte[33]));
             clonedTransaction.AddInput(txin);
         }
@@ -198,7 +194,7 @@ public class WalletOperations : IWalletOperations
         var changeAmount = totalAvailable - outputsTotal - totalFee;
         
         // Add change output if above dust threshold
-        if (changeAmount > 294) // Dust threshold
+        if (changeAmount > ProtocolConstants.DustThresholdSats)
         {
             clonedTransaction.AddOutput(Money.Satoshis(changeAmount), 
                 BitcoinAddress.Create(changeAddress, network).ScriptPubKey);
@@ -213,18 +209,14 @@ public class WalletOperations : IWalletOperations
         }
 
         // Sign inputs
-        var index = 0;
-        foreach (var coin in coins.coins)
+        foreach (var sc in signingCoins)
         {
-            var key = coins.keys[index];
+            if (sc.Key.PubKey.WitHash.ScriptPubKey != sc.Coin.ScriptPubKey)
+                throw new InvalidOperationException($"Derived key does not match coin ScriptPubKey for outpoint {sc.Coin.Outpoint}");
 
-            if (key.PubKey.WitHash.ScriptPubKey != coin.ScriptPubKey)
-                throw new InvalidOperationException($"Derived key does not match coin ScriptPubKey at index {index}");
-
-            var input = clonedTransaction.Inputs.Single(p => p.PrevOut == coin.Outpoint);
-            var signature = clonedTransaction.SignInput(network, key, coin, SigHash.All);
-            input.WitScript = new WitScript(Op.GetPushOp(signature.ToBytes()), Op.GetPushOp(key.PubKey.ToBytes()));
-            index++;
+            var input = clonedTransaction.Inputs.Single(p => p.PrevOut == sc.Coin.Outpoint);
+            var signature = clonedTransaction.SignInput(network, sc.Key, sc.Coin, SigHash.All);
+            input.WitScript = new WitScript(Op.GetPushOp(signature.ToBytes()), Op.GetPushOp(sc.Key.PubKey.ToBytes()));
         }
 
         return new TransactionInfo { Transaction = clonedTransaction, TransactionFee = totalFee };
@@ -246,14 +238,14 @@ public class WalletOperations : IWalletOperations
 
         // Step 2: Find UTXOs to fund the total cost of transaction (outputs + initial fee)
         var utxoDataWithPaths = FindOutputsForTransaction((long)initialFee, accountInfo);
-        var coins = GetUnspentOutputsForTransaction(walletWords, utxoDataWithPaths);
+        var signingCoins = GetUnspentOutputsForTransaction(walletWords, utxoDataWithPaths);
 
         // Step 3: Add inputs and recalculate the transaction size
-        foreach (var coin in coins.coins)
+        foreach (var sc in signingCoins)
         {
-            if (clonedTransaction.Inputs.Any(x => x.PrevOut == coin.Outpoint))
+            if (clonedTransaction.Inputs.Any(x => x.PrevOut == sc.Coin.Outpoint))
                 continue;
-            var txin = new TxIn(coin.Outpoint, null);
+            var txin = new TxIn(sc.Coin.Outpoint, null);
             txin.WitScript = new WitScript(Op.GetPushOp(new byte[72]), Op.GetPushOp(new byte[33])); // for total size calculation
             clonedTransaction.AddInput(txin);
         }
@@ -264,11 +256,11 @@ public class WalletOperations : IWalletOperations
         var totalFee = new FeeRate(Money.Satoshis(feeRate)).GetFee(totalSize);
 
         // Step 5: Adjust the change output (remaining coins after paying the fee)
-        var totalSats = coins.coins.Sum(s => s.Amount.Satoshi);
+        var totalSats = signingCoins.Sum(s => s.Coin.Amount.Satoshi);
         totalSats -= totalFee;
 
         // Handle cases where change is below "dust threshold" for SegWit
-        if (totalSats <= 294)
+        if (totalSats <= ProtocolConstants.DustThresholdSats)
         {
             // Absorb small change into the transaction fee
             changeOutput.Value = Money.Zero;
@@ -280,19 +272,14 @@ public class WalletOperations : IWalletOperations
         }
 
         // Step 6: Sign inputs
-        var index = 0;
-        foreach (var coin in coins.coins)
+        foreach (var sc in signingCoins)
         {
-            var key = coins.keys[index];
+            if (sc.Key.PubKey.WitHash.ScriptPubKey != sc.Coin.ScriptPubKey)
+                throw new InvalidOperationException($"Derived key does not match coin ScriptPubKey for outpoint {sc.Coin.Outpoint}");
 
-            if (key.PubKey.WitHash.ScriptPubKey != coin.ScriptPubKey)
-                throw new InvalidOperationException($"Derived key does not match coin ScriptPubKey at index {index}");
-
-            var input = clonedTransaction.Inputs.Single(p => p.PrevOut == coin.Outpoint);
-            var signature = clonedTransaction.SignInput(network, key, coin, SigHash.All);
-            input.WitScript = new WitScript(Op.GetPushOp(signature.ToBytes()), Op.GetPushOp(key.PubKey.ToBytes()));
-
-            index++;
+            var input = clonedTransaction.Inputs.Single(p => p.PrevOut == sc.Coin.Outpoint);
+            var signature = clonedTransaction.SignInput(network, sc.Key, sc.Coin, SigHash.All);
+            input.WitScript = new WitScript(Op.GetPushOp(signature.ToBytes()), Op.GetPushOp(sc.Key.PubKey.ToBytes()));
         }
 
         return new TransactionInfo { Transaction = clonedTransaction, TransactionFee = totalFee };
@@ -309,18 +296,18 @@ public class WalletOperations : IWalletOperations
             throw new ApplicationException("not enough funds");
         }
 
-        var (coins, keys) =
+        var signingCoins =
             GetUnspentOutputsForTransaction(walletWords, sendInfo.SendUtxos.Values.ToList());
 
-        if (coins == null)
+        if (signingCoins == null || !signingCoins.Any())
         {
             return new OperationResult<Transaction> { Success = false, Message = "not enough funds" };
         }
 
         var builder = new TransactionBuilder(network)
             .Send(BitcoinWitPubKeyAddress.Create(sendInfo.SendToAddress, network), Money.Satoshis(sendInfo.SendAmount))
-            .AddCoins(coins)
-            .AddKeys(keys.ToArray())
+            .AddCoins(signingCoins.Select(sc => sc.Coin))
+            .AddKeys(signingCoins.Select(sc => sc.Key).ToArray())
             .SetChange(BitcoinWitPubKeyAddress.Create(sendInfo.ChangeAddress, network))
             .SendEstimatedFees(new FeeRate(Money.Satoshis(sendInfo.FeeRate)));
 
@@ -407,7 +394,7 @@ public class WalletOperations : IWalletOperations
         return utxosToSpend;
     }
 
-    public (List<Coin>? coins,List<Key> keys) GetUnspentOutputsForTransaction(WalletWords walletWords , List<UtxoDataWithPath> utxoDataWithPaths)
+    public List<SigningCoin> GetUnspentOutputsForTransaction(WalletWords walletWords , List<UtxoDataWithPath> utxoDataWithPaths)
     {
         ExtKey extendedKey;
         try
@@ -416,7 +403,7 @@ public class WalletOperations : IWalletOperations
         }
         catch (NotSupportedException ex)
         {
-            Console.WriteLine("Exception occurred: {0}", ex);
+            _logger.LogError(ex, "Failed to derive extended key from mnemonic");
 
             if (ex.Message == "Unknown")
                 throw new Exception("Please make sure you enter valid mnemonic words.");
@@ -424,23 +411,23 @@ public class WalletOperations : IWalletOperations
             throw;
         }
 
-        var coins = new List<Coin>();
-        var keys = new List<Key>();
+        var signingCoins = new List<SigningCoin>();
 
         foreach (var utxoDataWithPath in utxoDataWithPaths)
         {
             var utxo = utxoDataWithPath.UtxoData;
 
-            coins.Add(new Coin(uint256.Parse(utxo.outpoint.transactionId), (uint)utxo.outpoint.outputIndex,
-                Money.Satoshis(utxo.value), Script.FromHex(utxo.scriptHex)));
+            var coin = new Coin(uint256.Parse(utxo.outpoint.transactionId), (uint)utxo.outpoint.outputIndex,
+                Money.Satoshis(utxo.value), Script.FromHex(utxo.scriptHex));
 
             // derive the private key
             var extKey = extendedKey.Derive(new KeyPath(utxoDataWithPath.HdPath));
             Key privateKey = extKey.PrivateKey;
-            keys.Add(privateKey);
+            
+            signingCoins.Add(new SigningCoin(coin, privateKey));
         }
 
-        return (coins,keys);
+        return signingCoins;
     }
 
 


### PR DESCRIPTION
## Summary

Addresses findings from an internal security audit with a backward-compatible, version-gated approach. V3+ projects use new secure methods; V1/V2 legacy behavior is preserved for reading existing on-chain data.

**All 154 shared tests pass.** SDK tests have pre-existing Blockcore build errors from `main` (unrelated, pending PR #905).

## Changes by Severity

### Critical
- **C1**: Demote sensitive data logs (WitScript, tx hex, signatures, keys) from `LogInformation` to `LogDebug` across FounderTransactionActions, InvestorTransactionActions, SeederTransactionActions, DerivationOperations
- **C2**: Add `WordsMemory`/`PassphraseMemory` properties to `WalletWords`; fix `PsbtOperations` to use `GetOrDeriveExtKey()` instead of accessing `.Words` directly

### High
- **H1**: Add `DeriveProjectIndicesV2()` returning `(uint Hi, uint Lo)` with 62-bit entropy via two-level BIP-32 hardened path; `BuildProjectSubPath` version-gated for V3+
- **H2**: Replace `(List<Coin>?, List<Key>)` tuple with strongly-typed `SigningCoin` record in `IWalletOperations`
- **H4**: Use BIP-341 NUMS point (`0x50929b74c1a04954...`) as unspendable Taproot internal key for V3+ projects
- **H5**: Use public key hash (not private key bytes) for Nostr storage path derivation in V3+; zero sensitive byte arrays in `finally` blocks for legacy V1/V2 path

### Medium
- **M1**: Zero private key byte arrays in `finally` blocks across InvestorTransactionActions, SeederTransactionActions, SpendingTransactionBuilder
- **M8**: Prepend 1-byte version marker to V3+ OP_RETURN scripts; parser auto-detects version byte and adjusts data start index

### Low
- Remove redundant `.Replace("-","").ToLower()` in hex encoding (already lowercase)
- Replace `Console.WriteLine` with `ILogger.LogError` in WalletOperations
- Replace hardcoded `294` dust threshold with `ProtocolConstants.DustThresholdSats`

## Version Gating Strategy

All protocol-breaking changes use `ProjectInfo.Version` (existing field, currently 1 or 2):
- **V3+**: New secure behavior (NUMS internal key, pubkey-hash storage paths, two-level derivation, OP_RETURN version byte)
- **V1/V2**: Legacy behavior preserved for backward compatibility with existing on-chain projects

## Files Changed (17 files, +388/-178)

| Area | Files |
|------|-------|
| Protocol | FounderTransactionActions, InvestorTransactionActions, SeederTransactionActions, SpendingTransactionBuilder |
| Scripts | TaprootScriptBuilder, ProjectScriptsBuilder |
| Derivation | DerivationOperations, IDerivationOperations |
| Wallet | WalletOperations, IWalletOperations, PsbtOperations, WalletWords |
| Tests | WalletOperationsTest, FounderTransactionActionTest, InvestmentIntegrationsTests, InvestmentOperationsTest, InvestmentOperations (DataBuilder) |