### PR TITLE
Founder auto-approve for investment signing requests

### DIFF
--- a/src/design/App/UI/Sections/Funders/FundersView.axaml
+++ b/src/design/App/UI/Sections/Funders/FundersView.axaml
@@ -211,6 +211,36 @@
                     </i:Icon.Styles>
                 </i:Icon>
             </Button>
+            <!-- Auto-approve toggle — available even before the first request arrives -->
+            <Border Background="{DynamicResource Surface}"
+                    BorderBrush="{DynamicResource Stroke}"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Padding="16,12"
+                    Margin="24"
+                    MaxWidth="480"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Bottom">
+                <DockPanel>
+                    <ToggleSwitch Name="EmptyAutoApproveToggle"
+                                  DockPanel.Dock="Right"
+                                  IsChecked="{Binding AutoApproveEnabled}"
+                                  OnContent="{x:Null}"
+                                  OffContent="{x:Null}"
+                                  VerticalAlignment="Center"
+                                  Margin="12,0,0,0" />
+                    <StackPanel Spacing="2" VerticalAlignment="Center">
+                        <TextBlock Text="Auto-approve requests"
+                                   FontSize="14"
+                                   FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextStrong}" />
+                        <TextBlock Text="New funding requests are checked and approved automatically in the background"
+                                   FontSize="12"
+                                   Foreground="{DynamicResource TextMuted}"
+                                   TextWrapping="Wrap" />
+                    </StackPanel>
+                </DockPanel>
+            </Border>
         </Panel>
 
         <!-- ═══════════════════════════════════════════════════════ -->
@@ -307,6 +337,39 @@
                     </Button>
                     </StackPanel>
                 </DockPanel>
+
+                <!-- ═══════════════════════════════════════ -->
+                <!-- AUTO-APPROVE TOGGLE                     -->
+                <!-- Background worker (FundersMonitor)      -->
+                <!-- approves new requests automatically      -->
+                <!-- ═══════════════════════════════════════ -->
+                <Border Background="{DynamicResource Surface}"
+                        BorderBrush="{DynamicResource Stroke}"
+                        BorderThickness="1"
+                        CornerRadius="12"
+                        Padding="16,12"
+                        Margin="0,0,0,16">
+                    <DockPanel>
+                        <ToggleSwitch Name="AutoApproveToggle"
+                                      AutomationProperties.AutomationId="FundersAutoApproveToggle"
+                                      DockPanel.Dock="Right"
+                                      IsChecked="{Binding AutoApproveEnabled}"
+                                      OnContent="{x:Null}"
+                                      OffContent="{x:Null}"
+                                      VerticalAlignment="Center"
+                                      Margin="12,0,0,0" />
+                        <StackPanel Spacing="2" VerticalAlignment="Center">
+                            <TextBlock Text="Auto-approve requests"
+                                       FontSize="14"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextStrong}" />
+                            <TextBlock Text="New funding requests are checked and approved automatically in the background"
+                                       FontSize="12"
+                                       Foreground="{DynamicResource TextMuted}"
+                                       TextWrapping="Wrap" />
+                        </StackPanel>
+                    </DockPanel>
+                </Border>
 
                 <!-- ═══════════════════════════════════════ -->
                 <!-- FILTER TABS                             -->

--- a/src/design/App/UI/Sections/Funders/FundersViewModel.cs
+++ b/src/design/App/UI/Sections/Funders/FundersViewModel.cs
@@ -6,6 +6,7 @@ using Angor.Sdk.Funding.Projects;
 using Angor.Sdk.Funding.Shared;
 using App.UI.Shared;
 using App.UI.Shared.Services;
+using App.UI.Shell;
 using Microsoft.Extensions.Logging;
 using Nostr.Client.Utils;
 
@@ -71,6 +72,7 @@ public partial class FundersViewModel : ReactiveObject, IDisposable
     private readonly IFounderAppService _founderAppService;
     private readonly FundersMonitor _fundersMonitor;
     private readonly ICurrencyService _currencyService;
