### PR TITLE
fix: budget for up to 3 inputs in on-chain required amount estimate

### DIFF
--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowConfig.cs
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowConfig.cs
@@ -52,7 +52,16 @@ public record PaymentFlowConfig
         //  N×43   vB  N P2TR stage outputs
         //    31   vB  1 P2WPKH change output
         // Total ≈ 252 + (stageCount × 43) vbytes
-        int estimatedTxVbytes = 252 + (stageCount * 43);
+        //
+        // The signing code (AddInputsFromAddressAndSignTransaction) spends ALL UTXOs on the
+        // funding address and charges ~68 vB per input. Lightning claims always produce a
+        // single UTXO, but a user paying on-chain from an external wallet may deliver the
+        // funds as multiple UTXOs (two separate sends, exchange withdrawal splits, RBF
+        // leftovers). Budget for up to 3 inputs so signing still succeeds in those cases;
+        // any surplus is returned to the user's wallet as change.
+        const int MaxBudgetedInputs = 3;
+        const int InputVbytes = 68;
+        int estimatedTxVbytes = 252 + ((MaxBudgetedInputs - 1) * InputVbytes) + (stageCount * 43);
         long estimatedMinerFee = feeRateSatsPerVbyte * estimatedTxVbytes;
 
         return investmentAmountSats + angorFee + estimatedMinerFee;


### PR DESCRIPTION
## Problem

Follow-up to #923. The on-chain required amount estimate (\EstimateOnChainRequired\) assumes the payment arrives as **exactly one UTXO** (a single ~68 vB P2WPKH input is baked into the 252 vB constant).

But the signing path for on-chain invoice payments (\AddInputsFromAddressAndSignTransaction\ in \WalletOperations.cs\) spends **all** UTXOs on the funding address and charges ~68 vB per input:

\\\csharp
var estimatedSize = transaction.GetVirtualSize() + (availableUtxos.Count * 68);
\\\

\MonitorAddressForFunds\ aggregates UTXOs at the address, so if the user pays in two separate sends, or their exchange/wallet splits the withdrawal, monitoring declares the amount met — and then signing fails with 'Insufficient funds' because each extra input costs ~68 vB × feerate that was never budgeted.

Lightning claims (Boltz) always produce a single UTXO, so this only affects the **manual on-chain** path — explaining why the flow works sometimes and fails other times.

## Fix

Budget the miner-fee estimate for up to **3 inputs** (+136 vB, i.e. ~2,720 sats at 20 sat/vB). Any surplus is returned to the user's own wallet as change, so overestimating costs the user nothing.

A follow-up PR will add a dynamic recheck against the actual UTXO count at the funding address before building the draft (targeted at the next release).