### PR TITLE
feat: add Show Logs button in Settings

### DIFF
--- a/src/design/App/UI/Sections/Settings/SettingsView.axaml
+++ b/src/design/App/UI/Sections/Settings/SettingsView.axaml
@@ -679,34 +679,55 @@
                                            FontSize="14"
                                            Foreground="{DynamicResource TextMuted}"
                                            TextWrapping="Wrap" />
-                                <Button HorizontalAlignment="Left"
-                                        Classes="MobileAction"
-                                        Padding="20,14"
-                                        Background="{DynamicResource GreenGradient}"
-                                        Foreground="White"
-                                        BorderThickness="0"
-                                        CornerRadius="8"
-                                        FontWeight="SemiBold"
-                                        FontSize="14"
-                                        IsEnabled="{Binding CanExportLogs}"
-                                        Click="OnExportLogsClick">
-                                    <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <i:Icon Value="fa-solid fa-file-export"
-                                                FontSize="16"
-                                                Foreground="White"
-                                                IsVisible="{Binding !IsExportingLogs}" />
-                                        <i:Icon Value="fa-solid fa-spinner"
-                                                FontSize="16"
-                                                Foreground="White"
-                                                IsVisible="{Binding IsExportingLogs}" />
-                                        <TextBlock Text="Exporting..."
-                                                   IsVisible="{Binding IsExportingLogs}"
-                                                   VerticalAlignment="Center" />
-                                        <TextBlock Text="Export Logs"
-                                                   IsVisible="{Binding !IsExportingLogs}"
-                                                   VerticalAlignment="Center" />
-                                    </StackPanel>
-                                </Button>
+                                <StackPanel Orientation="Horizontal" Spacing="12">
+                                    <Button HorizontalAlignment="Left"
+                                            Classes="MobileAction"
+                                            Padding="20,14"
+                                            Background="{DynamicResource GreenGradient}"
+                                            Foreground="White"
+                                            BorderThickness="0"
+                                            CornerRadius="8"
+                                            FontWeight="SemiBold"
+                                            FontSize="14"
+                                            IsEnabled="{Binding CanExportLogs}"
+                                            Click="OnExportLogsClick">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <i:Icon Value="fa-solid fa-file-export"
+                                                    FontSize="16"
+                                                    Foreground="White"
+                                                    IsVisible="{Binding !IsExportingLogs}" />
+                                            <i:Icon Value="fa-solid fa-spinner"
+                                                    FontSize="16"
+                                                    Foreground="White"
+                                                    IsVisible="{Binding IsExportingLogs}" />
+                                            <TextBlock Text="Exporting..."
+                                                       IsVisible="{Binding IsExportingLogs}"
+                                                       VerticalAlignment="Center" />
+                                            <TextBlock Text="Export Logs"
+                                                       IsVisible="{Binding !IsExportingLogs}"
+                                                       VerticalAlignment="Center" />
+                                        </StackPanel>
+                                    </Button>
+                                    <Button HorizontalAlignment="Left"
+                                            Classes="MobileAction"
+                                            Padding="20,14"
+                                            Background="Transparent"
+                                            Foreground="{DynamicResource TextStrong}"
+                                            BorderBrush="{DynamicResource Stroke}"
+                                            BorderThickness="1"
+                                            CornerRadius="8"
+                                            FontWeight="SemiBold"
+                                            FontSize="14"
+                                            Click="OnShowLogsClick">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <i:Icon Value="fa-solid fa-scroll"
+                                                    FontSize="16"
+                                                    Foreground="{DynamicResource TextStrong}" />
+                                            <TextBlock Text="Show Logs"
+                                                       VerticalAlignment="Center" />
+                                        </StackPanel>
+                                    </Button>
+                                </StackPanel>
                             </StackPanel>
                         </Border>
                     </StackPanel>

--- a/src/design/App/UI/Sections/Settings/SettingsView.axaml.cs
+++ b/src/design/App/UI/Sections/Settings/SettingsView.axaml.cs
@@ -312,6 +312,16 @@ public partial class SettingsView : UserControl, ISectionView
         }
     }
 