+    private readonly PrototypeSettings _settings;
     private readonly ILogger<FundersViewModel> _logger;
 
     [Reactive] private bool hasFunders;
@@ -119,12 +121,19 @@ public partial class FundersViewModel : ReactiveObject, IDisposable
         IFounderAppService founderAppService,
         FundersMonitor fundersMonitor,
         ICurrencyService currencyService,
+        PrototypeSettings settings,
         ILogger<FundersViewModel> logger)
     {
         _founderAppService = founderAppService;
         _fundersMonitor = fundersMonitor;
         _currencyService = currencyService;
+        _settings = settings;
         _logger = logger;
+
+        // Reflect settings changes (including the async load at startup) into the toggle.
+        _settings.WhenAnyValue(x => x.IsAutoApproveEnabled)
+            .Subscribe(_ => this.RaisePropertyChanged(nameof(AutoApproveEnabled)))
+            .DisposeWith(_disposables);
 
         this.WhenAnyValue(x => x.CurrentFilter)
             .Subscribe(_ => UpdateFilteredSignatures())
@@ -152,6 +161,18 @@ public partial class FundersViewModel : ReactiveObject, IDisposable
     }
 
     private void OnMonitorUpdated() => RebuildFromSnapshot();
+
+    /// <summary>
+    /// Founder auto-approve toggle. Persisted via <see cref="PrototypeSettings"/>;
+    /// the background <see cref="FundersMonitor"/> reacts to it — switching it on
+    /// triggers an immediate refresh + approval of everything pending, and every
+    /// subsequent background poll approves new requests as they arrive.
+    /// </summary>
+    public bool AutoApproveEnabled
+    {
+        get => _settings.IsAutoApproveEnabled;
+        set => _settings.IsAutoApproveEnabled = value;
+    }
 
     /// <summary>
     /// Load investment requests. If the monitor already has a warm snapshot the tab

--- a/src/design/App/UI/Shared/Services/FundersMonitor.cs
+++ b/src/design/App/UI/Shared/Services/FundersMonitor.cs
@@ -3,6 +3,8 @@ using Angor.Sdk.Common;
 using Angor.Sdk.Funding.Founder;
 using Angor.Sdk.Funding.Founder.Operations;
 using Angor.Sdk.Funding.Projects;
+using Angor.Sdk.Funding.Shared;
+using App.UI.Shell;
 using Microsoft.Extensions.Logging;
 
 namespace App.UI.Shared.Services;
@@ -37,11 +39,19 @@ public record FunderRecord(
 /// </summary>
 public sealed class FundersMonitor : IDisposable
 {
-    private static readonly TimeSpan PollInterval = TimeSpan.FromMinutes(2);
+    /// <summary>Baseline poll interval. Each poll re-sends REQ filters on the already-open
+    /// relay websockets (EOSE usually within a few seconds), so polling is cheap; the
+    /// refresh lock coalesces overlaps if a sync ever runs longer than the interval.</summary>
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMinutes(1);
+
+    /// <summary>Faster cadence while auto-approve is on — an investor is actively waiting
+    /// for the founder's signatures, so keep their wait short.</summary>
+    private static readonly TimeSpan AutoApprovePollInterval = TimeSpan.FromSeconds(30);
 
     private readonly IFounderAppService _founderAppService;
     private readonly IProjectAppService _projectAppService;
     private readonly IWalletContext _walletContext;
+    private readonly PrototypeSettings _settings;
     private readonly ILogger<FundersMonitor> _logger;
 
     private readonly SemaphoreSlim _refreshLock = new(1, 1);
@@ -85,11 +95,13 @@ public sealed class FundersMonitor : IDisposable
         IFounderAppService founderAppService,
         IProjectAppService projectAppService,
         IWalletContext walletContext,
+        PrototypeSettings settings,
         ILogger<FundersMonitor> logger)
     {
         _founderAppService = founderAppService;
         _projectAppService = projectAppService;
         _walletContext = walletContext;
+        _settings = settings;
         _logger = logger;
     }
 
@@ -110,6 +122,16 @@ public sealed class FundersMonitor : IDisposable
             .Subscribe(unit => { _ = RefreshAsync(); })
             .DisposeWith(_disposables);
 
+        // When the founder switches auto-approve on, run a refresh immediately so any
+        // requests already waiting get approved without waiting for the next poll.
+        // The relay websockets stay open between polls (auto-reconnect after 30s if
+        // dropped); each refresh just re-sends the REQ filters on the existing client.
+        _settings.WhenAnyValue(x => x.IsAutoApproveEnabled)
+            .DistinctUntilChanged()
+            .Where(enabled => enabled)
+            .Subscribe(enabled => { _ = RefreshAsync(); })
+            .DisposeWith(_disposables);
+
         _ = Task.Run(() => PollLoopAsync(_loopCts.Token));
     }
 
