### PR TITLE
test: verify Penalties popup shows in-penalty investment in MultiFund UAT

### DIFF
--- a/src/design/App.Test.Uat/MultiFundClaimAndRecoverTest.cs
+++ b/src/design/App.Test.Uat/MultiFundClaimAndRecoverTest.cs
@@ -200,6 +200,9 @@ public class MultiFundClaimAndRecoverTest
         });
         recover3.Success.Should().BeTrue(recover3.Error);
 
+        // ── Investor3 is now "In Penalty": verify the Penalties popup on the Funded tab shows it ──
+        await VerifyPenaltiesPopupAsync(investor3Host, projectId, projectName);
+
         Log(Investor3Profile, "Claiming via penaltyRelease...");
         var penalty3 = await investor3Host.Client.ExecuteRecoveryAsync(new RecoveryRequest
         {
@@ -243,6 +246,61 @@ public class MultiFundClaimAndRecoverTest
         recover2.Success.Should().BeTrue(recover2.Error);
 
         Log(null, $"========== {nameof(MultiFundClaimAndRecover)} PASSED ==========");
+    }
+
+    /// <summary>
+    /// Opens the Penalties popup from the Funded tab and asserts it lists the investment
+    /// that was just recovered to penalty. Retries LoadPenaltiesAsync to absorb indexer lag.
+    /// </summary>
+    private static async Task VerifyPenaltiesPopupAsync(TestProcessHost host, string projectId, string projectName)
+    {
+        Log(Investor3Profile, "Opening Penalties popup to verify In Penalty entry...");
+        await host.Client.NavigateAsync("Funded");
+        await host.Client.WaitForControlAsync("PenaltiesButton", TimeSpan.FromSeconds(30));
+        await host.Client.ClickAsync("PenaltiesButton");
+
+        // PenaltiesModal is mounted in the shell modal overlay; its CloseButton confirms it opened
+        await host.Client.WaitForControlAsync("CloseButton", TimeSpan.FromSeconds(15));
+
+        // Clicking the button kicks off LoadPenaltiesAsync; wait for the initial load to finish,
+        // then retry the wallet-wide penalty scan until the entry appears (indexer may lag).
+        await host.Client.WaitForVmPropertyAsync(
+            "PortfolioViewModel", "IsLoadingPenalties", "False", TimeSpan.FromMinutes(2));
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(3);
+        while (DateTime.UtcNow < deadline)
+        {
+            var hasPenalties = await host.Client.GetVmPropertyAsync("PortfolioViewModel", "HasPenalties");
+            if (string.Equals(hasPenalties, "True", StringComparison.OrdinalIgnoreCase))
+            {
+                break;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            await host.Client.InvokeVmAsync("PortfolioViewModel", "LoadPenaltiesAsync");
+            await host.Client.WaitForVmPropertyAsync(
+                "PortfolioViewModel", "IsLoadingPenalties", "False", TimeSpan.FromMinutes(1));
+        }
+
+        var penaltyCount = await host.Client.GetVmPropertyAsync("PortfolioViewModel", "Penalties.Count");
+        penaltyCount.Should().Be("1", "the investor recovered exactly one investment to penalty");
+
+        var penaltyProjectId = await host.Client.GetVmPropertyAsync("PortfolioViewModel", "Penalties[0].ProjectIdentifier");
+        penaltyProjectId.Should().Be(projectId);
+
+        var penaltyProjectName = await host.Client.GetVmPropertyAsync("PortfolioViewModel", "Penalties[0].ProjectName");
+        penaltyProjectName.Should().Be(projectName);
+
+        var penaltyDaysRemaining = await host.Client.GetVmPropertyAsync("PortfolioViewModel", "Penalties[0].DaysRemaining");
+        penaltyDaysRemaining.Should().Be("0", "the project was created with PenaltyDays = 0");
+
+        var penaltyStatus = await host.Client.GetVmPropertyAsync("PortfolioViewModel", "Penalties[0].StatusText");
+        penaltyStatus.Should().Be("Penalty release available now");
+
+        Log(Investor3Profile, $"Penalties popup verified: {penaltyProjectName} ({penaltyProjectId}), status '{penaltyStatus}'");
+
+        // Close the popup so the subsequent penaltyRelease flow starts from a clean Funded tab
+        await host.Client.ClickAsync("CloseButton");
     }
 
     private static void Log(string? profileName, string message)


### PR DESCRIPTION
﻿## Summary

The Funded tab recently gained support for showing investments that are in penalty, but the UAT suite never exercised the Penalties popup. This adds a verification step to `MultiFundClaimAndRecoverTest` at the exact point where Investor3 has recovered to penalty (between the `recovery` and `penaltyRelease` actions).

The new step:
- Navigates to the Funded tab and clicks `PenaltiesButton` to open `PenaltiesModal`
- Waits for `PortfolioViewModel.LoadPenaltiesAsync` to finish, retrying the wallet-wide penalty scan to absorb indexer lag
- Asserts the popup lists exactly one penalty entry matching the test project (`ProjectIdentifier`, `ProjectName`), with `DaysRemaining == 0` and status `Penalty release available now` (project is created with `PenaltyDays = 0`)
- Closes the popup so the subsequent `penaltyRelease` flow starts clean

## Testing

```
dotnet test src/design/App.Test.Uat/App.Test.Uat.csproj --filter FullyQualifiedName~MultiFundClaimAndRecover
Passed App.Test.Uat.MultiFundClaimAndRecoverTest.MultiFundClaimAndRecover [5 m 7 s]
```
