### PR TITLE
fix: show project nsec/hex in Private Keys modal

### DIFF
--- a/src/design/App/Composition/CompositionRoot.cs
+++ b/src/design/App/Composition/CompositionRoot.cs
@@ -206,6 +206,7 @@ public static class CompositionRoot
                 sp.GetRequiredService<IProjectAppService>(),
                 sp.GetRequiredService<IProjectService>(),
                 sp.GetRequiredService<ICurrencyService>(),
+                sp.GetRequiredService<IWalletContext>(),
                 sp.GetRequiredService<ILoggerFactory>().CreateLogger<ManageProjectViewModel>()));
 
         services.AddSingleton<Func<MyProjectItemViewModel, EditProfileViewModel>>(sp =>

--- a/src/design/App/UI/Sections/MyProjects/ManageProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/ManageProjectViewModel.cs
@@ -9,6 +9,7 @@ using Angor.Sdk.Funding.Founder.Operations;
 using Angor.Sdk.Funding.Projects;
 using Angor.Sdk.Funding.Services;
 using Angor.Sdk.Funding.Shared;
+using App.UI.Shared.Services;
 using Nostr.Client.Utils;
 using Microsoft.Extensions.Logging;
 using ReactiveUI;
@@ -117,6 +118,7 @@ public partial class ManageProjectViewModel : ReactiveObject
     private readonly IProjectAppService _projectAppService;
     private readonly IProjectService _projectService;
     private readonly ICurrencyService _currencyService;
+    private readonly IWalletContext _walletContext;
     private readonly ILogger<ManageProjectViewModel> _logger;
 
     public event Action<string>? ToastRequested;
@@ -194,12 +196,14 @@ public partial class ManageProjectViewModel : ReactiveObject
         IProjectAppService projectAppService,
         IProjectService projectService,
         ICurrencyService currencyService,
+        IWalletContext walletContext,
         ILogger<ManageProjectViewModel> logger)
     {
         _founderAppService = founderAppService;
         _projectAppService = projectAppService;
         _projectService = projectService;
         _currencyService = currencyService;
+        _walletContext = walletContext;
         _logger = logger;
         Project = project;
         WalletPassword = "";
@@ -285,10 +289,43 @@ public partial class ManageProjectViewModel : ReactiveObject
             {
                 NostrNpub = NostrConverter.ToNpub(project.NostrPubKey) ?? project.NostrPubKey;
             }
+
+            // Derive the project nostr private key (nsec + hex) from the wallet seed
+            if (!string.IsNullOrEmpty(project.FounderKey))
+            {
+                await LoadNostrPrivateKeysAsync(project.FounderKey);
+            }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to load project keys for project {ProjectId}", Project.ProjectIdentifier);
+        }
+    }
+
+    /// <summary>
+    /// Derives the project-specific Nostr private key via the SDK.
+    /// Populates NostrNsec (bech32 nsec1...) and NostrHex (raw hex) fields.
+    /// </summary>
+    private async Task LoadNostrPrivateKeysAsync(string founderKey)
+    {
+        var selectedWallet = _walletContext.SelectedWallet;
+        if (selectedWallet == null)
+        {
+            _logger.LogWarning("No wallet selected — cannot derive project nostr private key");
+            return;
+        }
+
+        var result = await _founderAppService.GetFounderNsec(
+            new GetFounderNsec.GetFounderNsecRequest(selectedWallet.Id, founderKey));
+
+        if (result.IsSuccess)
+        {
+            NostrNsec = result.Value.Nsec;
+            NostrHex = result.Value.Hex;
+        }
+        else
+        {
+            _logger.LogWarning("Failed to derive project nostr private key: {Error}", result.Error);
         }
     }
 

--- a/src/sdk/Angor.Sdk/Funding/Founder/FounderAppService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/FounderAppService.cs
@@ -17,6 +17,8 @@ public class FounderAppService(IMediator mediator) : IFounderAppService
     public Task<Result<GetReleasableTransactions.GetReleasableTransactionsResponse>> GetReleasableTransactions(GetReleasableTransactions.GetReleasableTransactionsRequest request) => mediator.Send(request);
 
     public Task<Result<ReleaseFunds.ReleaseFundsResponse>> ReleaseFunds(ReleaseFunds.ReleaseFundsRequest request) => mediator.Send(request);
