### PR TITLE
M8: Prepend version byte to V3+ OP_RETURN scripts

### DIFF
--- a/src/shared/Angor.Shared/Protocol/Scripts/ProjectScriptsBuilder.cs
+++ b/src/shared/Angor.Shared/Protocol/Scripts/ProjectScriptsBuilder.cs
@@ -32,8 +32,15 @@ public class ProjectScriptsBuilder : IProjectScriptsBuilder
         var ops = new List<Op>
         {
             OpcodeType.OP_RETURN,
-            Op.GetPushOp(new PubKey(parameters.InvestorKey).ToBytes())
         };
+
+        // V3+: prepend a 1-byte protocol version marker for unambiguous parsing
+        if (projectInfo.Version >= 3)
+        {
+            ops.Add(Op.GetPushOp(new byte[] { (byte)projectInfo.Version }));
+        }
+
+        ops.Add(Op.GetPushOp(new PubKey(parameters.InvestorKey).ToBytes()));
 
         // For Fund/Subscribe projects, add dynamic stage info
         if (projectInfo.ProjectType == ProjectType.Fund || projectInfo.ProjectType == ProjectType.Subscribe)
@@ -61,9 +68,16 @@ public class ProjectScriptsBuilder : IProjectScriptsBuilder
         var ops = new List<Op>
         {
             OpcodeType.OP_RETURN,
-            Op.GetPushOp(new PubKey(parameters.InvestorKey).ToBytes()),
-            Op.GetPushOp((parameters.HashOfSecret ?? new uint256(0)).ToBytes())
         };
+
+        // V3+: prepend a 1-byte protocol version marker for unambiguous parsing
+        if (projectInfo.Version >= 3)
+        {
+            ops.Add(Op.GetPushOp(new byte[] { (byte)projectInfo.Version }));
+        }
+
+        ops.Add(Op.GetPushOp(new PubKey(parameters.InvestorKey).ToBytes()));
+        ops.Add(Op.GetPushOp((parameters.HashOfSecret ?? new uint256(0)).ToBytes()));
 
         // For Fund/Subscribe projects, add dynamic stage info
         if (projectInfo.ProjectType == ProjectType.Fund || projectInfo.ProjectType == ProjectType.Subscribe)
@@ -91,57 +105,72 @@ public class ProjectScriptsBuilder : IProjectScriptsBuilder
         if (ops.Count < 2 || ops[1].PushData == null)
             throw new Exception($"Unexpected OP_RETURN format: expected at least 2 operations with push data, got {ops.Count}");
 
-        // Validate investor key is a valid compressed public key (33 bytes)
-        if (ops[1].PushData.Length != 33)
-            throw new Exception($"Invalid investor key length in OP_RETURN: expected 33 bytes (compressed pubkey), got {ops[1].PushData.Length}");
-
-        if (ops.Count == 2)
+        // Detect V3+ format: first push after OP_RETURN is a 1-byte version marker
+        int dataStartIndex = 1; // default: data starts at ops[1]
+        if (ops[1].PushData.Length == 1 && ops[1].PushData[0] >= 3)
         {
-            // Invest project: investor key only
-            return (new PubKey(ops[1].PushData).ToHex(), null);
+            // V3+ protocol: skip the version byte
+            dataStartIndex = 2;
+            if (ops.Count < 3 || ops[2].PushData == null)
+                throw new Exception($"V3 OP_RETURN: expected investor key after version byte, got {ops.Count - 1} data pushes");
         }
 
-        if (ops.Count == 3)
+        // Validate investor key is a valid compressed public key (33 bytes)
+        if (ops[dataStartIndex].PushData.Length != 33)
+            throw new Exception($"Invalid investor key length in OP_RETURN: expected 33 bytes (compressed pubkey), got {ops[dataStartIndex].PushData.Length}");
+
+        var remainingOps = ops.Count - dataStartIndex;
+
+        if (remainingOps == 1)
+        {
+            // Invest project: investor key only
+            return (new PubKey(ops[dataStartIndex].PushData).ToHex(), null);
+        }
+
+        if (remainingOps == 2)
         {
             // Could be:
             // 1. Invest project with seeder: investor key + secret hash (32 bytes)
             // 2. Fund/Subscribe project: investor key + dynamic info (4 bytes)
 
-            if (ops[2].PushData == null)
-                throw new Exception("Unexpected OP_RETURN format: third operation has no push data");
+            var nextIdx = dataStartIndex + 1;
+            if (ops[nextIdx].PushData == null)
+                throw new Exception("Unexpected OP_RETURN format: push data is null after investor key");
 
-            if (ops[2].PushData.Length == 32)
+            if (ops[nextIdx].PushData.Length == 32)
             {
                 // Seeder with secret hash
-                PubKey pubKey = new PubKey(ops[1].PushData);
-                uint256 secretHash = new uint256(ops[2].PushData);
+                PubKey pubKey = new PubKey(ops[dataStartIndex].PushData);
+                uint256 secretHash = new uint256(ops[nextIdx].PushData);
                 return (pubKey.ToHex(), secretHash);
             }
-            else if (ops[2].PushData.Length == 4)
+            else if (ops[nextIdx].PushData.Length == 4)
             {
                 // Dynamic stage info (no secret hash)
-                return (new PubKey(ops[1].PushData).ToHex(), null);
+                return (new PubKey(ops[dataStartIndex].PushData).ToHex(), null);
             }
             else
             {
-                throw new Exception($"Unexpected OP_RETURN format: third push data has unrecognized length {ops[2].PushData.Length} (expected 32 for secret hash or 4 for dynamic info)");
+                throw new Exception($"Unexpected OP_RETURN format: push data has unrecognized length {ops[nextIdx].PushData.Length} (expected 32 for secret hash or 4 for dynamic info)");
             }
         }
 
