### PR TITLE
Fix stale Find Projects list after network switch on mobile

### DIFF
--- a/src/design/App/Composition/CompositionRoot.cs
+++ b/src/design/App/Composition/CompositionRoot.cs
@@ -261,7 +261,9 @@ public static class CompositionRoot
                 prewarmLogger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("Prewarm");
 
                 await FindProjectsViewModel.LoadCachedDtosFromDiskAsync(
-                    provider.GetRequiredService<IStore>(), prewarmLogger);
+                    provider.GetRequiredService<IStore>(),
+                    networkConfig.GetNetwork().Name,
+                    prewarmLogger);
             }
             catch (Exception ex)
             {

--- a/src/design/App/UI/Sections/FindProjects/FindProjectsViewModel.cs
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsViewModel.cs
@@ -11,6 +11,7 @@ using Angor.Sdk.Funding.Projects;
 using Angor.Sdk.Funding.Projects.Dtos;
 using Angor.Sdk.Funding.Projects.Operations;
 using Angor.Sdk.Funding.Shared;
+using Angor.Shared;
 using Angor.Shared.Models;
 using Avalonia.Media.Imaging;
 using App.UI.Sections.Portfolio;
@@ -388,18 +389,36 @@ public partial class FindProjectsViewModel : ReactiveObject, IDisposable
     /// </summary>
     internal static IReadOnlyList<ProjectDto>? CachedDtos { get; set; }
 
-    internal const string CacheStoreKey = "findprojects_cache.json";
+    /// <summary>
+    /// Monotonically increasing token bumped on every network switch.
+    /// In-flight loads capture it at start and discard their results if it
+    /// changed by the time they complete, preventing a stale pre-switch
+    /// Latest() call from repopulating the list/caches with old-network data
+    /// (mobile keeps the same VM instance alive across a network switch).
+    /// </summary>
+    private static int loadGeneration;
+
+    /// <summary>Bump the load generation, invalidating all in-flight loads.</summary>
+    internal static void InvalidateInFlightLoads() => Interlocked.Increment(ref loadGeneration);
+
+    /// <summary>
+    /// Disk cache key, qualified by network name so a cache written on one
+    /// network is never seeded on another.
+    /// </summary>
+    internal static string CacheStoreKeyFor(string networkName) =>
+        $"findprojects_cache_{networkName.ToLowerInvariant()}.json";
 
     /// <summary>
     /// Load persisted DTO cache from disk into <see cref="CachedDtos"/>.
     /// Called from CompositionRoot on startup so the first tap seeds from disk.
     /// </summary>
-    internal static async Task LoadCachedDtosFromDiskAsync(IStore store, ILogger logger)
+    internal static async Task LoadCachedDtosFromDiskAsync(IStore store, string networkName, ILogger logger)
     {
-        logger.LogInformation("[FindProjects] disk-load: attempt key={Key}", CacheStoreKey);
+        var cacheStoreKey = CacheStoreKeyFor(networkName);
+        logger.LogInformation("[FindProjects] disk-load: attempt key={Key}", cacheStoreKey);
         try
         {
-            var result = await store.Load<List<ProjectDto>>(CacheStoreKey);
+            var result = await store.Load<List<ProjectDto>>(cacheStoreKey);
             if (!result.IsSuccess)
             {
                 logger.LogInformation("[FindProjects] disk-load: Load() returned failure: {Error}", result.Error);
@@ -428,12 +447,13 @@ public partial class FindProjectsViewModel : ReactiveObject, IDisposable
     /// Persist the current <see cref="CachedDtos"/> to disk for the next app launch.
     /// Fire-and-forget; failures are logged and swallowed.
     /// </summary>
-    internal static async Task SaveCachedDtosToDiskAsync(IStore store, IReadOnlyList<ProjectDto> dtos, ILogger logger)
+    internal static async Task SaveCachedDtosToDiskAsync(IStore store, string networkName, IReadOnlyList<ProjectDto> dtos, ILogger logger)
     {
-        logger.LogInformation("[FindProjects] disk-save: attempt count={Count} key={Key}", dtos.Count, CacheStoreKey);
+        var cacheStoreKey = CacheStoreKeyFor(networkName);
+        logger.LogInformation("[FindProjects] disk-save: attempt count={Count} key={Key}", dtos.Count, cacheStoreKey);
         try
         {
-            var result = await store.Save(CacheStoreKey, dtos.ToList());
+            var result = await store.Save(cacheStoreKey, dtos.ToList());
             if (result.IsSuccess)
                 logger.LogInformation("[FindProjects] disk-save: SUCCESS wrote {Count} projects", dtos.Count);
             else
@@ -735,6 +755,10 @@ public partial class FindProjectsViewModel : ReactiveObject, IDisposable
     /// </summary>
     public void ResetAfterNetworkSwitch()
     {
+        // Invalidate any in-flight Latest() call from before the switch so it
+        // cannot repopulate Projects/CachedDtos/disk cache with old-network data
+        // (on mobile this VM instance stays alive across the switch).
+        InvalidateInFlightLoads();
         CloseInvestPage();
         CloseProjectDetail();
         CachedDtos = null;
@@ -747,6 +771,10 @@ public partial class FindProjectsViewModel : ReactiveObject, IDisposable
 
     public async Task LoadProjectsFromSdkAsync()
     {
+        // Capture the generation and network at start; if a network switch
+        // happens while Latest() is in flight, the results are discarded.
+        var generation = Volatile.Read(ref loadGeneration);
+        var networkName = App.Services.GetRequiredService<INetworkConfiguration>().GetNetwork().Name;
         var pl = App.Services.GetRequiredService<ILoggerFactory>().CreateLogger("ProjectsLoad");
         var sw = System.Diagnostics.Stopwatch.StartNew();
         pl.LogInformation("[ProjectsLoad] t=0ms begin");
@@ -785,6 +813,15 @@ public partial class FindProjectsViewModel : ReactiveObject, IDisposable
 
             if (result.IsSuccess)
             {
+                // A network switch happened while Latest() was in flight: these
+                // results belong to the old network — discard them entirely.
+                if (generation != Volatile.Read(ref loadGeneration))
+                {
+                    pl.LogWarning("[ProjectsLoad] t={T}ms discarding stale results (network switched mid-load, gen {Old} != {New})",
+                        sw.ElapsedMilliseconds, generation, Volatile.Read(ref loadGeneration));
+                    return;
+                }
+
                 var dtos = result.Value.Projects;
                 var dtoCount = dtos.Count();
                 pl.LogInformation("[ProjectsLoad] t={T}ms got {Count} dtos", sw.ElapsedMilliseconds, dtoCount);
@@ -798,6 +835,7 @@ public partial class FindProjectsViewModel : ReactiveObject, IDisposable
                 // instantly while the SDK fetch runs in background.
                 _ = SaveCachedDtosToDiskAsync(
                     App.Services.GetRequiredService<IStore>(),
+                    networkName,
                     cachedCopy,
                     App.Services.GetRequiredService<ILoggerFactory>().CreateLogger("FindProjectsCache"));
 

--- a/src/design/App/UI/Sections/FindProjects/FindProjectsViewModel.cs
+++ b/src/design/App/UI/Sections/FindProjects/FindProjectsViewModel.cs
@@ -379,7 +379,7 @@ public class ProjectItemViewModel : INotifyPropertyChanged
 /// FindProjects ViewModel -- connected to SDK for project discovery.
 /// Falls back to sample data if SDK call fails.
 /// </summary>
-public partial class FindProjectsViewModel : ReactiveObject, IDisposable
+public partial class FindProjectsViewModel : ReactiveObject, IDisposable, INetworkSwitchAware
 {
     /// <summary>
     /// Process-wide cache of the last successful Latest() DTOs.

--- a/src/design/App/UI/Sections/Funders/FundersViewModel.cs
+++ b/src/design/App/UI/Sections/Funders/FundersViewModel.cs
@@ -66,7 +66,7 @@ public partial class SignatureRequestViewModel : ReactiveObject
 /// instant; a background sync then refreshes relays and pushes updates in.
 /// Approval goes through IFounderAppService.ApproveInvestment().
 /// </summary>
-public partial class FundersViewModel : ReactiveObject, IDisposable
+public partial class FundersViewModel : ReactiveObject, IDisposable, INetworkSwitchAware
 {
     private readonly IFounderAppService _founderAppService;
     private readonly FundersMonitor _fundersMonitor;
@@ -237,6 +237,24 @@ public partial class FundersViewModel : ReactiveObject, IDisposable
         _sdkSignatures.AddRange(signatures);
 
         _cachedAllViewModels = null;
+        UpdateFilteredSignatures();
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Clears all funder state derived from the previous network. The shared
+    /// <see cref="FundersMonitor"/> is reset separately by the shell; its
+    /// Updated event then rebuilds this VM from the (now empty) snapshot.
+    /// </remarks>
+    public void ResetAfterNetworkSwitch()
+    {
+        _sdkSignatures.Clear();
+        _locallyRejected.Clear();
+        _expandedEventIds.Clear();
+        _cachedAllViewModels = null;
+        HasEverLoaded = false;
+        IsLoading = false;
+        IsRefreshing = false;
         UpdateFilteredSignatures();
     }
 

--- a/src/design/App/UI/Sections/Funds/FundsViewModel.cs
+++ b/src/design/App/UI/Sections/Funds/FundsViewModel.cs
@@ -26,7 +26,7 @@ public class SeedGroupViewModel
 /// Funds ViewModel — connected to Angor.SDK wallet services.
 /// Uses <see cref="IWalletContext"/> for wallet state and <see cref="IWalletAppService"/> for wallet operations.
 /// </summary>
-public partial class FundsViewModel : ReactiveObject, IDisposable
+public partial class FundsViewModel : ReactiveObject, IDisposable, INetworkSwitchAware
 {
     private readonly IWalletAppService _walletAppService;
     private readonly IWalletAccountBalanceService _balanceService;
@@ -224,6 +224,9 @@ public partial class FundsViewModel : ReactiveObject, IDisposable
         this.RaisePropertyChanged(nameof(DefaultWalletName));
         this.RaisePropertyChanged(nameof(CurrencySymbol));
     }
+
+    /// <inheritdoc />
+    public void ResetAfterNetworkSwitch() => RefreshNetworkState();
 
     /// <summary>
     /// Create a new wallet using the SDK.

--- a/src/design/App/UI/Sections/MyProjects/MyProjectsViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/MyProjectsViewModel.cs
@@ -52,7 +52,7 @@ public class MyProjectItemViewModel
 /// My Projects ViewModel — connected to SDK for founder project discovery and management.
 /// Uses IProjectAppService.GetFounderProjects() to load projects owned by the user.
 /// </summary>
-public partial class MyProjectsViewModel : ReactiveObject, IDisposable
+public partial class MyProjectsViewModel : ReactiveObject, IDisposable, INetworkSwitchAware
 {
     private readonly IProjectAppService _projectAppService;
     private readonly IWalletContext _walletContext;
@@ -351,6 +351,9 @@ public partial class MyProjectsViewModel : ReactiveObject, IDisposable
         Interlocked.Increment(ref _loadGeneration);
         IsLoading = false;
         ClearProjects();
+        // On mobile the view stays alive and only reloads via OnBecameActive()
+        // when this flag is set — without it the tab would stay empty/stale.
+        NeedsRefresh = true;
     }
 
     public void OpenManageProject(MyProjectItemViewModel project)

--- a/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
@@ -519,7 +519,7 @@ public class InvestmentViewModel : INotifyPropertyChanged
 /// Portfolio/Funded ViewModel — connected to SDK for investment discovery and management.
 /// Uses IInvestmentAppService for loading investments and performing recovery/release operations.
 /// </summary>
-public partial class PortfolioViewModel : ReactiveObject, IDisposable
+public partial class PortfolioViewModel : ReactiveObject, IDisposable, INetworkSwitchAware
 {
     private readonly IInvestmentAppService _investmentAppService;
     private readonly Angor.Sdk.Funding.Projects.IProjectAppService _projectAppService;
@@ -1386,6 +1386,13 @@ public partial class PortfolioViewModel : ReactiveObject, IDisposable
 
     public void ResetAfterDataWipe()
     {
+        ClearToEmpty();
+    }
+
+    /// <inheritdoc />
+    public void ResetAfterNetworkSwitch()
+    {
+        CloseInvestmentDetail();
         ClearToEmpty();
     }
 

--- a/src/design/App/UI/Sections/Settings/SettingsViewModel.cs
+++ b/src/design/App/UI/Sections/Settings/SettingsViewModel.cs
@@ -26,6 +26,7 @@ public partial class SettingsViewModel : ReactiveObject, IDisposable
     private readonly INetworkStorage _networkStorage;
     private readonly IWalletAppService _walletAppService;
     private readonly IDatabaseManagementService _databaseManagementService;
+    private readonly INostrCommunicationFactory _nostrCommunicationFactory;
     private readonly ICurrencyService _currencyService;
     private readonly IWalletContext _walletContext;
     private readonly ILogExportService _logExportService;
@@ -140,6 +141,7 @@ public partial class SettingsViewModel : ReactiveObject, IDisposable
         INetworkStorage networkStorage,
         IWalletAppService walletAppService,
         IDatabaseManagementService databaseManagementService,
+        INostrCommunicationFactory nostrCommunicationFactory,
         PrototypeSettings prototypeSettings,
         ICurrencyService currencyService,
         IWalletContext walletContext,
@@ -154,6 +156,7 @@ public partial class SettingsViewModel : ReactiveObject, IDisposable
         _networkStorage = networkStorage;
         _walletAppService = walletAppService;
         _databaseManagementService = databaseManagementService;
+        _nostrCommunicationFactory = nostrCommunicationFactory;
         _prototypeSettings = prototypeSettings;
         _currencyService = currencyService;
         _walletContext = walletContext;
@@ -318,6 +321,11 @@ public partial class SettingsViewModel : ReactiveObject, IDisposable
 
         // Persist new network to SDK storage.
         _networkStorage.SetNetwork(newNetwork);
+
+        // Tear down the shared Nostr multi-websocket client so old-network relay
+        // connections don't keep streaming events; it is lazily rebuilt with the
+        // new network's relays on the next GetOrCreateClient call.
+        _nostrCommunicationFactory.CloseClientConnection();
 
         // Clear settings for the new network.
         _networkStorage.SetSettings(new SettingsInfo());

--- a/src/design/App/UI/Sections/Settings/SettingsViewModel.cs
+++ b/src/design/App/UI/Sections/Settings/SettingsViewModel.cs
@@ -302,8 +302,10 @@ public partial class SettingsViewModel : ReactiveObject, IDisposable
 
             ToastRequested?.Invoke("Network updated successfully.");
 
-            if (!OperatingSystem.IsAndroid() && !OperatingSystem.IsIOS())
-                _ = RebuildWalletsAfterNetworkSwitchAsync();
+            // Rebuild wallet balances for the new network on all platforms.
+            // This used to be desktop-only, which left mobile showing
+            // balances/UTXOs derived from the previous network.
+            _ = RebuildWalletsAfterNetworkSwitchAsync();
         }
         finally
         {

--- a/src/design/App/UI/Shared/INetworkSwitchAware.cs
+++ b/src/design/App/UI/Shared/INetworkSwitchAware.cs
@@ -1,0 +1,21 @@
+namespace App.UI.Shared;
+
+/// <summary>
+/// Implemented by section ViewModels that hold network-derived state.
+///
+/// On mobile the shell keeps all section views (and their ViewModels) alive
+/// across a network switch — the view cache is only cleared on desktop — so
+/// every VM with network-derived state must reset itself explicitly.
+/// <see cref="Shell.ShellViewModel.ResetAfterNetworkSwitch"/> iterates the
+/// view cache and calls this on every DataContext that implements it, which
+/// removes the need for a hand-maintained per-section reset list.
+/// </summary>
+public interface INetworkSwitchAware
+{
+    /// <summary>
+    /// Clear all state derived from the previous network and, where
+    /// appropriate, kick off a reload for the new network. Called on the UI
+    /// thread immediately after the network configuration has been switched.
+    /// </summary>
+    void ResetAfterNetworkSwitch();
+}

--- a/src/design/App/UI/Shared/Services/FundersMonitor.cs
+++ b/src/design/App/UI/Shared/Services/FundersMonitor.cs
@@ -222,6 +222,25 @@ public sealed class FundersMonitor : IDisposable
     }
 
     /// <summary>
+    /// Drop all state derived from the previous network (snapshot, change-detection
+    /// baseline, optimistic overlays). Called by the shell on a network switch so
+    /// stale funder records never survive into the new network; the next poll or
+    /// explicit RefreshAsync rebuilds the snapshot from the new network's data.
+    /// </summary>
+    public void Reset()
+    {
+        lock (_stateLock)
+        {
+            _snapshot = Array.Empty<FunderRecord>();
+            _previousStatuses = null;
+            _locallyApproved.Clear();
+            HasLoaded = false;
+        }
+
+        Avalonia.Threading.Dispatcher.UIThread.Post(() => Updated?.Invoke());
+    }
+
+    /// <summary>
     /// Mark a request as approved locally (optimistic). The snapshot keeps reporting
     /// the synced status, but <see cref="EffectiveStatus"/> overlays this until the
     /// approval DM is visible on relays — prevents the badge/tab flipping back to

--- a/src/design/App/UI/Shell/ShellViewModel.cs
+++ b/src/design/App/UI/Shell/ShellViewModel.cs
@@ -1323,27 +1323,24 @@ public partial class ShellViewModel : ReactiveObject, IDisposable
         const string settingsKey = "Settings";
 
         _signatureStore.Clear();
-        _portfolioVm.ResetAfterDataWipe();
+        _fundersMonitor.Reset();
+        // PortfolioViewModel is a singleton that may not (yet) be in the view
+        // cache, so reset it directly rather than relying on the cache sweep.
+        _portfolioVm.ResetAfterNetworkSwitch();
         InvestedBalanceDisplay = "0.0000 " + _currencyService.Symbol;
         ModalContent = null;
         IsModalOpen = false;
 
-        if (_viewCache.TryGetValue("My Projects", out object? myProjectsView)
-            && myProjectsView is MyProjectsView { DataContext: MyProjectsViewModel myProjectsVm })
+        // Reset every cached section VM that holds network-derived state.
+        // Crucial on mobile, where the view cache is kept alive (SectionPanel
+        // owns the views) and the same VM instances survive the switch.
+        foreach (object view in _viewCache.Values)
         {
-            myProjectsVm.ResetAfterNetworkSwitch();
-        }
-
-        if (_viewCache.TryGetValue("Find Projects", out object? findProjectsView)
-            && findProjectsView is FindProjectsView { DataContext: FindProjectsViewModel findProjectsVm })
-        {
-            findProjectsVm.ResetAfterNetworkSwitch();
-        }
-
-        if (_viewCache.TryGetValue("Funds", out object? fundsView)
-            && fundsView is FundsView { DataContext: FundsViewModel fundsVm })
-        {
-            fundsVm.RefreshNetworkState();
+            if (view is StyledElement { DataContext: INetworkSwitchAware aware }
+                && !ReferenceEquals(aware, _portfolioVm))
+            {
+                aware.ResetAfterNetworkSwitch();
+            }
         }
 
         if (!OperatingSystem.IsAndroid() && !OperatingSystem.IsIOS())


### PR DESCRIPTION
## Problem

On mobile, switching Bitcoin network in Settings left the **Find Projects** tab showing projects from the previous network. Desktop was unaffected. A follow-up audit found the same stale-state class of bug across other sections on mobile.

## Root causes

- On mobile the shell keeps cached views alive across a network switch (`ShellViewModel.ResetAfterNetworkSwitch` only clears the view cache on desktop), so the same VM instances survive the switch. Only 3 sections were in the hand-maintained reset list.
- `LoadProjectsFromSdkAsync` had no cancellation/generation guard. Nostr relay queries take 10-15s, so a `Latest()` call started **before** the switch could complete **after** it, repopulating `Projects`, the static `CachedDtos` seed, and the disk cache with old-network data (last-writer-wins).
- The disk cache `findprojects_cache.json` was not keyed by network, so the poisoned cache re-seeded stale projects on subsequent visits and app launches.
- `NostrCommunicationFactory` never dropped old-network relay websockets on switch.
- Wallet rebuild after a network switch was desktop-only (since #810), leaving stale balances/UTXOs on mobile.
- The singleton `FundersMonitor` snapshot was never reset, so old-network funder records survived on mobile.

## Fixes

**Commit 1 — Find Projects stale list**
- Load-generation token bumped by `ResetAfterNetworkSwitch()`; `LoadProjectsFromSdkAsync` discards results if it changed while `Latest()` was in flight.
- Disk cache keyed by network name (`findprojects_cache_{network}.json`).
- `INostrCommunicationFactory.CloseClientConnection()` called in `SwitchNetworkStorageAsync`; the client is lazily rebuilt with the new network's relays.

**Commit 2 — systematic reset across sections**
- New `INetworkSwitchAware` interface; the shell sweeps the view cache and resets **every** cached VM implementing it (FindProjects, MyProjects, Funds, Portfolio, Funders), replacing the per-section reset list. New sections get reset automatically.
- `FundersMonitor.Reset()` drops the snapshot/change baseline/optimistic overlays on switch.
- `RebuildWalletsAfterNetworkSwitchAsync` now runs on mobile too.
- `MyProjectsViewModel` reset sets `NeedsRefresh` so the mobile `OnBecameActive` path reloads founder projects.

## Testing

- `dotnet build src/design/App/App.csproj` and `App.Desktop` build clean.