### PR TITLE
feat: recheck on-chain required amount against actual UTXO count

### DIFF
--- a/src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs
+++ b/src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs
@@ -706,6 +706,8 @@ public partial class InvestPageViewModel : ReactiveObject, IDisposable
             StageCount = Stages.Count,
             FeeRateSatsPerVbyte = 20,
             OnChainRequiredSatsOverride = PaymentFlowConfig.EstimateOnChainRequired(amountSats, Stages.Count, 20),
+            OnChainRequiredForUtxoCount = utxoCount =>
+                PaymentFlowConfig.EstimateOnChainRequired(amountSats, Stages.Count, 20, utxoCount),
             Title = $"Pay to {actionVerb}",
             SuccessTitle = successTitle,
             SuccessDescription = $"Your {actionVerb.ToLowerInvariant()} of {FormattedAmount} {_currencyService.Symbol} has been submitted.",

--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowConfig.cs
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowConfig.cs
@@ -35,24 +35,44 @@ public record PaymentFlowConfig
     public long OnChainRequiredSats => OnChainRequiredSatsOverride ?? AmountSats;
 
     /// <summary>
+    /// Optional: recalculates the on-chain required amount for the actual number of UTXOs
+    /// detected on the funding address. The signing code spends ALL UTXOs on the address
+    /// and pays ~68 vB per input, so if the user pays in multiple transactions the required
+    /// amount grows with each extra input. When set, the payment flow rechecks the received
+    /// total against this after funds arrive and keeps monitoring for the shortfall instead
+    /// of failing at signing. Null = no recheck (flows not restricted to the funding address).
+    /// </summary>
+    public Func<int, long>? OnChainRequiredForUtxoCount { get; init; }
+
+    /// <summary>
     /// Calculates the total on-chain amount needed for an investment transaction,
     /// including the Angor fee (1%) and estimated miner fee.
     /// Use this as <see cref="OnChainRequiredSatsOverride"/> for investment flows.
     /// </summary>
     public static long EstimateOnChainRequired(long investmentAmountSats, int stageCount, int feeRateSatsPerVbyte)
+        => EstimateOnChainRequired(investmentAmountSats, stageCount, feeRateSatsPerVbyte, inputCount: 1);
+
+    /// <summary>
+    /// Calculates the total on-chain amount needed for an investment transaction for a
+    /// specific number of funding inputs. The signing transaction spends all UTXOs on the
+    /// funding address, so each extra UTXO adds ~68 vB of miner fee.
+    /// </summary>
+    public static long EstimateOnChainRequired(long investmentAmountSats, int stageCount, int feeRateSatsPerVbyte, int inputCount)
     {
         const int AngorFeePercentage = 1;
         long angorFee = (investmentAmountSats * AngorFeePercentage) / 100;
 
         // Investment tx structure (same estimate as CreateLightningSwap):
         //   ~10.5 vB  tx overhead
-        //   ~68   vB  1 P2WPKH input
+        //   ~68   vB  per P2WPKH input (first input included in the 252 constant)
         //    43   vB  1 P2WSH output (angor fee)
         //   ~99   vB  1 OP_RETURN output
         //  N×43   vB  N P2TR stage outputs
         //    31   vB  1 P2WPKH change output
-        // Total ≈ 252 + (stageCount × 43) vbytes
-        int estimatedTxVbytes = 252 + (stageCount * 43);
+        // Total ≈ 252 + ((inputCount − 1) × 68) + (stageCount × 43) vbytes
+        const int InputVbytes = 68;
+        int extraInputs = Math.Max(0, inputCount - 1);
+        int estimatedTxVbytes = 252 + (extraInputs * InputVbytes) + (stageCount * 43);
         long estimatedMinerFee = feeRateSatsPerVbyte * estimatedTxVbytes;
 
         return investmentAmountSats + angorFee + estimatedMinerFee;

--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs
@@ -715,6 +715,52 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
                 return;
             }
 