+    // ── Show Logs ──
+    private void OnShowLogsClick(object? sender, RoutedEventArgs e)
+    {
+        var shellVm = this.FindAncestorOfType<ShellView>()?.DataContext as ShellViewModel;
+        if (shellVm == null) return;
+
+        var modal = new LogViewerModal();
+        shellVm.ShowModal(modal);
+    }
+
     // ── Backup ──
     private async void OnRevealSeedClick(object? sender, RoutedEventArgs e)
     {

--- a/src/design/App/UI/Shared/Controls/LogViewerModal.axaml
+++ b/src/design/App/UI/Shared/Controls/LogViewerModal.axaml
@@ -53,25 +53,48 @@
                                Foreground="{DynamicResource TextMuted}"
                                VerticalAlignment="Center"
                                TextTrimming="CharacterEllipsis" />
-                    <Button Name="RefreshButton"
-                            DockPanel.Dock="Right"
-                            HorizontalAlignment="Right"
-                            Classes="MobileAction"
-                            Padding="12,8"
-                            Background="{DynamicResource GreenGradient}"
-                            Foreground="White"
-                            BorderThickness="0"
-                            CornerRadius="6"
-                            FontWeight="SemiBold"
-                            FontSize="13">
-                        <StackPanel Orientation="Horizontal" Spacing="6">
-                            <i:Icon Value="fa-solid fa-rotate-right"
-                                    FontSize="14"
-                                    Foreground="White" />
-                            <TextBlock Text="Refresh"
-                                       VerticalAlignment="Center" />
-                        </StackPanel>
-                    </Button>
+                    <StackPanel DockPanel.Dock="Right"
+                              Orientation="Horizontal"
+                              Spacing="8"
+                              HorizontalAlignment="Right">
+                        <Button Name="CopyLogsButton"
+                                Classes="MobileAction"
+                                Padding="12,8"
+                                Background="Transparent"
+                                Foreground="{DynamicResource TextStrong}"
+                                BorderBrush="{DynamicResource Stroke}"
+                                BorderThickness="1"
+                                CornerRadius="6"
+                                FontWeight="SemiBold"
+                                FontSize="13">
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <i:Icon Name="CopyIcon"
+                                        Value="fa-solid fa-copy"
+                                        FontSize="14"
+                                        Foreground="{DynamicResource TextStrong}" />
+                                <TextBlock Name="CopyButtonText"
+                                           Text="Copy"
+                                           VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+                        <Button Name="RefreshButton"
+                                Classes="MobileAction"
+                                Padding="12,8"
+                                Background="{DynamicResource GreenGradient}"
+                                Foreground="White"
+                                BorderThickness="0"
+                                CornerRadius="6"
+                                FontWeight="SemiBold"
+                                FontSize="13">
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <i:Icon Value="fa-solid fa-rotate-right"
+                                        FontSize="14"
+                                        Foreground="White" />
+                                <TextBlock Text="Refresh"
+                                           VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
                 </DockPanel>
             </Border>
 

--- a/src/design/App/UI/Shared/Controls/LogViewerModal.axaml
+++ b/src/design/App/UI/Shared/Controls/LogViewerModal.axaml
@@ -1,0 +1,92 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:i="https://github.com/projektanker/icons.avalonia"
+             mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="600"
+             x:Class="App.UI.Shared.Controls.LogViewerModal">
+
+    <Border Classes="ModalCard Wide"
+            CornerRadius="16"
+            Background="{DynamicResource CardSurface}"
+            BorderBrush="{DynamicResource Stroke}"
+            BorderThickness="1"
+            BoxShadow="0 8 32 0 #40000000"
+            ClipToBounds="True"
+            Padding="0"
+            MaxHeight="600">
+
+        <DockPanel>
+            <!-- ═══ Header ═══ -->
+            <Border DockPanel.Dock="Top"
+                    BorderBrush="{DynamicResource Stroke}"
+                    BorderThickness="0,0,0,1"
+                    Padding="24,16">
+                <Panel>
+                    <StackPanel Orientation="Horizontal" Spacing="12"
+                                VerticalAlignment="Center">
+                        <i:Icon Value="fa-solid fa-scroll"
+                                FontSize="20"
+                                Foreground="{DynamicResource PrimaryGreenBrush}" />
+                        <TextBlock Text="Application Logs"
+                                   FontSize="18"
+                                   FontWeight="Bold"
+                                   Foreground="{DynamicResource TextStrong}"
+                                   VerticalAlignment="Center" />
+                    </StackPanel>
+                    <Button Name="CloseButton"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Center"
+                            Classes="ModalCloseBtnSmall" />
+                </Panel>
+            </Border>
+
+            <!-- ═══ Footer ═══ -->
+            <Border DockPanel.Dock="Bottom"
+                    BorderBrush="{DynamicResource Stroke}"
+                    BorderThickness="0,1,0,0"
+                    Padding="24,12">
+                <DockPanel>
+                    <TextBlock Name="LogFilePathText"
+                               DockPanel.Dock="Left"
+                               FontSize="12"
+                               Foreground="{DynamicResource TextMuted}"
+                               VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis" />
+                    <Button Name="RefreshButton"
+                            DockPanel.Dock="Right"
+                            HorizontalAlignment="Right"
+                            Classes="MobileAction"
+                            Padding="12,8"
+                            Background="{DynamicResource GreenGradient}"
+                            Foreground="White"
+                            BorderThickness="0"
+                            CornerRadius="6"
+                            FontWeight="SemiBold"
+                            FontSize="13">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <i:Icon Value="fa-solid fa-rotate-right"
+                                    FontSize="14"
+                                    Foreground="White" />
+                            <TextBlock Text="Refresh"
+                                       VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                </DockPanel>
+            </Border>
+
+            <!-- ═══ Log Content ═══ -->
+            <ScrollViewer Name="LogScrollViewer"
+                          Padding="16"
+                          HorizontalScrollBarVisibility="Auto"
+                          VerticalScrollBarVisibility="Auto">
+                <TextBlock Name="LogContentText"
+                           FontFamily="Consolas, Menlo, monospace"
+                           FontSize="12"
+                           Foreground="{DynamicResource TextStrong}"
+                           TextWrapping="NoWrap"
+                           Text="Loading logs..." />
+            </ScrollViewer>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/src/design/App/UI/Shared/Controls/LogViewerModal.axaml.cs
+++ b/src/design/App/UI/Shared/Controls/LogViewerModal.axaml.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
+using App.UI.Shared.Helpers;
 using App.UI.Shell;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -32,6 +33,9 @@ public partial class LogViewerModal : UserControl, IBackdropCloseable
         var refreshBtn = this.FindControl<Button>("RefreshButton");
         if (refreshBtn != null) refreshBtn.Click += OnRefreshClick;
 
+        var copyBtn = this.FindControl<Button>("CopyLogsButton");
+        if (copyBtn != null) copyBtn.Click += OnCopyLogsClick;
+
         // Load logs on attach
         AttachedToVisualTree += (_, _) => LoadLatestLogs();
     }