+
+    public Task<Result<GetFounderNsec.GetFounderNsecResponse>> GetFounderNsec(GetFounderNsec.GetFounderNsecRequest request) => mediator.Send(request);
     
     public Task<Result<CreateProjectKeys.CreateProjectKeysResponse>> CreateProjectKeys(CreateProjectKeys.CreateProjectKeysRequest request) => mediator.Send(request);
     

--- a/src/sdk/Angor.Sdk/Funding/Founder/IFounderAppService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/IFounderAppService.cs
@@ -11,6 +11,7 @@ public interface IFounderAppService
     Task<Result<GetClaimableTransactions.GetClaimableTransactionsResponse>> GetClaimableTransactions(GetClaimableTransactions.GetClaimableTransactionsRequest request);
     Task<Result<GetReleasableTransactions.GetReleasableTransactionsResponse>> GetReleasableTransactions(GetReleasableTransactions.GetReleasableTransactionsRequest request);
     Task<Result<ReleaseFunds.ReleaseFundsResponse>> ReleaseFunds(ReleaseFunds.ReleaseFundsRequest request);
+    Task<Result<GetFounderNsec.GetFounderNsecResponse>> GetFounderNsec(GetFounderNsec.GetFounderNsecRequest request);
   
     Task<Result<CreateProjectKeys.CreateProjectKeysResponse>> CreateProjectKeys(CreateProjectKeys.CreateProjectKeysRequest request);
     Task<Result<PublishFounderTransaction.PublishFounderTransactionResponse>> SubmitTransactionFromDraft(PublishFounderTransaction.PublishFounderTransactionRequest request);

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetFounderNsec.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetFounderNsec.cs
@@ -1,0 +1,41 @@
+using Angor.Sdk.Common;
+using Angor.Sdk.Funding.Shared;
+using Angor.Shared;
+using NBitcoin.DataEncoders;
+using CSharpFunctionalExtensions;
+using MediatR;
+using Nostr.Client.Utils;
+
+namespace Angor.Sdk.Funding.Founder.Operations;
+
+public static class GetFounderNsec
+{
+    public record GetFounderNsecRequest(WalletId WalletId, string FounderKey) : IRequest<Result<GetFounderNsecResponse>>;
+
+    public record GetFounderNsecResponse(string Nsec, string Hex);
+
+    public class GetFounderNsecHandler(
+        ISeedwordsProvider seedwordsProvider,
+        IDerivationOperations derivationOperations
+    ) : IRequestHandler<GetFounderNsecRequest, Result<GetFounderNsecResponse>>
+    {
+        public async Task<Result<GetFounderNsecResponse>> Handle(GetFounderNsecRequest request, CancellationToken cancellationToken)
+        {
+            var sensitiveDataResult = await seedwordsProvider.GetSensitiveData(request.WalletId.Value);
+
+            if (sensitiveDataResult.IsFailure)
+                return Result.Failure<GetFounderNsecResponse>(sensitiveDataResult.Error);
+
+            var nostrPrivateKey = await derivationOperations.DeriveProjectNostrPrivateKeyAsync(
+                sensitiveDataResult.Value.ToWalletWords(),
+                request.FounderKey);
+
+            var privateKeyHex = Encoders.Hex.EncodeData(nostrPrivateKey.ToBytes());
+
+            // Convert to nsec format using Nostr.Client library
+            var nsec = NostrConverter.ToNsec(privateKeyHex);
+
+            return Result.Success(new GetFounderNsecResponse(nsec, privateKeyHex));
+        }
+    }
+}


### PR DESCRIPTION
﻿## Problem

The **View Private Keys** modal in My Projects showed empty fields for the NOSTR private key (nsec) and NOSTR private key (hex). The LoadProjectKeysAsync method only loaded public keys (founder key, recovery key, npub) but never derived the private key from the wallet seed.

## Solution

- Added GetFounderNsec SDK operation (mirrors GetInvestorNsec) that derives the project nostr private key and returns both nsec (bech32) and hex formats
- Exposed GetFounderNsec via IFounderAppService
- ManageProjectViewModel now calls the SDK operation after loading the founder key, keeping all derivation logic in the SDK layer

## Changes

- **New:** src/sdk/Angor.Sdk/Funding/Founder/Operations/GetFounderNsec.cs
- **Modified:** IFounderAppService, FounderAppService, ManageProjectViewModel, CompositionRoot