+            // The signing transaction spends ALL UTXOs on the funding address and pays a miner
+            // fee per input. If the payment arrived as multiple UTXOs (e.g. two separate sends),
+            // the originally displayed amount may no longer cover the fee. Recheck against the
+            // actual UTXO count and keep monitoring for the shortfall instead of failing later.
+            if (_config.OnChainRequiredForUtxoCount != null)
+            {
+                var received = monitorResult.Value.TotalAmount.Sats;
+                var utxoCount = monitorResult.Value.DetectedUtxos.Count;
+                var requiredForCount = _config.OnChainRequiredForUtxoCount(utxoCount);
+
+                while (received < requiredForCount)
+                {
+                    var shortfall = requiredForCount - received;
+                    _logger.LogWarning(
+                        "Funds received as {UtxoCount} UTXO(s) totaling {Received} sats, but {Required} sats are needed to cover the per-input miner fee. Waiting for {Shortfall} more sats.",
+                        utxoCount, received, requiredForCount, shortfall);
+                    PaymentStatusText = $"Payment arrived in {utxoCount} parts — network fees increased. Please send {shortfall:N0} sats more.";
+
+                    var topUpRequest = new MonitorOp.MonitorAddressForFundsRequest(
+                        walletId,
+                        OnChainAddress,
+                        new Amount(requiredForCount),
+                        TimeSpan.FromMinutes(30));
+
+                    var topUpResult = await _investmentAppService.MonitorAddressForFunds(
+                        topUpRequest, cts.Token);
+
+                    if (topUpResult.IsFailure)
+                    {
+                        if (cts.IsCancellationRequested)
+                        {
+                            _logger.LogInformation("On-chain top-up monitoring cancelled — suppressing error");
+                            return;
+                        }
+                        _logger.LogError("On-chain top-up monitor failed: {Error}", topUpResult.Error);
+                        ErrorMessage = "Your payment arrived in multiple parts, which increased the network fee. Please send the remaining amount shown above — your funds are safe.";
+                        IsProcessing = false;
+                        return;
+                    }
+
+                    received = topUpResult.Value.TotalAmount.Sats;
+                    utxoCount = topUpResult.Value.DetectedUtxos.Count;
+                    requiredForCount = _config.OnChainRequiredForUtxoCount(utxoCount);
+                }
+            }
+
             PaymentStatusText = "Payment received!";
             PaymentReceived = true;
 


### PR DESCRIPTION
## Problem

Follow-up to #923 and companion to #929 (this one targeted at the **next** release).

The estimate shown to the user assumes a fixed number of inputs, but the signing path (`AddInputsFromAddressAndSignTransaction`) spends **all** UTXOs on the funding address and pays ~68 vB per input. If the payment arrives as multiple UTXOs (two separate sends, exchange withdrawal splits, RBF leftovers), the paid amount can no longer cover the miner fee — `MonitorAddressForFunds` declares the payment received, then `BuildInvestmentDraft` fails with "Insufficient funds".

#929 mitigates this with a static 3-input buffer; this PR makes the flow correct for any UTXO count.

## Fix

- `PaymentFlowConfig.OnChainRequiredForUtxoCount` — optional delegate that recomputes the required total for the actual number of detected UTXOs.
- `EstimateOnChainRequired` overload accepting an `inputCount` (existing signature delegates with count 1, so #929's padding merges cleanly on top).
- `PaymentFlowViewModel.PayToOnChainAddressAsync` — after funds arrive, recheck against the actual UTXO count; if short, show the exact shortfall ("Payment arrived in N parts — please send X sats more") and keep monitoring for the top-up instead of proceeding to a signing failure.
- `InvestPageViewModel` wires the delegate (invest flow only; deploy is unaffected as it doesn't restrict signing to the funding address).

Lightning/Boltz claims always deliver a single UTXO, so the recheck loop is a no-op on that path.

## Known caveat

The top-up monitor reuses `MonitorAddressForFunds`, which (via the mempool polling service) tracks unconfirmed UTXOs. If the first payment confirms before the top-up arrives, the aggregate check may need revisiting — worth verifying with a signet UAT run before merging. Marked as draft for the next release accordingly.
