### PR TITLE
fix: bundle native libraries into portable single-file exe

### DIFF
--- a/src/design/App.Desktop/App.Desktop.csproj
+++ b/src/design/App.Desktop/App.Desktop.csproj
@@ -8,6 +8,9 @@
         <PublishTrimmed>true</PublishTrimmed>
         <TrimMode>partial</TrimMode>
         <PublishSingleFile>true</PublishSingleFile>
+        <!-- Bundle native libs (libSkiaSharp, ANGLE, etc.) into the single-file exe.
+             Without this, the portable exe crashes with DllNotFoundException. -->
+        <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <PublishReadyToRun>true</PublishReadyToRun>
         <!-- SDK uses reflection-based System.Text.Json (FileStore, WalletFactory, AesWalletEncryption, etc.) -->
         <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>


### PR DESCRIPTION
## Problem
`Angor-*-win-x64-Portable.exe` crashes immediately on launch:

```n Unhandled exception. System.TypeInitializationException: The type initializer for 'SkiaSharp.SKImageInfo' threw an exception.
 ---> System.DllNotFoundException: Dll was not found.
```n
## Root cause
The portable artifact is built with `PublishSingleFile=true`, but without `IncludeNativeLibrariesForSelfExtract` the native libraries (libSkiaSharp.dll, HarfBuzz, ANGLE) are placed *next to* the exe instead of inside it. The release workflow copies only `Angor2.exe` into the portable artifact, leaving the native libs behind.

## Fix
Add `IncludeNativeLibrariesForSelfExtract=true` to the Release publish settings so native DLLs are embedded in the single-file exe.

## Verification
- Published locally with `dotnet publish -c Release -r win-x64 --self-contained`
- Confirmed no native .dll files remain beside the exe (all bundled)
- Copied only the exe to a clean directory and launched it — app starts and runs normally