### PR TITLE
Fix investor npub display: show bech32 npub instead of raw hex

### DIFF
--- a/src/design/App/UI/Sections/Funders/FundersViewModel.cs
+++ b/src/design/App/UI/Sections/Funders/FundersViewModel.cs
@@ -7,6 +7,7 @@ using Angor.Sdk.Funding.Shared;
 using App.UI.Shared;
 using App.UI.Shared.Services;
 using Microsoft.Extensions.Logging;
+using Nostr.Client.Utils;
 
 namespace App.UI.Sections.Funders;
 
@@ -162,7 +163,7 @@ public partial class FundersViewModel : ReactiveObject, IDisposable
                                 Date = investment.CreatedOn.ToString("dd MMM yyyy"),
                                 Time = investment.CreatedOn.ToString("HH:mm"),
                                 Status = status,
-                                Npub = investment.InvestorNostrPubKey ?? "",
+                                Npub = NostrConverter.ToNpub(investment.InvestorNostrPubKey) ?? investment.InvestorNostrPubKey ?? "",
                                 EventId = investment.EventId ?? "",
                                 ProjectIdentifier = project.Id.Value,
                                 FounderWalletId = wallet.Id.Value,


### PR DESCRIPTION
The Funders view was displaying the raw hex public key instead of the bech32 npub format. This converts it using \NostrConverter.ToNpub()\, consistent with how npubs are displayed elsewhere in the app (e.g. ManageProjectViewModel, FunderItem in the Avalonia app).