### PR TITLE
test: expand UAT coverage - founder auto-approve, Settings page, portfolio auto-recovery

### DIFF
--- a/src/design/App.Test.Uat/Helpers/TestAutomationClient.cs
+++ b/src/design/App.Test.Uat/Helpers/TestAutomationClient.cs
@@ -412,6 +412,13 @@ public sealed class TestAutomationClient : IDisposable
         return await PostAsync<GetBalanceResponse>("/flows/get-balance", request, ct);
     }
 
+    public async Task<GetFindProjectsCountResponse> GetFindProjectsCountAsync(
+        GetFindProjectsCountRequest request,
+        CancellationToken ct = default)
+    {
+        return await PostAsync<GetFindProjectsCountResponse>("/flows/get-find-projects-count", request, ct);
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // HTTP Helpers
     // ═══════════════════════════════════════════════════════════════════

--- a/src/design/App.Test.Uat/MultiInvestClaimAndRecoverTest.cs
+++ b/src/design/App.Test.Uat/MultiInvestClaimAndRecoverTest.cs
@@ -11,10 +11,11 @@ namespace App.Test.Uat;
 /// founder claim stage 1, founder release remaining, all investors unfundedRelease.
 ///
 /// Investor1: invest → cancel before approval (Step 1) → reinvest
-/// Investor2: invest → founder approves just this one → cancel after approval (Step 2) → reinvest
+/// Investor2: invest → founder approves just this one (manual path) → cancel after approval (Step 2) → reinvest
 /// Investor3: invest normally (0.02 BTC)
 /// Investor4: invest normally (0.03 BTC)
-/// Founder approves all 4 remaining investments, all confirm.
+/// Founder enables the auto-approve toggle; FundersMonitor approves all 4 remaining
+/// investments unattended, all investors confirm.
 /// Founder claims stage 1, releases remaining stages.
 /// All 4 investors claim via unfundedRelease.
 /// </summary>
@@ -195,17 +196,19 @@ public class MultiInvestClaimAndRecoverTest
         });
         invest4.Success.Should().BeTrue(invest4.Error);
 
-        // ── Founder approves all 4 remaining investments ──
-        Log(FounderProfile, "Approving all 4 investments...");
-        var approve = await founderHost.Client.ApproveInvestmentsAsync(new ApproveInvestmentsRequest
-        {
-            ProjectIdentifier = projectId,
-            ExpectedCount = 4,
-            Batch = true,
-        });
-        approve.Success.Should().BeTrue(approve.Error);
+        // ── Founder enables auto-approve; all 4 remaining investments are approved unattended ──
+        // (Manual per-row approval is covered above by investor2's first investment.)
+        Log(FounderProfile, "Enabling auto-approve toggle on Funders page...");
+        await founderHost.Client.NavigateAsync("Funders");
+        await founderHost.Client.WaitForControlAsync("FundersAutoApproveToggle", TimeSpan.FromMinutes(2));
+        await founderHost.Client.ClickAsync("FundersAutoApproveToggle");
 
-        // ── All 4 investors confirm ──
+        // The toggle writes through to the shared PrototypeSettings singleton
+        await founderHost.Client.WaitForVmPropertyAsync(
+            "PrototypeSettings", "IsAutoApproveEnabled", "True", TimeSpan.FromSeconds(30));
+        Log(FounderProfile, "Auto-approve enabled — waiting for FundersMonitor to approve all 4 investments...");
+
+        // ── All 4 investors confirm (each confirm waits for its approval to arrive) ──
         Log(Investor1Profile, "Confirming investment...");
         var confirm1 = await investor1Host.Client.ConfirmInvestmentAsync(new ConfirmInvestmentRequest { ProjectIdentifier = projectId });
         confirm1.Success.Should().BeTrue(confirm1.Error);