@@ -47,6 +51,31 @@ public partial class LogViewerModal : UserControl, IBackdropCloseable
     private void OnRefreshClick(object? sender, RoutedEventArgs e)
     {
         LoadLatestLogs();
+    }
+
+    private async void OnCopyLogsClick(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var logContent = this.FindControl<TextBlock>("LogContentText");
+            var text = logContent?.Text;
+            if (string.IsNullOrWhiteSpace(text)) return;
+
+            ClipboardHelper.CopyToClipboard(this, text);
+
+            // Brief visual feedback
+            var copyText = this.FindControl<TextBlock>("CopyButtonText");
+            if (copyText != null)
+            {
+                copyText.Text = "Copied!";
+                await Task.Delay(2000);
+                copyText.Text = "Copy";
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to copy logs to clipboard");
+        }
     }
 
     private void LoadLatestLogs()

--- a/src/design/App/UI/Shared/Controls/LogViewerModal.axaml.cs
+++ b/src/design/App/UI/Shared/Controls/LogViewerModal.axaml.cs
@@ -1,0 +1,138 @@
+using System.IO;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using App.UI.Shell;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace App.UI.Shared.Controls;
+
+/// <summary>
+/// Log Viewer Modal — displays the latest application log file content
+/// in a scrollable monospace text view. Opened from Settings > Export Logs section.
+/// </summary>
+public partial class LogViewerModal : UserControl, IBackdropCloseable
+{
+    private readonly ILogger<LogViewerModal> _logger;
+    private string? _logFilePath;
+
+    /// <summary>
+    /// Parameterless constructor for XAML designer/loader.
+    /// </summary>
+    public LogViewerModal()
+    {
+        _logger = App.Services.GetRequiredService<ILoggerFactory>().CreateLogger<LogViewerModal>();
+
+        InitializeComponent();
+
+        var closeBtn = this.FindControl<Button>("CloseButton");
+        if (closeBtn != null) closeBtn.Click += OnCloseClick;
+
+        var refreshBtn = this.FindControl<Button>("RefreshButton");
+        if (refreshBtn != null) refreshBtn.Click += OnRefreshClick;
+
+        // Load logs on attach
+        AttachedToVisualTree += (_, _) => LoadLatestLogs();
+    }
+
+    public void OnBackdropCloseRequested() { }
+
+    private void OnCloseClick(object? sender, RoutedEventArgs e)
+    {
+        var shellVm = this.FindAncestorOfType<ShellView>()?.DataContext as ShellViewModel;
+        shellVm?.HideModal();
+    }
+
+    private void OnRefreshClick(object? sender, RoutedEventArgs e)
+    {
+        LoadLatestLogs();
+    }
+
+    private void LoadLatestLogs()
+    {
+        try
+        {
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (string.IsNullOrWhiteSpace(localAppData))
+            {
+                localAppData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            }
+
+            if (string.IsNullOrWhiteSpace(localAppData))
+            {
+                SetContent("Cannot determine application data directory.", null);
+                return;
+            }
+
+            var logsDir = Path.Combine(localAppData, "Angor", "logs");
+
+            if (!Directory.Exists(logsDir))
+            {
+                SetContent("No log directory found.", null);
+                return;
+            }
+
+            var logFiles = Directory.GetFiles(logsDir, "*.log");
+            if (logFiles.Length == 0)
+            {
+                SetContent("No log files found.", logsDir);
+                return;
+            }
+
+            // Pick the most recently modified log file
+            var latestLog = logFiles
+                .Select(f => new FileInfo(f))
+                .OrderByDescending(f => f.LastWriteTimeUtc)
+                .First();
+
+            _logFilePath = latestLog.FullName;
+
+            // Read the tail of the file (last ~200KB to keep UI responsive)
+            // Open with ReadWrite share since Serilog holds the file open
+            using var fileStream = new FileStream(
+                latestLog.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+            const long maxBytes = 200 * 1024;
+            if (fileStream.Length > maxBytes)
+            {
+                fileStream.Seek(-maxBytes, SeekOrigin.End);
+                // Skip partial line
+                using var reader = new StreamReader(fileStream);
+                reader.ReadLine(); // discard partial first line
+                var content = reader.ReadToEnd();
+                SetContent($"... (showing last ~200KB of {latestLog.Name})\n\n{content}", latestLog.FullName);
+            }
+            else
+            {
+                using var reader = new StreamReader(fileStream);
+                var content = reader.ReadToEnd();
+                SetContent(content, latestLog.FullName);
+            }
+
+            // Scroll to bottom
+            var scrollViewer = this.FindControl<ScrollViewer>("LogScrollViewer");
+            scrollViewer?.ScrollToEnd();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load logs");
+            SetContent($"Failed to load logs: {ex.Message}", null);
+        }
+    }
+
+    private void SetContent(string text, string? filePath)
+    {
+        var logContent = this.FindControl<TextBlock>("LogContentText");
+        if (logContent != null)
+        {
+            logContent.Text = string.IsNullOrWhiteSpace(text) ? "(empty)" : text;
+        }
+
+        var pathText = this.FindControl<TextBlock>("LogFilePathText");
+        if (pathText != null)
+        {
+            pathText.Text = filePath ?? "";
+        }
+    }
+}


### PR DESCRIPTION
Adds a **Show Logs** button next to the existing Export Logs button in Settings. Clicking it opens a modal overlay displaying the latest application log file in a scrollable monospace text view.

## Changes

- **New:** `LogViewerModal.axaml` / `.axaml.cs` — modal that reads the latest log file from `%LocalAppData%/Angor/logs/`, shows the tail (~200KB), with a Refresh button and file path display in the footer.
- **Modified:** `SettingsView.axaml` — added outlined Show Logs button alongside the Export Logs button in a horizontal StackPanel.
- **Modified:** `SettingsView.axaml.cs` — added `OnShowLogsClick` handler that opens the modal via `ShellViewModel.ShowModal()`.

## Notes

- Uses `ModalCard Wide` class for appropriate sizing (320–672px)
- Opens log file with `FileShare.ReadWrite` so it works while Serilog is writing
- Scrolls to the bottom on load to show the most recent entries
- No new dependencies added