-        if (ops.Count == 4)
+        if (remainingOps == 3)
         {
             // Fund/Subscribe seeder: investor key + secret hash + dynamic info
-            if (ops[2].PushData?.Length != 32)
-                throw new Exception($"Unexpected OP_RETURN format: expected 32-byte secret hash at position 2, got {ops[2].PushData?.Length}");
-            if (ops[3].PushData?.Length != 4)
-                throw new Exception($"Unexpected OP_RETURN format: expected 4-byte dynamic info at position 3, got {ops[3].PushData?.Length}");
+            var hashIdx = dataStartIndex + 1;
+            var dynIdx = dataStartIndex + 2;
+            if (ops[hashIdx].PushData?.Length != 32)
+                throw new Exception($"Unexpected OP_RETURN format: expected 32-byte secret hash at position {hashIdx}, got {ops[hashIdx].PushData?.Length}");
+            if (ops[dynIdx].PushData?.Length != 4)
+                throw new Exception($"Unexpected OP_RETURN format: expected 4-byte dynamic info at position {dynIdx}, got {ops[dynIdx].PushData?.Length}");
 
-            PubKey pubKey = new PubKey(ops[1].PushData);
-            uint256 secretHash = new uint256(ops[2].PushData);
+            PubKey pubKey = new PubKey(ops[dataStartIndex].PushData);
+            uint256 secretHash = new uint256(ops[hashIdx].PushData);
             return (pubKey.ToHex(), secretHash);
         }
 
-        throw new Exception($"Unexpected OP_RETURN format with {ops.Count} operations");
+        throw new Exception($"Unexpected OP_RETURN format with {ops.Count} operations (data starts at index {dataStartIndex})");
     }
 
     public DynamicStageInfo? GetDynamicStageInfoFromOpReturnScript(Script script)
@@ -153,17 +182,26 @@ public class ProjectScriptsBuilder : IProjectScriptsBuilder
 
         var ops = script.ToOps();
 
-        // Check for dynamic stage info in different positions
-        if (ops.Count == 3 && ops[2].PushData?.Length == 4)
+        // Detect V3+ format: first push after OP_RETURN is a 1-byte version marker
+        int dataStartIndex = 1;
+        if (ops.Count >= 2 && ops[1].PushData?.Length == 1 && ops[1].PushData[0] >= 3)
         {
-            // Investor with dynamic info: [OP_RETURN] [investor key] [dynamic info]
-            return DynamicStageInfo.FromBytes(ops[2].PushData);
+            dataStartIndex = 2; // skip version byte
         }
 
-        if (ops.Count == 4 && ops[3].PushData?.Length == 4)
+        var remainingOps = ops.Count - dataStartIndex;
+
+        // Check for dynamic stage info: last push is 4 bytes
+        if (remainingOps == 2 && ops[dataStartIndex + 1].PushData?.Length == 4)
         {
-            // Seeder with dynamic info: [OP_RETURN] [investor key] [secret hash] [dynamic info]
-            return DynamicStageInfo.FromBytes(ops[3].PushData);
+            // Investor with dynamic info: [investor key] [dynamic info]
+            return DynamicStageInfo.FromBytes(ops[dataStartIndex + 1].PushData);
+        }
+
+        if (remainingOps == 3 && ops[dataStartIndex + 2].PushData?.Length == 4)
+        {
+            // Seeder with dynamic info: [investor key] [secret hash] [dynamic info]
+            return DynamicStageInfo.FromBytes(ops[dataStartIndex + 2].PushData);
         }
 
         return null;


### PR DESCRIPTION
## Summary

Prepend a 1-byte version marker to OP_RETURN scripts for V3+ projects, enabling future protocol evolution while maintaining backward-compatible parsing.

## Problem

The current OP_RETURN format has no version indicator. If the data layout needs to change in the future, there's no way to distinguish between old and new formats during parsing — leading to silent misinterpretation of data.

## Solution

### Builder (V3+)
Prepend a single byte with value equal to the project version (e.g., `0x03`) before the existing data pushes.

### Parser
Detect the version byte by checking:
1. First data push is exactly 1 byte long
2. Its value is >= 3

If detected, adjust the data start index to skip the version byte. Otherwise, parse using the legacy V1/V2 layout.

## Backward Compatibility

- V1/V2 projects have no version byte — parser recognizes them by the absence of the marker
- V3+ projects have the version byte — parser adjusts offsets accordingly
- No existing on-chain data is affected

## Testing

All 154 shared tests pass.