@@ -122,7 +144,7 @@ public sealed class FundersMonitor : IDisposable
             while (!token.IsCancellationRequested)
             {
                 await RefreshAsync();
-                await Task.Delay(PollInterval, token);
+                await Task.Delay(_settings.IsAutoApproveEnabled ? AutoApprovePollInterval : PollInterval, token);
             }
         }
         catch (OperationCanceledException)
@@ -189,11 +211,56 @@ public sealed class FundersMonitor : IDisposable
                 }
             }
 
+            // Cancel + reinvest with the same investor key produces multiple handshakes
+            // for the same (project, investor) pair. Only the most recent one reflects
+            // the investor's current request — older entries are superseded, so showing
+            // them would duplicate the investor in the list and skew the pending badge.
+            records = records
+                .GroupBy(r => (r.WalletId, r.ProjectIdentifier, PubKey: r.InvestorNostrPubKey))
+                .SelectMany(g => g.Key.PubKey.Length == 0
+                    ? g.AsEnumerable() // no pubkey to correlate on — keep all
+                    : new[] { g.OrderByDescending(r => r.CreatedOn).First() })
+                .ToList();
+
+            // ── Auto-approve: sign every newly discovered pending request ──
+            // Signing is unattended: seed words resolve via the OS-secured key store,
+            // so no password prompt is required. Runs before change-detection so the
+            // "awaiting your approval" notification is replaced by "auto-approved".
+            var autoApprovedIds = new HashSet<string>();
+            var autoApproveMessages = new List<string>();
+            if (_settings.IsAutoApproveEnabled)
+            {
+                List<FunderRecord> pending;
+                lock (_stateLock)
+                {
+                    pending = records
+                        .Where(r => r.Status == InvestmentStatus.PendingFounderSignatures
+                                    && r.EventId.Length > 0
+                                    && r.InvestmentTransactionHex.Length > 0
+                                    && !_locallyApproved.Contains(r.EventId))
+                        .GroupBy(r => r.EventId)
+                        .Select(g => g.First())
+                        .ToList();
+                }
+
+                foreach (var record in pending)
+                {
+                    if (await TryAutoApproveAsync(record))
+                    {
+                        autoApprovedIds.Add(record.EventId);
+                        autoApproveMessages.Add(
+                            $"Auto-approved funding request for \"{record.ProjectTitle}\" — {FormatBtc(record.AmountSats)}");
+                    }
+                }
+            }
+
             List<string> notifications;
             lock (_stateLock)
             {
-                notifications = DetectChanges(records);
+                notifications = DetectChanges(records, autoApprovedIds);
                 _snapshot = records;
+                // Overlay auto-approvals so the UI shows them as approved immediately.
+                _locallyApproved.UnionWith(autoApprovedIds);
                 // Drop local-approval overlays once the synced status caught up.
                 _locallyApproved.RemoveWhere(id =>
                     records.Any(r => r.EventId == id && r.Status != InvestmentStatus.PendingFounderSignatures));
@@ -203,6 +270,8 @@ public sealed class FundersMonitor : IDisposable
                     .ToDictionary(g => g.Key, g => g.First().Status);
                 HasLoaded = true;
             }