--- a/src/design/App.Test.Uat/SettingsTest.cs
+++ b/src/design/App.Test.Uat/SettingsTest.cs
@@ -1,0 +1,142 @@
+using FluentAssertions;
+using App.Test.Uat.Helpers;
+using static App.Automation.AutomationFlowDtos;
+using Xunit;
+
+namespace App.Test.Uat;
+
+/// <summary>
+/// Exercises the Settings page:
+/// 1. Dark theme toggle — flips IsDarkThemeEnabled and verifies it persists in shared settings
+/// 2. Backup Account — reveals seed words in the UI and verifies they match the wallet's seed
+/// 3. Network switch — Angornet → Mainnet → Angornet, verifying:
+///    - NetworkType reflects the switch
+///    - the Find Projects list is repopulated after each switch (no stale list, PR #933)
+///    - the wallet survives the round trip (same stored wallet recovered)
+/// </summary>
+public class SettingsTest
+{
+    private const string TestName = "Settings";
+    private const string Profile = TestName + "-User";
+
+    [Fact]
+    public async Task SettingsThemeBackupAndNetworkSwitch()
+    {
+        Log($"========== STARTING {nameof(SettingsThemeBackupAndNetworkSwitch)} ==========");
+
+        await using var host = await TestProcessHost.LaunchAsync(Profile);
+        await host.Client.WipeDataAsync();
+        await host.Client.SwitchNetworkAsync("Angornet");
+        await host.Client.EnableDebugModeAsync();
+
+        // ── Wallet (unfunded — Settings features only need a wallet to exist) ──
+        Log("Creating wallet (no funding)...");
+        var wallet = await host.Client.CreateWalletAndFundAsync(new CreateWalletAndFundRequest
+        {
+            ProfileName = Profile,
+            SkipFunding = true,
+        });
+        wallet.Success.Should().BeTrue(wallet.Error);
+        wallet.SeedWords.Should().NotBeNullOrEmpty("Seed words should be captured at creation");
+        var seedWords = wallet.SeedWords!;
+
+        // ══════════════════════════════════════════════════════════════
+        // 1. Dark theme toggle persists through shared settings
+        // ══════════════════════════════════════════════════════════════
+        Log("Testing dark theme toggle...");
+        await host.Client.NavigateAsync("Settings");
+
+        var initialTheme = await host.Client.GetVmPropertyAsync("SettingsViewModel", "IsDarkThemeEnabled");
+        Log($"Initial IsDarkThemeEnabled: {initialTheme}");
+        var flipped = !string.Equals(initialTheme, "True", StringComparison.OrdinalIgnoreCase);
+
+        await host.Client.SetVmPropertyAsync("SettingsViewModel", "IsDarkThemeEnabled", flipped);
+        await Task.Delay(500);
+
+        // SettingsViewModel is transient — a fresh resolution reads back from the shared
+        // PrototypeSettings singleton, proving the change was written through.
+        var afterFlip = await host.Client.GetVmPropertyAsync("SettingsViewModel", "IsDarkThemeEnabled");
+        afterFlip.Should().Be(flipped ? "True" : "False", "theme change should persist in shared settings");
+
+        // Restore the original theme
+        await host.Client.SetVmPropertyAsync("SettingsViewModel", "IsDarkThemeEnabled", !flipped);
+        var restored = await host.Client.GetVmPropertyAsync("SettingsViewModel", "IsDarkThemeEnabled");
+        restored.Should().Be(initialTheme, "theme should be restorable to its original value");
+        Log("Dark theme toggle verified.");
+
+        // ══════════════════════════════════════════════════════════════
+        // 2. Backup Account — reveal seed words and compare with the wallet's seed
+        // ══════════════════════════════════════════════════════════════
+        Log("Testing Backup Account (Show Seed Words)...");
+        await host.Client.NavigateAsync("Settings");
+        await host.Client.WaitForControlAsync("BtnRevealSeed", TimeSpan.FromSeconds(30));
+        await host.Client.ClickAsync("BtnRevealSeed");
+
+        var seedControl = await host.Client.WaitForControlAsync("SettingsSeedWordsText", TimeSpan.FromSeconds(30));
+        seedControl.Text.Should().NotBeNullOrWhiteSpace("Seed words should be displayed after reveal");
+        seedControl.Text!.Trim().Should().Be(seedWords.Trim(),
+            "Revealed seed words must match the seed captured at wallet creation");
+
+        // Download Seed button becomes visible alongside the revealed seed
+        var downloadBtn = await host.Client.FindControlAsync("BtnDownloadBackup");
+        downloadBtn.Found.Should().BeTrue();
+        downloadBtn.IsVisible.Should().BeTrue("Download Seed button should be visible after reveal");
+
+        // Hide again (same button toggles)
+        await host.Client.ClickAsync("BtnRevealSeed");
+        await Task.Delay(500);
+        Log("Backup Account verified.");
+
+        // ══════════════════════════════════════════════════════════════
+        // 3. Network switch round trip refreshes Find Projects (PR #933)
+        // ══════════════════════════════════════════════════════════════
+        Log("Loading Find Projects on Angornet...");
+        var angornetProjects = await host.Client.GetFindProjectsCountAsync(new GetFindProjectsCountRequest
+        {
+            MinCount = 1,
+            TimeoutSeconds = 120,
+        });
+        angornetProjects.Success.Should().BeTrue(angornetProjects.Error);
+        Log($"Angornet projects: {angornetProjects.Count}");
+
+        Log("Switching to Mainnet...");
+        await host.Client.SwitchNetworkAsync("Mainnet");
+
+        var networkType = await host.Client.GetVmPropertyAsync("SettingsViewModel", "NetworkType");
+        networkType.Should().Contain("Mainnet", "NetworkType should reflect the switch to Mainnet");
+
+        // The project list must reload with mainnet projects (not remain stale)
+        var mainnetProjects = await host.Client.GetFindProjectsCountAsync(new GetFindProjectsCountRequest
+        {
+            MinCount = 1,
+            TimeoutSeconds = 180,
+        });
+        mainnetProjects.Success.Should().BeTrue(mainnetProjects.Error);
+        Log($"Mainnet projects: {mainnetProjects.Count}");
+
+        Log("Switching back to Angornet...");
+        await host.Client.SwitchNetworkAsync("Angornet");
+
+        networkType = await host.Client.GetVmPropertyAsync("SettingsViewModel", "NetworkType");
+        networkType.Should().Contain("Angornet", "NetworkType should reflect the switch back to Angornet");
+
+        var angornetProjectsAgain = await host.Client.GetFindProjectsCountAsync(new GetFindProjectsCountRequest
+        {
+            MinCount = 1,
+            TimeoutSeconds = 120,
+        });
+        angornetProjectsAgain.Success.Should().BeTrue(angornetProjectsAgain.Error);
+        Log($"Angornet projects after round trip: {angornetProjectsAgain.Count}");
+
+        // ── Wallet survives the network round trip via stored recovery files ──
+        var storedWallets = await host.Client.GetStoredWalletsCountAsync();
+        storedWallets.Should().BeGreaterThanOrEqualTo(1, "Wallet recovery file should survive network switches");
+
+        Log($"========== {nameof(SettingsThemeBackupAndNetworkSwitch)} PASSED ==========");
+    }
+
+    private static void Log(string message)
+    {
+        Console.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] [{TestName}] {message}");
+    }
+}

