### PR TITLE
C2: Add WordsMemory/PassphraseMemory and use cached ExtKey in PsbtOperations

### DIFF
--- a/src/shared/Angor.Shared/Models/WalletWords.cs
+++ b/src/shared/Angor.Shared/Models/WalletWords.cs
@@ -18,7 +18,13 @@ public class WalletWords : IDisposable
     private ExtKey? cachedExtKey;
     private bool disposed;
 
-    /// <summary>The BIP-39 mnemonic words (space-separated).</summary>
+    /// <summary>
+    /// The BIP-39 mnemonic words (space-separated).
+    /// SECURITY: Each access creates a new immutable string on the managed heap that
+    /// cannot be zeroed by the GC. Prefer <see cref="GetOrDeriveExtKey"/> which caches
+    /// the derived key and only calls this once. Use <see cref="WordsMemory"/> for
+    /// read-only access without allocating a new string.
+    /// </summary>
     public string Words
     {
         get
@@ -34,6 +40,20 @@ public class WalletWords : IDisposable
         }
     }
 
+    /// <summary>
+    /// Read-only access to the mnemonic characters without allocating a new string.
+    /// The backing memory is zeroed on <see cref="Dispose"/>.
+    /// </summary>
+    [JsonIgnore]
+    public ReadOnlyMemory<char> WordsMemory
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            return wordsChars.AsMemory();
+        }
+    }
+
     /// <summary>Optional BIP-39 passphrase.</summary>
     public string? Passphrase
     {
@@ -43,6 +63,20 @@ public class WalletWords : IDisposable
             return passphraseChars != null ? new string(passphraseChars) : null;
         }
         set => passphraseChars = value?.ToCharArray();
+    }
+
+    /// <summary>
+    /// Read-only access to the passphrase characters without allocating a new string.
+    /// The backing memory is zeroed on <see cref="Dispose"/>.
+    /// </summary>
+    [JsonIgnore]
+    public ReadOnlyMemory<char>? PassphraseMemory
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            return passphraseChars?.AsMemory();
+        }
     }
 
     /// <summary>

--- a/src/shared/Angor.Shared/PsbtOperations.cs
+++ b/src/shared/Angor.Shared/PsbtOperations.cs
@@ -209,7 +209,7 @@ public class PsbtOperations : IPsbtOperations
 
         var psbt = NBitcoin.PSBT.Parse(psbtData.PsbtHex, nbitcoinNetwork);
 
-        ExtKey extendedKey = _hdOperations.GetExtendedKey(walletWords.Words, walletWords.Passphrase);
+        ExtKey extendedKey = walletWords.GetOrDeriveExtKey(_hdOperations);
 
         var nbitcoinExtendedKey = NBitcoin.ExtKey.CreateFromBytes(extendedKey.ToBytes(network.Consensus.ConsensusFactory));
 


### PR DESCRIPTION
## Summary

Reduce mnemonic exposure by adding zero-allocation `ReadOnlyMemory<char>` accessors and fixing `PsbtOperations` to use the cached ExtKey instead of re-reading `.Words`.

## Changes

- **WalletWords.cs**: Add `WordsMemory` and `PassphraseMemory` properties that expose the backing `char[]` without creating new string copies. Add security documentation to the `Words` getter.
- **PsbtOperations.cs**: Replace `_hdOperations.GetExtendedKey(walletWords.Words, walletWords.Passphrase)` with `walletWords.GetOrDeriveExtKey(_hdOperations)` to use the cached key and avoid extra mnemonic string allocations.

## Rationale

Every call to `.Words` creates a new `string` on the managed heap that cannot be deterministically zeroed. By preferring `GetOrDeriveExtKey()` (which derives once and caches), we minimize the number of mnemonic string copies that linger in memory.

## Testing

All 154 shared tests pass.