+
+            notifications.AddRange(autoApproveMessages);
 
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
             {
@@ -249,9 +318,49 @@ public sealed class FundersMonitor : IDisposable
         return record.Status;
     }
 
+    /// <summary>
+    /// Approve a single pending request via the SDK (builds recovery signatures and
+    /// publishes the encrypted DM to the investor). Returns true on success.
+    /// </summary>
+    private async Task<bool> TryAutoApproveAsync(FunderRecord record)
+    {
+        try
+        {
+            var investment = new Angor.Sdk.Funding.Founder.Domain.Investment(
+                record.EventId,
+                DateTime.UtcNow,
+                record.InvestmentTransactionHex,
+                record.InvestorNostrPubKey,
+                record.AmountSats,
+                InvestmentStatus.PendingFounderSignatures);
+
+            var result = await _founderAppService.ApproveInvestment(
+                new ApproveInvestment.ApproveInvestmentRequest(
+                    new WalletId(record.WalletId),
+                    new ProjectId(record.ProjectIdentifier),
+                    investment));
+
+            if (result.IsSuccess) return true;
+
+            _logger.LogWarning(
+                "FundersMonitor: auto-approve failed for request {EventId} in project {ProjectId}: {Error}",
+                record.EventId, record.ProjectIdentifier, result.Error);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "FundersMonitor: auto-approve threw for request {EventId} in project {ProjectId}",
+                record.EventId, record.ProjectIdentifier);
+            return false;
+        }
+    }
+
     /// <summary>Compare against the previous poll and build notification messages.
+    /// Requests in <paramref name="autoApprovedIds"/> are skipped — the caller raises
+    /// an "auto-approved" message for them instead.
     /// Must be called under <see cref="_stateLock"/>.</summary>