--- a/src/design/App.Test.Uat/WalletRecoveryTest.cs
+++ b/src/design/App.Test.Uat/WalletRecoveryTest.cs
@@ -6,17 +6,18 @@ using Xunit;
 namespace App.Test.Uat;
 
 /// <summary>
-/// Tests wallet recovery from seed words:
-/// 1. Create wallet (generate) → capture seed words
-/// 2. Fund wallet and deploy a project
-/// 3. Wipe all data
-/// 4. Import wallet from seed words
-/// 5. Verify the wallet balance is recovered and the project is visible in My Projects
+/// Tests wallet recovery from seed words, for both a founder and an investor:
+/// 1. Founder: create wallet (generate) → capture seed words → fund → deploy a project
+/// 2. Investor: create wallet → invest in the project → founder approves → confirm (Step 3)
+/// 3. Founder: wipe all data → import wallet from seed → same deterministic WalletId
+/// 4. Investor: wipe all data → import wallet from seed → portfolio investment is
+///    auto-recovered from Nostr relays (PR #924 relay decryption / handshake sync)
 /// </summary>
 public class WalletRecoveryTest
 {
     private const string TestName = "WalletRecovery";
     private const string Profile = TestName + "-User";
+    private const string InvestorProfile = TestName + "-Investor";
 
     [Fact]
     public async Task RecoverWalletFromSeedWords()
@@ -35,8 +36,8 @@ public class WalletRecoveryTest
         await host.Client.SwitchNetworkAsync("Angornet");
         await host.Client.EnableDebugModeAsync();
 
-        // ── Step 1: Create wallet and fund (captures seed words) ──
-        Log("Step 1: Creating wallet and funding...");
+        // ── Step 1: Create founder wallet and fund (captures seed words) ──
+        Log("Step 1: Creating founder wallet and funding...");
         var wallet = await host.Client.CreateWalletAndFundAsync(new CreateWalletAndFundRequest
         {
             ProfileName = Profile,
@@ -62,14 +63,56 @@ public class WalletRecoveryTest
         var projectId = createdProject.ProjectIdentifier!;
         Log($"Project deployed: {projectId}");
 
-        // ── Step 3: Wipe all data ──
-        Log("Step 3: Wiping all data...");
+        // ── Step 3: Investor invests, founder approves, investor confirms ──
+        Log("Step 3: Launching investor, investing in the project...");
+        await using var investorHost = await TestProcessHost.LaunchAsync(InvestorProfile);
+        await investorHost.Client.WipeDataAsync();
+        await investorHost.Client.SwitchNetworkAsync("Angornet");
+        await investorHost.Client.EnableDebugModeAsync();
+
+        var investorWallet = await investorHost.Client.CreateWalletAndFundAsync(new CreateWalletAndFundRequest
+        {
+            ProfileName = InvestorProfile,
+        });
+        investorWallet.Success.Should().BeTrue(investorWallet.Error);
+        investorWallet.SeedWords.Should().NotBeNullOrEmpty();
+        var investorSeedWords = investorWallet.SeedWords!;
+        var investorWalletId = investorWallet.WalletId!;
+        Log($"Investor wallet created: {investorWalletId}");
+
+        var invest = await investorHost.Client.InvestInProjectAsync(new InvestInProjectRequest
+        {
+            ProjectIdentifier = projectId,
+            RunId = runId,
+            ProjectName = projectName,
+            AmountBtc = "0.02",
+            ExpectFounderApproval = true,
+            TargetPatternStageCount = 0,
+        });
+        invest.Success.Should().BeTrue(invest.Error);
+
+        Log("Founder approving the investment...");
+        var approve = await host.Client.ApproveInvestmentsAsync(new ApproveInvestmentsRequest
+        {
+            ProjectIdentifier = projectId,
+            ExpectedCount = 1,
+            Batch = true,
+        });
+        approve.Success.Should().BeTrue(approve.Error);
+
+        Log("Investor confirming the investment...");
+        var confirm = await investorHost.Client.ConfirmInvestmentAsync(new ConfirmInvestmentRequest
+        {
+            ProjectIdentifier = projectId,
+        });
+        confirm.Success.Should().BeTrue(confirm.Error);
+        confirm.Step.Should().Be(3);
+
+        // ── Step 4: Founder wipes and re-imports from seed ──
+        Log("Step 4: Wiping founder data and re-importing from seed words...");
         await host.Client.WipeDataAsync();
         await host.Client.SwitchNetworkAsync("Angornet");
-        Log("Data wiped.");
 
-        // ── Step 4: Import wallet from seed words ──
-        Log("Step 4: Importing wallet from seed words...");
         var imported = await host.Client.ImportWalletAsync(new ImportWalletRequest
         {
             SeedWords = seedWords,
@@ -77,12 +120,73 @@ public class WalletRecoveryTest
         });
         imported.Success.Should().BeTrue(imported.Error);
         imported.WalletId.Should().NotBeNullOrEmpty("Imported wallet should have an ID");
-        Log($"Wallet imported: {imported.WalletId}");
+        Log($"Founder wallet imported: {imported.WalletId}");
 
         // The wallet ID should be the same since it's derived from the same seed
         imported.WalletId.Should().Be(originalWalletId, "Imported wallet should have the same ID as the original");
 
+        // ── Step 5: Investor wipes and re-imports; portfolio must auto-recover from relays ──
+        Log("Step 5: Wiping investor data and re-importing from seed words...");
+        await investorHost.Client.WipeDataAsync();
+        await investorHost.Client.SwitchNetworkAsync("Angornet");
+
+        var investorImported = await investorHost.Client.ImportWalletAsync(new ImportWalletRequest
+        {
+            SeedWords = investorSeedWords,
+            ProfileName = InvestorProfile,
+        });
+        investorImported.Success.Should().BeTrue(investorImported.Error);
+        investorImported.WalletId.Should().Be(investorWalletId,
+            "Imported investor wallet should have the same ID as the original");
+
+        Log("Waiting for portfolio auto-recovery from Nostr relays...");
+        var recovered = await WaitForPortfolioInvestmentAsync(investorHost, projectId, TimeSpan.FromMinutes(5));
+        recovered.Should().BeTrue(
+            $"Investment in project {projectId} should be auto-recovered into the portfolio after wallet re-import");
+        Log("Portfolio investment recovered.");
+
         Log($"========== {nameof(RecoverWalletFromSeedWords)} PASSED ==========");
+    }
+
+    /// <summary>
+    /// Polls PortfolioViewModel (singleton) until an investment for the given project appears,
+    /// re-triggering LoadInvestmentsFromSdkAsync between attempts (relay handshake sync).
+    /// </summary>
+    private static async Task<bool> WaitForPortfolioInvestmentAsync(
+        TestProcessHost host, string projectId, TimeSpan timeout)
+    {
+        await host.Client.NavigateAsync("Funded");
+
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                await host.Client.InvokeVmAsync("PortfolioViewModel", "LoadInvestmentsFromSdkAsync");
+
+                var countText = await host.Client.GetVmPropertyAsync("PortfolioViewModel", "Investments.Count");
+                if (int.TryParse(countText, out var count) && count > 0)
+                {
+                    for (var i = 0; i < count; i++)
+                    {
+                        var identifier = await host.Client.GetVmPropertyAsync(
+                            "PortfolioViewModel", $"Investments[{i}].ProjectIdentifier");
+                        if (string.Equals(identifier, projectId, StringComparison.Ordinal))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log($"Portfolio poll attempt failed (will retry): {ex.Message}");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(10));
+        }
+
+        return false;
     }
 
     private static void Log(string message)

--- a/src/design/App/Automation/AutomationFlowDtos.cs
+++ b/src/design/App/Automation/AutomationFlowDtos.cs
@@ -611,6 +611,30 @@ public static class AutomationFlowDtos
         public string? Error { get; init; }
     }
 
+    public sealed class GetFindProjectsCountRequest
+    {
+        /// <summary>
+        /// Minimum number of projects to wait for before returning (0 = return immediately after load).
+        /// </summary>
+        [JsonPropertyName("minCount")]
+        public int MinCount { get; init; }
+
+        [JsonPropertyName("timeoutSeconds")]
+        public int TimeoutSeconds { get; init; } = 60;
+    }
+
+    public sealed class GetFindProjectsCountResponse
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; init; }
+
+        [JsonPropertyName("count")]
+        public int Count { get; init; }
+
+        [JsonPropertyName("error")]
+        public string? Error { get; init; }
+    }
+
     public sealed class ImportWalletRequest
     {
         [JsonPropertyName("seedWords")]

--- a/src/design/App/Automation/AutomationFlows.cs
+++ b/src/design/App/Automation/AutomationFlows.cs
@@ -2460,6 +2460,56 @@ public static class AutomationFlows
     }
 
     /// <summary>
