### PR TITLE
fix: include miner fee + angor fee in on-chain funding required amount

### DIFF
--- a/src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs
+++ b/src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs
@@ -705,6 +705,7 @@ public partial class InvestPageViewModel : ReactiveObject, IDisposable
             AmountSats = amountSats,
             StageCount = Stages.Count,
             FeeRateSatsPerVbyte = 20,
+            OnChainRequiredSatsOverride = PaymentFlowConfig.EstimateOnChainRequired(amountSats, Stages.Count, 20),
             Title = $"Pay to {actionVerb}",
             SuccessTitle = successTitle,
             SuccessDescription = $"Your {actionVerb.ToLowerInvariant()} of {FormattedAmount} {_currencyService.Symbol} has been submitted.",

--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowConfig.cs
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowConfig.cs
@@ -10,7 +10,7 @@ namespace App.UI.Shared.PaymentFlow;
 /// </summary>
 public record PaymentFlowConfig
 {
-    /// <summary>Amount to receive in satoshis.</summary>
+    /// <summary>Amount to receive in satoshis (the net investment/deploy amount).</summary>
     public required long AmountSats { get; init; }
 
     /// <summary>Number of stage outputs for Lightning swap fee estimation (0 if not applicable).</summary>
@@ -18,6 +18,45 @@ public record PaymentFlowConfig
 
     /// <summary>Default fee rate in sat/vB.</summary>
     public int FeeRateSatsPerVbyte { get; init; } = 20;
+
+    /// <summary>
+    /// Total on-chain amount the user must send when paying via on-chain invoice.
+    /// For investment flows, this must cover the investment amount + Angor fee + miner fee,
+    /// because the spending transaction is built exclusively from UTXOs on the funding address.
+    /// If null, defaults to <see cref="AmountSats"/> (suitable for flows like deploy where the
+    /// spending transaction is not restricted to the funding address).
+    /// </summary>
+    public long? OnChainRequiredSatsOverride { get; init; }
+
+    /// <summary>
+    /// Effective on-chain required amount: uses the explicit override if provided,
+    /// otherwise falls back to <see cref="AmountSats"/>.
+    /// </summary>
+    public long OnChainRequiredSats => OnChainRequiredSatsOverride ?? AmountSats;
+
+    /// <summary>
+    /// Calculates the total on-chain amount needed for an investment transaction,
+    /// including the Angor fee (1%) and estimated miner fee.
+    /// Use this as <see cref="OnChainRequiredSatsOverride"/> for investment flows.
+    /// </summary>
+    public static long EstimateOnChainRequired(long investmentAmountSats, int stageCount, int feeRateSatsPerVbyte)
+    {
+        const int AngorFeePercentage = 1;
+        long angorFee = (investmentAmountSats * AngorFeePercentage) / 100;
+
+        // Investment tx structure (same estimate as CreateLightningSwap):
+        //   ~10.5 vB  tx overhead
+        //   ~68   vB  1 P2WPKH input
+        //    43   vB  1 P2WSH output (angor fee)
+        //   ~99   vB  1 OP_RETURN output
+        //  N×43   vB  N P2TR stage outputs
+        //    31   vB  1 P2WPKH change output
+        // Total ≈ 252 + (stageCount × 43) vbytes
+        int estimatedTxVbytes = 252 + (stageCount * 43);
+        long estimatedMinerFee = feeRateSatsPerVbyte * estimatedTxVbytes;
+
+        return investmentAmountSats + angorFee + estimatedMinerFee;
+    }
 
     /// <summary>Title for the invoice screen, e.g. "Pay to Invest" or "Fund Deployment".</summary>
     public string Title { get; init; } = "Payment";

--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs
@@ -122,7 +122,7 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
     [Reactive] private string successDescription;
     public string SuccessButtonText => _config.SuccessButtonText;
     public string CurrencySymbol => _currencyService.Symbol;
-    public string AmountDisplay => $"{_config.AmountSats / 100_000_000m:F8} {_currencyService.Symbol}";
+    public string AmountDisplay => $"{_config.OnChainRequiredSats / 100_000_000m:F8} {_currencyService.Symbol}";
 
     // ── Wallets ──
     public ReadOnlyObservableCollection<WalletInfo> Wallets => _walletContext.Wallets;
@@ -275,7 +275,7 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
 
     private bool CanWalletPay(WalletInfo wallet)
     {
-        return wallet.AvailableSats >= _config.AmountSats;
+        return wallet.AvailableSats >= _config.OnChainRequiredSats;
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -565,7 +565,7 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
             PaymentStatusText = "Confirming on-chain claim...";
             var monitorAddressRequest = new MonitorOp.MonitorAddressForFundsRequest(
                 walletId, receivingAddress,
-                new Amount(_config.AmountSats),
+                new Amount(_config.OnChainRequiredSats),
                 TimeSpan.FromMinutes(30));
 
             var monitorAddressResult = await _investmentAppService.MonitorAddressForFunds(
@@ -696,7 +696,7 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
             var monitorRequest = new MonitorOp.MonitorAddressForFundsRequest(
                 walletId,
                 OnChainAddress,
-                new Amount(_config.AmountSats),
+                new Amount(_config.OnChainRequiredSats),
                 TimeSpan.FromMinutes(30));
 
             var monitorResult = await _investmentAppService.MonitorAddressForFunds(
@@ -855,7 +855,7 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
             PaymentStatusText = "Confirming on-chain claim...";
             var monitorAddressRequest = new MonitorOp.MonitorAddressForFundsRequest(
                 walletId, receivingAddress,
-                new Amount(_config.AmountSats),
+                new Amount(_config.OnChainRequiredSats),
                 TimeSpan.FromMinutes(30));
 
             var monitorAddressResult = await _investmentAppService.MonitorAddressForFunds(


### PR DESCRIPTION
﻿## Problem

When the user chooses **pay on-chain**, the app generates a receive address and tells the user how much to send. The required amount was calculated as just the investment amount (e.g. 6,400,000 sats). But when `BuildInvestmentDraft` later tries to sign the transaction using that UTXO, it needs **investment amount + Angor fee + miner fee** — since the spending transaction is built exclusively from UTXOs on that funding address. Since only exactly the investment amount was sent, signing fails with "Insufficient funds".

### Log evidence

```
15:47:44 MonitorAddressForFunds: required amount: 6400000 sats
15:48:35 AddressPollingService: Required amount met. Required: 6400000, Available: 6400000
15:49:05 BuildInvestmentDraftHandler: Found 1 UTXO totaling 6400000 sats
15:49:05 BuildInvestmentDraftHandler: Failed to sign - Required: 6408320 sats, Available: 6400000 sats
```

The gap (8,320 sats) is the mining fee for the investment transaction.

## Fix

Add `OnChainRequiredSats` to `PaymentFlowConfig` that estimates the total on-chain amount needed, using the same tx size formula as `CreateLightningSwap` (which already handled this correctly for the Lightning path):

- `investmentAmount` (net investment)
- `+ angorFee` (1% platform fee)
- `+ estimatedMinerFee` (based on tx vsize estimate)

The invest flow sets `OnChainRequiredSatsOverride` so the user is told to send enough to cover all costs. The deploy flow is unaffected (it doesn't set the override and doesn't restrict signing to the funding address).

### Fee calculation example

For a 6,400,000 sats investment with 3 stages at 20 sat/vB:

| Component | Calculation | Amount |
|-----------|------------|--------|
| Investment | — | 6,400,000 sats |
| Angor fee (1%) | 6,400,000 × 0.01 | 64,000 sats |
| Tx size estimate | 252 + (3 × 43) = 381 vB | — |
| Miner fee | 381 × 20 sat/vB | 7,620 sats |
| **Total required** | | **6,471,620 sats** |

The user is now asked to send **0.06471620 BTC** instead of 0.06400000 BTC, and signing succeeds.

## Files changed

- `src/design/App/UI/Shared/PaymentFlow/PaymentFlowConfig.cs` — added `OnChainRequiredSatsOverride`, `OnChainRequiredSats`, and `EstimateOnChainRequired()` helper
- `src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs` — use `OnChainRequiredSats` for monitoring, display, and wallet-can-pay check
- `src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs` — set the override when creating the payment flow config