-    private List<string> DetectChanges(List<FunderRecord> records)
+    private List<string> DetectChanges(List<FunderRecord> records, HashSet<string> autoApprovedIds)
     {
         var notifications = new List<string>();
 
@@ -262,6 +371,7 @@ public sealed class FundersMonitor : IDisposable
         foreach (var record in records)
         {
             if (record.EventId.Length == 0) continue;
+            if (autoApprovedIds.Contains(record.EventId)) continue;
 
             if (!_previousStatuses.TryGetValue(record.EventId, out var previous))
             {

--- a/src/design/App/UI/Shell/ShellViewModel.cs
+++ b/src/design/App/UI/Shell/ShellViewModel.cs
@@ -208,6 +208,12 @@ public partial class PrototypeSettings : ReactiveObject
     /// </summary>
     [Reactive] private HashSet<string> walletsNeedingBackup = new();
 
+    /// <summary>
+    /// When true, the FundersMonitor automatically approves pending investment
+    /// signing requests as soon as they are discovered during a background poll.
+    /// </summary>
+    [Reactive] private bool isAutoApproveEnabled;
+
     public PrototypeSettings(IStore store, ILogger<PrototypeSettings> logger)
     {
         _store = store;
@@ -229,6 +235,7 @@ public partial class PrototypeSettings : ReactiveObject
                         IsDebugMode = result.Value.IsDebugMode;
                         SelectedWalletId = result.Value.SelectedWalletId;
                         WalletsNeedingBackup = result.Value.WalletsNeedingBackup ?? new HashSet<string>();
+                        IsAutoApproveEnabled = result.Value.IsAutoApproveEnabled;
 
                         // Set IsDarkTheme last — its WhenAnyValue subscription
                         // applies the theme, so we want the other fields settled first.
@@ -268,7 +275,7 @@ public partial class PrototypeSettings : ReactiveObject
             });
 
         // Persist after visible state changes so disk I/O never competes with the theme flip.
-        this.WhenAnyValue(x => x.IsDebugMode, x => x.IsDarkTheme, x => x.SelectedWalletId, x => x.WalletsNeedingBackup)
+        this.WhenAnyValue(x => x.IsDebugMode, x => x.IsDarkTheme, x => x.SelectedWalletId, x => x.WalletsNeedingBackup, x => x.IsAutoApproveEnabled)
             .Skip(1)
             .Throttle(TimeSpan.FromMilliseconds(250), RxSchedulers.TaskpoolScheduler)
             .Subscribe(_ => ScheduleSaveSettings());
@@ -284,6 +291,7 @@ public partial class PrototypeSettings : ReactiveObject
         bool? currentDarkTheme = IsDarkTheme;
         string? currentWalletId = SelectedWalletId;
         HashSet<string> currentBackupSet = new(WalletsNeedingBackup);
+        bool currentAutoApprove = IsAutoApproveEnabled;
         CancellationToken token = saveSettingsCts.Token;
 
         Task.Run(async () =>
@@ -295,6 +303,7 @@ public partial class PrototypeSettings : ReactiveObject
                 IsDarkTheme = currentDarkTheme,
                 SelectedWalletId = currentWalletId,
                 WalletsNeedingBackup = currentBackupSet,
+                IsAutoApproveEnabled = currentAutoApprove,
             });
 
             if (!token.IsCancellationRequested && saveResult.IsFailure)
@@ -323,6 +332,7 @@ public partial class PrototypeSettings : ReactiveObject
             IsDarkTheme = IsDarkTheme,
             SelectedWalletId = SelectedWalletId,
             WalletsNeedingBackup = new HashSet<string>(WalletsNeedingBackup),
+            IsAutoApproveEnabled = IsAutoApproveEnabled,
         });
 
         if (saveResult.IsFailure)
@@ -356,6 +366,7 @@ public partial class PrototypeSettings : ReactiveObject
         public bool? IsDarkTheme { get; set; }
         public string? SelectedWalletId { get; set; }
         public HashSet<string>? WalletsNeedingBackup { get; set; }
+        public bool IsAutoApproveEnabled { get; set; }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a founder-side **auto-approve** toggle: a background worker that refreshes pending investment signing requests and approves them immediately, so investors don't wait for the founder to open the Funders tab.

### Changes

- **Persisted setting**: new `IsAutoApproveEnabled` in `PrototypeSettings` (saved with the existing throttled settings store, included in `FlushAsync`).
- **FundersMonitor** (background worker):
  - After each poll, if the toggle is on, every pending request is approved unattended via `IFounderAppService.ApproveInvestment` (seed words resolve through the OS-secured key store — no password prompt needed).
  - Turning the toggle on triggers an immediate refresh + approval of everything already waiting.
  - Poll interval reduced from 2min to **1min baseline / 30s while auto-approve is on**. Polls are cheap: relay websockets stay open between polls (auto-reconnect after 30s if dropped); each refresh only re-sends REQ filters on the existing client. The refresh lock coalesces overlaps.
  - Notifications: auto-approved requests raise an "Auto-approved funding request…" toast instead of "awaiting your approval".
- **UI**: "Auto-approve requests" toggle card in the Funders section (both the populated list and the empty state, desktop + mobile).
- **Bug fix (related)**: cancel + reinvest with the same investor nostr key produced duplicate entries in the Funders list (old approved entry + new request). The monitor now dedupes per `(wallet, project, investor pubkey)` keeping only the latest handshake, so the list, pending badge, and auto-approve all operate on the investor's current request only.

### Testing

- `App.Desktop` Debug build passes.
- Manually validated on signet: toggle persists across restarts, pending requests are approved in the background, cancel+reinvest now shows only the latest entry.