+    /// Navigate to Find Projects and return the number of projects in the live list,
+    /// optionally waiting until at least MinCount projects have loaded.
+    /// </summary>
+    public static async Task<GetFindProjectsCountResponse> GetFindProjectsCountAsync(
+        IServiceProvider services,
+        GetFindProjectsCountRequest req)
+    {
+        try
+        {
+            var window = await RequireWindowAsync();
+            await NavigateToAsync(window, "Find Projects");
+
+            var findProjectsVm = await Dispatcher.UIThread.InvokeAsync(() => GetFindProjectsViewModel(window));
+            if (findProjectsVm == null)
+            {
+                return new GetFindProjectsCountResponse { Success = false, Error = "FindProjectsViewModel not found" };
+            }
+
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(Math.Max(1, req.TimeoutSeconds));
+            var count = 0;
+            while (DateTime.UtcNow < deadline)
+            {
+                count = await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    Dispatcher.UIThread.RunJobs();
+                    return findProjectsVm.Projects.Count;
+                });
+
+                if (count >= req.MinCount)
+                {
+                    return new GetFindProjectsCountResponse { Success = true, Count = count };
+                }
+
+                await Task.Delay(PollInterval);
+            }
+
+            return new GetFindProjectsCountResponse
+            {
+                Success = false,
+                Count = count,
+                Error = $"Find Projects list did not reach {req.MinCount} projects within {req.TimeoutSeconds}s (last count: {count})",
+            };
+        }
+        catch (Exception ex)
+        {
+            return new GetFindProjectsCountResponse { Success = false, Error = ex.Message };
+        }
+    }
+
+    /// <summary>
     /// Cancel an investment at Step 1 (before founder approval) or Step 2 (after approval, before confirm).
     /// </summary>
     public static async Task<CancelInvestmentResponse> CancelInvestmentAsync(

--- a/src/design/App/Automation/AutomationServer.cs
+++ b/src/design/App/Automation/AutomationServer.cs
@@ -522,6 +522,14 @@ public sealed class AutomationServer : IDisposable
                 return (200, result);
             }
 
