### PR TITLE
M1: Zero private key byte arrays in finally blocks

### DIFF
--- a/src/shared/Angor.Shared/Protocol/InvestorTransactionActions.cs
+++ b/src/shared/Angor.Shared/Protocol/InvestorTransactionActions.cs
@@ -142,7 +142,16 @@ public class InvestorTransactionActions : IInvestorTransactionActions
 
         // sign the inputs (replace fake WitScript with real one)
         // Convert AngorKey (NBitcoin.Key) to Blockcore Key for P2WSH signing
-        var key = new Key(investorPrivateKey.ToBytes());
+        var keyBytes = investorPrivateKey.ToBytes();
+        Key key;
+        try
+        {
+            key = new Key(keyBytes);
+        }
+        finally
+        {
+            System.Security.Cryptography.CryptographicOperations.ZeroMemory(keyBytes);
+        }
 
         foreach (var intput in transaction.Inputs)
         {

--- a/src/shared/Angor.Shared/Protocol/SeederTransactionActions.cs
+++ b/src/shared/Angor.Shared/Protocol/SeederTransactionActions.cs
@@ -77,7 +77,16 @@ public class SeederTransactionActions : ISeederTransactionActions
             .Select(_ => _.TxOut)
             .ToArray();
 
-        var key = new Key(privateKey.ToBytes());
+        var keyBytes = privateKey.ToBytes();
+        Key key;
+        try
+        {
+            key = new Key(keyBytes);
+        }
+        finally
+        {
+            System.Security.Cryptography.CryptographicOperations.ZeroMemory(keyBytes);
+        }
         var sigHash = TaprootSigHash.Single | TaprootSigHash.AnyoneCanPay;
 
         for (var stageIndex = 0; stageIndex < projectInfo.Stages.Count; stageIndex++)

--- a/src/shared/Angor.Shared/Protocol/TransactionBuilders/SpendingTransactionBuilder.cs
+++ b/src/shared/Angor.Shared/Protocol/TransactionBuilders/SpendingTransactionBuilder.cs
@@ -118,7 +118,16 @@ public class SpendingTransactionBuilder : ISpendingTransactionBuilder
 
         // Step 4 - sign the taproot inputs
         var trxData = spendingTrx.PrecomputeTransactionData(investmentTrxOutputs.Select(s => s.TxOut).ToArray());
-        var key = new Key(privateKey.ToBytes());
+        var keyBytes = privateKey.ToBytes();
+        Key key;
+        try
+        {
+            key = new Key(keyBytes);
+        }
+        finally
+        {
+            System.Security.Cryptography.CryptographicOperations.ZeroMemory(keyBytes);
+        }
 
         const TaprootSigHash sigHash = TaprootSigHash.All;
         var inputIndex = 0;


### PR DESCRIPTION
## Summary

Zero private key byte arrays immediately after use via `CryptographicOperations.ZeroMemory` in `finally` blocks.

## Problem

When converting `AngorKey` to NBitcoin `Key` via `new Key(privateKey.ToBytes())`, the intermediate byte array containing raw private key material was never zeroed. It remained in managed memory until garbage collected, exposing it to memory-scraping attacks and crash dumps.

## Solution

Wrap the `new Key(bytes)` call in a try/finally that zeros the byte array:

`csharp
var keyBytes = privateKey.ToBytes();
Key key;
try
{
    key = new Key(keyBytes);
}
finally
{
    CryptographicOperations.ZeroMemory(keyBytes);
}
`

## Files Changed

- **InvestorTransactionActions.cs** — `BuildAndSignRecoverReleaseFundsTransaction`
- **SeederTransactionActions.cs** — `SignInvestorRecoveryTransactions`
- **SpendingTransactionBuilder.cs** — founder key conversion

## Testing

All 154 shared tests pass.