+            // POST /flows/get-find-projects-count
+            if (method == "POST" && path == "/flows/get-find-projects-count")
+            {
+                var req = Deserialize<GetFindProjectsCountRequest>(body);
+                var result = await AutomationFlows.GetFindProjectsCountAsync(services, req);
+                return (200, result);
+            }
+
             return (404, new ActionResponse { Success = false, Error = $"Unknown route: {method} {path}" });
         }
         catch (Exception ex)
@@ -575,6 +583,14 @@ public sealed class AutomationServer : IDisposable
         if (control is not Button button)
         {
             return new ActionResponse { Success = false, Error = $"Button '{id}' not found" };
+        }
+
+        // Raising ClickEvent alone doesn't flip toggles — set IsChecked so two-way bindings fire.
+        if (button is Avalonia.Controls.Primitives.ToggleButton toggle)
+        {
+            toggle.IsChecked = !(toggle.IsChecked ?? false);
+            Dispatcher.UIThread.RunJobs();
+            return new ActionResponse { Success = true };
         }
 
         button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, button));

--- a/src/design/App/UI/Sections/Settings/SettingsView.axaml
+++ b/src/design/App/UI/Sections/Settings/SettingsView.axaml
@@ -546,6 +546,7 @@
                                         CornerRadius="8"
                                         Padding="16">
                                     <SelectableTextBlock Text="{Binding SeedWords}"
+                                               AutomationProperties.AutomationId="SettingsSeedWordsText"
                                                FontSize="14"
                                                FontFamily="Cascadia Mono, Consolas, monospace"
                                                Foreground="{DynamicResource CreateWalletSeedText}"


### PR DESCRIPTION
Expands UAT coverage for three recently merged features, verified locally against signet.

## Test changes

### MultiInvestClaimAndRecoverTest — founder auto-approve (#936)
The founder now enables the **auto-approve toggle** on the Funders page instead of manually batch-approving the 4 remaining investments. \FundersMonitor\ approves them unattended, and each investor's confirm step (which waits for the approval to arrive) implicitly verifies auto-approval worked. Manual per-row approval remains covered by investor2's first investment earlier in the test.

### SettingsTest (new)
- **Dark theme toggle** — flips \IsDarkThemeEnabled\ and verifies write-through to the shared \PrototypeSettings\ singleton (read back via a fresh transient VM), then restores it
- **Backup Account** — clicks *Show Seed Words*, asserts the revealed seed matches the seed captured at wallet creation, asserts *Download Seed* becomes visible, then hides again
- **Network switch round trip** (#933) — Angornet → Mainnet → Angornet, asserting \NetworkType\ after each switch and that the **Find Projects list repopulates** on each network (no stale list), plus wallet recovery file surviving the round trip

### WalletRecoveryTest — portfolio auto-recovery (#924)
Adds an investor host that invests in the founder's project, gets approved, and confirms (Step 3). After wipe + seed re-import, the test polls \PortfolioViewModel\ until the investment is **auto-recovered from Nostr relays** (handshake sync). The existing founder deterministic-WalletId assertion is unchanged.

## Automation server additions (Debug-only)
- \POST /flows/get-find-projects-count\ — reads the live \FindProjectsViewModel\ project list with an optional MinCount wait (the VM is transient, so \/vm/\ can't reach the live instance)
- \POST /click\ now flips \IsChecked\ for \ToggleButton\/\ToggleSwitch\ (raising \ClickEvent\ alone doesn't toggle)
- \SettingsSeedWordsText\ AutomationId on the seed phrase \SelectableTextBlock\

## Test results (local, signet)
| Test | Result | Time |
|---|---|---|
| SettingsTest | ✅ | 31s |
| WalletRecoveryTest | ✅ | 4m 2s |
| MultiInvestClaimAndRecoverTest | ✅ | 5m 34s |