### PR TITLE
feat: investment share statistics and investor breakdown

### DIFF
--- a/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml
@@ -963,6 +963,98 @@
                         </Border>
                     </Grid>
 
+                    <!-- ═══════════════════════════════════════ -->
+                    <!-- YOUR SHARE STATISTICS                    -->
+                    <!-- Shows investor's share of total pool     -->
+                    <!-- ═══════════════════════════════════════ -->
+                    <Grid ColumnDefinitions="*,*,*" Margin="0,0,0,0">
+                        <!-- Your Share -->
+                        <Border Grid.Column="0"
+                                Background="{DynamicResource StatsDetailInnerBackground}"
+                                CornerRadius="12"
+                                Padding="20"
+                                Margin="0,0,8,0"
+                                BorderBrush="{DynamicResource StatsDetailInnerBorder}"
+                                BorderThickness="2">
+                            <StackPanel Spacing="8">
+                                <TextBlock Text="{Binding ShareLabel}"
+                                           FontSize="13"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource StatsDetailLabel}" />
+                                <TextBlock Text="{Binding SharePercentageDisplay}"
+                                           FontSize="24"
+                                           FontWeight="Bold"
+                                           Foreground="{DynamicResource PrimaryGreenBrush}" />
+                                <TextBlock Text="of total pool"
+                                           FontSize="11"
+                                           Foreground="{DynamicResource StatsDetailSubtext}" />
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Claimed by Founder -->
+                        <Border Grid.Column="1"
+                                Background="{DynamicResource StatsDetailInnerBackground}"
+                                CornerRadius="12"
+                                Padding="20"
+                                Margin="8,0,8,0"
+                                BorderBrush="{DynamicResource StatsDetailInnerBorder}"
+                                BorderThickness="2">
+                            <StackPanel Spacing="8">
+                                <TextBlock Text="Claimed by Founder"
+                                           FontSize="13"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource StatsDetailLabel}" />
+                                <TextBlock Text="{Binding ClaimedPercentageDisplay}"
+                                           FontSize="24"
+                                           FontWeight="Bold"
+                                           Foreground="#F7931A" />
+                                <StackPanel Orientation="Horizontal" Spacing="4">
+                                    <TextBlock Text="{Binding AmountClaimedByFounder}"
+                                               FontSize="11"
+                                               Foreground="{DynamicResource StatsDetailSubtext}" />
+                                    <TextBlock Text="{Binding CurrencySymbol}"
+                                               FontSize="11"
+                                               Foreground="{DynamicResource StatsDetailSubtext}" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- View Investors Button -->
+                        <Border Grid.Column="2"
+                                Background="{DynamicResource StatsDetailInnerBackground}"
+                                CornerRadius="12"
+                                Padding="20"
+                                Margin="8,0,0,0"
+                                BorderBrush="{DynamicResource StatsDetailInnerBorder}"
+                                BorderThickness="2">
+                            <StackPanel Spacing="8" VerticalAlignment="Center">
+                                <TextBlock Text="Investor Breakdown"
+                                           FontSize="13"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource StatsDetailLabel}" />
+                                <Button Name="ViewInvestorsButton"
+                                        HorizontalAlignment="Stretch"
+                                        HorizontalContentAlignment="Center"
+                                        Padding="14,8"
+                                        Background="Transparent"
+                                        BorderBrush="{DynamicResource PrimaryGreenBrush}"
+                                        BorderThickness="2"
+                                        CornerRadius="8">
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <i:Icon Value="fa-solid fa-chart-pie"
+                                               FontSize="14"
+                                               Foreground="{DynamicResource PrimaryGreenBrush}"
+                                               VerticalAlignment="Center" />
+                                        <TextBlock Text="View All"
+                                                   FontSize="14"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource PrimaryGreenBrush}" />
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+
                     <!-- Funding Progress Bar -->
                     <!-- Vue: .progress-section .progress-header flex space-between -->
                     <StackPanel Spacing="8">

--- a/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml.cs
+++ b/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
 using Angor.Shared.Services;
+using App.UI.Shared.Services;
 using App.UI.Shared;
 using App.UI.Shell;
 using App.UI.Shared.Helpers;
@@ -250,6 +251,10 @@ public partial class InvestmentDetailView : UserControl
             case "ViewTransactionButton":
                 OpenTransactionInBrowser();
                 break;
+
+            case "ViewInvestorsButton":
+                _ = ShowInvestorBreakdownAsync();
+                break;
         }
     }
 
@@ -387,5 +392,39 @@ public partial class InvestmentDetailView : UserControl
         {
             ExplorerHelper.OpenTransaction(networkService, investVm.InvestmentTransactionId);
         }
+    }
+
+    /// <summary>
+    /// Load investor shares from the SDK and show the breakdown modal.
+    /// </summary>
+    private async Task ShowInvestorBreakdownAsync()
+    {
+        if (DataContext is not InvestmentViewModel investVm) return;
+        if (string.IsNullOrEmpty(investVm.ProjectIdentifier)) return;
+
+        var shellVm = this.FindAncestorOfType<ShellView>()?.DataContext as ShellViewModel;
+        if (shellVm == null) return;
+
+        var projectAppService = App.Services.GetService<Angor.Sdk.Funding.Projects.IProjectAppService>();
+        if (projectAppService == null) return;
+
+        var result = await projectAppService.GetInvestorShares(
+            new Angor.Sdk.Funding.Shared.ProjectId(investVm.ProjectIdentifier));
+
+        if (result.IsFailure) return;
+
+        var currencyService = App.Services.GetService<ICurrencyService>();
+        var currencySymbol = currencyService?.Symbol ?? "BTC";
+
+        var breakdownView = new InvestorBreakdownView
+        {
+            DataContext = new InvestorBreakdownViewModel(
+                result.Value,
+                investVm.ProjectName,
+                investVm.ProjectType,
+                currencySymbol)
+        };
+
+        shellVm.ShowModal(breakdownView);
     }
 }

--- a/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml.cs
+++ b/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml.cs
@@ -422,7 +422,8 @@ public partial class InvestmentDetailView : UserControl
                 result.Value,
                 investVm.ProjectName,
                 investVm.ProjectType,
-                currencySymbol)
+                currencySymbol,
+                investVm.InvestorPublicKey)
         };
 
         shellVm.ShowModal(breakdownView);

--- a/src/design/App/UI/Sections/Portfolio/InvestorBreakdownView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/InvestorBreakdownView.axaml
@@ -1,0 +1,188 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:portfolio="clr-namespace:App.UI.Sections.Portfolio"
+             xmlns:i="https://github.com/projektanker/icons.avalonia"
+             mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="600"
+             x:Class="App.UI.Sections.Portfolio.InvestorBreakdownView"
+             x:DataType="portfolio:InvestorBreakdownViewModel">
+
+    <Border Classes="ModalCard Wide"
+            Padding="0">
+        <DockPanel>
+            <!-- Footer: Close button -->
+            <Border DockPanel.Dock="Bottom"
+                    BorderBrush="{DynamicResource Stroke}"
+                    BorderThickness="0,1,0,0"
+                    Padding="24,16">
+                <Button Name="CloseButton"
+                        Classes="Primary"
+                        HorizontalAlignment="Center"
+                        Padding="32,10">
+                    <TextBlock Text="Close"
+                               FontSize="14"
+                               FontWeight="SemiBold" />
+                </Button>
+            </Border>
+
+            <!-- Content -->
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          MaxHeight="500">
+                <StackPanel Spacing="20" Margin="24">
+
+                    <!-- Header -->
+                    <StackPanel Spacing="8">
+                        <StackPanel Orientation="Horizontal" Spacing="12">
+                            <i:Icon Value="fa-solid fa-chart-pie"
+                                   FontSize="22"
+                                   Foreground="{DynamicResource PrimaryGreenBrush}"
+                                   VerticalAlignment="Center" />
+                            <TextBlock Text="Investor Breakdown"
+                                       FontSize="20"
+                                       FontWeight="Bold"
+                                       Foreground="{DynamicResource TextStrong}"
+                                       VerticalAlignment="Center" />
+                        </StackPanel>
+                        <TextBlock Text="{Binding ProjectName}"
+                                   FontSize="14"
+                                   Foreground="{DynamicResource TextMuted}" />
+                    </StackPanel>
+
+                    <!-- Summary stats -->
+                    <Grid ColumnDefinitions="*,*">
+                        <Border Grid.Column="0"
+                                Background="{DynamicResource SurfaceLow}"
+                                BorderBrush="{DynamicResource Stroke}"
+                                BorderThickness="1"
+                                CornerRadius="12"
+                                Padding="16"
+                                Margin="0,0,8,0">
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="Total Invested"
+                                           FontSize="12"
+                                           Foreground="{DynamicResource TextMuted}" />
+                                <StackPanel Orientation="Horizontal" Spacing="4">
+                                    <TextBlock Text="{Binding TotalInvested}"
+                                               FontSize="18"
+                                               FontWeight="Bold"
+                                               Foreground="{DynamicResource TextStrong}" />
+                                    <TextBlock Text="{Binding CurrencySymbol}"
+                                               FontSize="11"
+                                               Foreground="{DynamicResource TextMuted}"
+                                               VerticalAlignment="Bottom" Margin="0,0,0,1" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                        <Border Grid.Column="1"
+                                Background="{DynamicResource SurfaceLow}"
+                                BorderBrush="{DynamicResource Stroke}"
+                                BorderThickness="1"
+                                CornerRadius="12"
+                                Padding="16"
+                                Margin="8,0,0,0">
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="Total Investors"
+                                           FontSize="12"
+                                           Foreground="{DynamicResource TextMuted}" />
+                                <TextBlock Text="{Binding TotalInvestors}"
+                                           FontSize="18"
+                                           FontWeight="Bold"
+                                           Foreground="{DynamicResource TextStrong}" />
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+
+                    <!-- Context note for Fund projects -->
+                    <Border Background="#1AF7931A"
+                            CornerRadius="8"
+                            Padding="12"
+                            IsVisible="{Binding IsFundType}">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <i:Icon Value="fa-solid fa-circle-info"
+                                   FontSize="14"
+                                   Foreground="#F7931A"
+                                   VerticalAlignment="Top" Margin="0,2,0,0" />
+                            <TextBlock Text="{Binding ShareContextNote}"
+                                       FontSize="13"
+                                       Foreground="{DynamicResource TextMuted}"
+                                       TextWrapping="Wrap" />
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Table header -->
+                    <Grid ColumnDefinitions="40,*,120,100,100"
+                          Margin="0,4,0,0">
+                        <TextBlock Grid.Column="0" Text="#"
+                                   FontSize="12" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextMuted}" />
+                        <TextBlock Grid.Column="1" Text="Investor"
+                                   FontSize="12" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextMuted}" />
+                        <TextBlock Grid.Column="2" Text="Invested"
+                                   FontSize="12" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextMuted}"
+                                   HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="3" Text="Share"
+                                   FontSize="12" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextMuted}"
+                                   HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="4" Text="Claimed"
+                                   FontSize="12" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextMuted}"
+                                   HorizontalAlignment="Right" />
+                    </Grid>
+
+                    <Border Height="1" Background="{DynamicResource Stroke}" />
+
+                    <!-- Investor rows -->
+                    <ItemsControl ItemsSource="{Binding Investors}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="portfolio:InvestorShareRowViewModel">
+                                <Border Padding="0,8"
+                                        BorderBrush="{DynamicResource Stroke}"
+                                        BorderThickness="0,0,0,1">
+                                    <Grid ColumnDefinitions="40,*,120,100,100">
+                                        <TextBlock Grid.Column="0"
+                                                   Text="{Binding Rank}"
+                                                   FontSize="13"
+                                                   Foreground="{DynamicResource TextMuted}"
+                                                   VerticalAlignment="Center" />
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding ShortKey}"
+                                                   FontSize="13"
+                                                   FontFamily="Consolas,Courier New,monospace"
+                                                   Foreground="{DynamicResource TextStrong}"
+                                                   VerticalAlignment="Center"
+                                                   TextTrimming="CharacterEllipsis" />
+                                        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="4"
+                                                    HorizontalAlignment="Right" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding TotalInvested}"
+                                                       FontSize="13"
+                                                       Foreground="{DynamicResource TextStrong}" />
+                                        </StackPanel>
+                                        <TextBlock Grid.Column="3"
+                                                   Text="{Binding SharePercentage}"
+                                                   FontSize="13"
+                                                   FontWeight="Bold"
+                                                   Foreground="{DynamicResource PrimaryGreenBrush}"
+                                                   HorizontalAlignment="Right"
+                                                   VerticalAlignment="Center" />
+                                        <TextBlock Grid.Column="4"
+                                                   Text="{Binding ClaimedPercentage}"
+                                                   FontSize="13"
+                                                   Foreground="#F7931A"
+                                                   HorizontalAlignment="Right"
+                                                   VerticalAlignment="Center" />
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                </StackPanel>
+            </ScrollViewer>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/src/design/App/UI/Sections/Portfolio/InvestorBreakdownView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/InvestorBreakdownView.axaml
@@ -148,46 +148,42 @@
                                             BorderBrush="{DynamicResource PrimaryGreenBrush}"
                                             BorderThickness="1.5"
                                             IsVisible="{Binding IsCurrentUser}">
-                                        <Panel>
-                                            <Border Background="{DynamicResource PrimaryGreenBrush}"
-                                                    CornerRadius="4"
-                                                    Padding="6,2"
-                                                    HorizontalAlignment="Right"
-                                                    VerticalAlignment="Top"
-                                                    Margin="0,-4,4,0">
-                                                <TextBlock Text="You"
-                                                           FontSize="10"
-                                                           FontWeight="Bold"
-                                                           Foreground="White" />
-                                            </Border>
-                                            <Grid ColumnDefinitions="40,*,120,100,100">
-                                                <TextBlock Grid.Column="0" Text="{Binding Rank}"
-                                                           FontSize="13" FontWeight="Bold"
-                                                           Foreground="{DynamicResource PrimaryGreenBrush}"
-                                                           VerticalAlignment="Center" />
-                                                <TextBlock Grid.Column="1" Text="{Binding ShortKey}"
+                                        <Grid ColumnDefinitions="40,*,120,100,100">
+                                            <TextBlock Grid.Column="0" Text="{Binding Rank}"
+                                                       FontSize="13" FontWeight="Bold"
+                                                       Foreground="{DynamicResource PrimaryGreenBrush}"
+                                                       VerticalAlignment="Center" />
+                                            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                                <TextBlock Text="{Binding ShortKey}"
                                                            FontSize="13" FontWeight="Bold"
                                                            FontFamily="Consolas,Courier New,monospace"
                                                            Foreground="{DynamicResource TextStrong}"
-                                                           VerticalAlignment="Center"
                                                            TextTrimming="CharacterEllipsis" />
-                                                <TextBlock Grid.Column="2" Text="{Binding TotalInvested}"
-                                                           FontSize="13" FontWeight="Bold"
-                                                           Foreground="{DynamicResource TextStrong}"
-                                                           HorizontalAlignment="Right"
-                                                           VerticalAlignment="Center" />
-                                                <TextBlock Grid.Column="3" Text="{Binding SharePercentage}"
-                                                           FontSize="13" FontWeight="Bold"
-                                                           Foreground="{DynamicResource PrimaryGreenBrush}"
-                                                           HorizontalAlignment="Right"
-                                                           VerticalAlignment="Center" />
-                                                <TextBlock Grid.Column="4" Text="{Binding ClaimedPercentage}"
-                                                           FontSize="13" FontWeight="Bold"
-                                                           Foreground="#F7931A"
-                                                           HorizontalAlignment="Right"
-                                                           VerticalAlignment="Center" />
-                                            </Grid>
-                                        </Panel>
+                                                <Border Background="{DynamicResource PrimaryGreenBrush}"
+                                                        CornerRadius="4"
+                                                        Padding="6,2">
+                                                    <TextBlock Text="You"
+                                                               FontSize="10"
+                                                               FontWeight="Bold"
+                                                               Foreground="White" />
+                                                </Border>
+                                            </StackPanel>
+                                            <TextBlock Grid.Column="2" Text="{Binding TotalInvested}"
+                                                       FontSize="13" FontWeight="Bold"
+                                                       Foreground="{DynamicResource TextStrong}"
+                                                       HorizontalAlignment="Right"
+                                                       VerticalAlignment="Center" />
+                                            <TextBlock Grid.Column="3" Text="{Binding SharePercentage}"
+                                                       FontSize="13" FontWeight="Bold"
+                                                       Foreground="{DynamicResource PrimaryGreenBrush}"
+                                                       HorizontalAlignment="Right"
+                                                       VerticalAlignment="Center" />
+                                            <TextBlock Grid.Column="4" Text="{Binding ClaimedPercentage}"
+                                                       FontSize="13" FontWeight="Bold"
+                                                       Foreground="#F7931A"
+                                                       HorizontalAlignment="Right"
+                                                       VerticalAlignment="Center" />
+                                        </Grid>
                                     </Border>
                                     <!-- Normal row for other investors -->
                                     <Border Padding="8,8"

--- a/src/design/App/UI/Sections/Portfolio/InvestorBreakdownView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/InvestorBreakdownView.axaml
@@ -140,43 +140,89 @@
                     <ItemsControl ItemsSource="{Binding Investors}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="portfolio:InvestorShareRowViewModel">
-                                <Border Padding="0,8"
-                                        BorderBrush="{DynamicResource Stroke}"
-                                        BorderThickness="0,0,0,1">
-                                    <Grid ColumnDefinitions="40,*,120,100,100">
-                                        <TextBlock Grid.Column="0"
-                                                   Text="{Binding Rank}"
-                                                   FontSize="13"
-                                                   Foreground="{DynamicResource TextMuted}"
-                                                   VerticalAlignment="Center" />
-                                        <TextBlock Grid.Column="1"
-                                                   Text="{Binding ShortKey}"
-                                                   FontSize="13"
-                                                   FontFamily="Consolas,Courier New,monospace"
-                                                   Foreground="{DynamicResource TextStrong}"
-                                                   VerticalAlignment="Center"
-                                                   TextTrimming="CharacterEllipsis" />
-                                        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="4"
-                                                    HorizontalAlignment="Right" VerticalAlignment="Center">
-                                            <TextBlock Text="{Binding TotalInvested}"
+                                <Panel Margin="0,2">
+                                    <!-- Highlighted row for current user -->
+                                    <Border Padding="8,8"
+                                            CornerRadius="8"
+                                            Background="#1A4B7C5A"
+                                            BorderBrush="{DynamicResource PrimaryGreenBrush}"
+                                            BorderThickness="1.5"
+                                            IsVisible="{Binding IsCurrentUser}">
+                                        <Panel>
+                                            <Border Background="{DynamicResource PrimaryGreenBrush}"
+                                                    CornerRadius="4"
+                                                    Padding="6,2"
+                                                    HorizontalAlignment="Right"
+                                                    VerticalAlignment="Top"
+                                                    Margin="0,-4,4,0">
+                                                <TextBlock Text="You"
+                                                           FontSize="10"
+                                                           FontWeight="Bold"
+                                                           Foreground="White" />
+                                            </Border>
+                                            <Grid ColumnDefinitions="40,*,120,100,100">
+                                                <TextBlock Grid.Column="0" Text="{Binding Rank}"
+                                                           FontSize="13" FontWeight="Bold"
+                                                           Foreground="{DynamicResource PrimaryGreenBrush}"
+                                                           VerticalAlignment="Center" />
+                                                <TextBlock Grid.Column="1" Text="{Binding ShortKey}"
+                                                           FontSize="13" FontWeight="Bold"
+                                                           FontFamily="Consolas,Courier New,monospace"
+                                                           Foreground="{DynamicResource TextStrong}"
+                                                           VerticalAlignment="Center"
+                                                           TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="2" Text="{Binding TotalInvested}"
+                                                           FontSize="13" FontWeight="Bold"
+                                                           Foreground="{DynamicResource TextStrong}"
+                                                           HorizontalAlignment="Right"
+                                                           VerticalAlignment="Center" />
+                                                <TextBlock Grid.Column="3" Text="{Binding SharePercentage}"
+                                                           FontSize="13" FontWeight="Bold"
+                                                           Foreground="{DynamicResource PrimaryGreenBrush}"
+                                                           HorizontalAlignment="Right"
+                                                           VerticalAlignment="Center" />
+                                                <TextBlock Grid.Column="4" Text="{Binding ClaimedPercentage}"
+                                                           FontSize="13" FontWeight="Bold"
+                                                           Foreground="#F7931A"
+                                                           HorizontalAlignment="Right"
+                                                           VerticalAlignment="Center" />
+                                            </Grid>
+                                        </Panel>
+                                    </Border>
+                                    <!-- Normal row for other investors -->
+                                    <Border Padding="8,8"
+                                            BorderBrush="{DynamicResource Stroke}"
+                                            BorderThickness="0,0,0,1"
+                                            IsVisible="{Binding !IsCurrentUser}">
+                                        <Grid ColumnDefinitions="40,*,120,100,100">
+                                            <TextBlock Grid.Column="0" Text="{Binding Rank}"
                                                        FontSize="13"
-                                                       Foreground="{DynamicResource TextStrong}" />
-                                        </StackPanel>
-                                        <TextBlock Grid.Column="3"
-                                                   Text="{Binding SharePercentage}"
-                                                   FontSize="13"
-                                                   FontWeight="Bold"
-                                                   Foreground="{DynamicResource PrimaryGreenBrush}"
-                                                   HorizontalAlignment="Right"
-                                                   VerticalAlignment="Center" />
-                                        <TextBlock Grid.Column="4"
-                                                   Text="{Binding ClaimedPercentage}"
-                                                   FontSize="13"
-                                                   Foreground="#F7931A"
-                                                   HorizontalAlignment="Right"
-                                                   VerticalAlignment="Center" />
-                                    </Grid>
-                                </Border>
+                                                       Foreground="{DynamicResource TextMuted}"
+                                                       VerticalAlignment="Center" />
+                                            <TextBlock Grid.Column="1" Text="{Binding ShortKey}"
+                                                       FontSize="13"
+                                                       FontFamily="Consolas,Courier New,monospace"
+                                                       Foreground="{DynamicResource TextStrong}"
+                                                       VerticalAlignment="Center"
+                                                       TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Grid.Column="2" Text="{Binding TotalInvested}"
+                                                       FontSize="13"
+                                                       Foreground="{DynamicResource TextStrong}"
+                                                       HorizontalAlignment="Right"
+                                                       VerticalAlignment="Center" />
+                                            <TextBlock Grid.Column="3" Text="{Binding SharePercentage}"
+                                                       FontSize="13" FontWeight="Bold"
+                                                       Foreground="{DynamicResource PrimaryGreenBrush}"
+                                                       HorizontalAlignment="Right"
+                                                       VerticalAlignment="Center" />
+                                            <TextBlock Grid.Column="4" Text="{Binding ClaimedPercentage}"
+                                                       FontSize="13"
+                                                       Foreground="#F7931A"
+                                                       HorizontalAlignment="Right"
+                                                       VerticalAlignment="Center" />
+                                        </Grid>
+                                    </Border>
+                                </Panel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/src/design/App/UI/Sections/Portfolio/InvestorBreakdownView.axaml.cs
+++ b/src/design/App/UI/Sections/Portfolio/InvestorBreakdownView.axaml.cs
@@ -1,0 +1,24 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using App.UI.Shell;
+
+namespace App.UI.Sections.Portfolio;
+
+public partial class InvestorBreakdownView : UserControl
+{
+    public InvestorBreakdownView()
+    {
+        InitializeComponent();
+        AddHandler(Button.ClickEvent, OnButtonClick, RoutingStrategies.Bubble);
+    }
+
+    private void OnButtonClick(object? sender, RoutedEventArgs e)
+    {
+        if (e.Source is Button { Name: "CloseButton" })
+        {
+            var shellVm = this.FindAncestorOfType<ShellView>()?.DataContext as ShellViewModel;
+            shellVm?.HideModal();
+        }
+    }
+}

--- a/src/design/App/UI/Sections/Portfolio/InvestorBreakdownViewModel.cs
+++ b/src/design/App/UI/Sections/Portfolio/InvestorBreakdownViewModel.cs
@@ -1,0 +1,86 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using Angor.Sdk.Common;
+using Angor.Sdk.Funding.Projects.Operations;
+
+namespace App.UI.Sections.Portfolio;
+
+/// <summary>
+/// ViewModel for a single row in the investor breakdown table.
+/// </summary>
+public class InvestorShareRowViewModel
+{
+    public int Rank { get; init; }
+    public string InvestorPublicKey { get; init; } = "";
+    public string ShortKey { get; init; } = "";
+    public string TotalInvested { get; init; } = "0.00000000";
+    public string SharePercentage { get; init; } = "0.00%";
+    public string AmountClaimed { get; init; } = "0.00000000";
+    public string ClaimedPercentage { get; init; } = "0.00%";
+    public bool IsCurrentUser { get; init; }
+    public string CurrencySymbol { get; init; } = "BTC";
+}
+
+/// <summary>
+/// ViewModel for the investor breakdown modal.
+/// Shows all investors in a project with their share percentages.
+/// </summary>
+public class InvestorBreakdownViewModel
+{
+    public string ProjectName { get; }
+    public string TotalInvested { get; }
+    public int TotalInvestors { get; }
+    public string CurrencySymbol { get; }
+    public string ProjectType { get; }
+    public bool IsFundType { get; }
+
+    /// <summary>
+    /// Context note for Fund projects: "Shares are calculated as of now.
+    /// New funds can always be added, which will change the percentages."
+    /// </summary>
+    public string? ShareContextNote { get; }
+
+    public ObservableCollection<InvestorShareRowViewModel> Investors { get; } = new();
+
+    public InvestorBreakdownViewModel(
+        GetInvestorShares.GetInvestorSharesResponse data,
+        string projectName,
+        string projectType,
+        string currencySymbol)
+    {
+        ProjectName = projectName;
+        ProjectType = projectType;
+        CurrencySymbol = currencySymbol;
+        IsFundType = projectType == "fund";
+        TotalInvested = ((double)new Amount(data.TotalInvested).Sats.ToUnitBtc())
+            .ToString("F8", CultureInfo.InvariantCulture);
+        TotalInvestors = data.TotalInvestors;
+
+        ShareContextNote = IsFundType
+            ? "Shares are calculated as of now. New funds can always be added, which will change the percentages."
+            : null;
+
+        int rank = 1;
+        foreach (var investor in data.Investors)
+        {
+            var key = investor.InvestorPublicKey;
+            var shortKey = key.Length > 12
+                ? $"{key[..6]}...{key[^6..]}"
+                : key;
+
+            Investors.Add(new InvestorShareRowViewModel
+            {
+                Rank = rank++,
+                InvestorPublicKey = key,
+                ShortKey = shortKey,
+                TotalInvested = ((double)new Amount(investor.TotalInvested).Sats.ToUnitBtc())
+                    .ToString("F8", CultureInfo.InvariantCulture),
+                SharePercentage = $"{investor.SharePercentage:F2}%",
+                AmountClaimed = ((double)new Amount(investor.AmountClaimedByFounder).Sats.ToUnitBtc())
+                    .ToString("F8", CultureInfo.InvariantCulture),
+                ClaimedPercentage = $"{investor.ClaimedPercentage:F2}%",
+                CurrencySymbol = currencySymbol
+            });
+        }
+    }
+}

--- a/src/design/App/UI/Sections/Portfolio/InvestorBreakdownViewModel.cs
+++ b/src/design/App/UI/Sections/Portfolio/InvestorBreakdownViewModel.cs
@@ -46,7 +46,8 @@ public class InvestorBreakdownViewModel
         GetInvestorShares.GetInvestorSharesResponse data,
         string projectName,
         string projectType,
-        string currencySymbol)
+        string currencySymbol,
+        string currentInvestorPublicKey = "")
     {
         ProjectName = projectName;
         ProjectType = projectType;
@@ -79,7 +80,9 @@ public class InvestorBreakdownViewModel
                 AmountClaimed = ((double)new Amount(investor.AmountClaimedByFounder).Sats.ToUnitBtc())
                     .ToString("F8", CultureInfo.InvariantCulture),
                 ClaimedPercentage = $"{investor.ClaimedPercentage:F2}%",
-                CurrencySymbol = currencySymbol
+                CurrencySymbol = currencySymbol,
+                IsCurrentUser = !string.IsNullOrEmpty(currentInvestorPublicKey)
+                    && string.Equals(key, currentInvestorPublicKey, StringComparison.OrdinalIgnoreCase)
             });
         }
     }

--- a/src/design/App/UI/Sections/Portfolio/PortfolioView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioView.axaml
@@ -507,7 +507,7 @@
                                                         TextWrapping="Wrap" />
 
                                             <!-- Funding info — Vue: .investment-stats flex justify-between -->
-                                            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto"
+                                            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto"
                                                   Margin="0,4,0,0">
                                                 <TextBlock Grid.Row="0" Grid.Column="0"
                                                            Text="Funding:"
@@ -525,11 +525,25 @@
                                                 <TextBlock Grid.Row="1" Grid.Column="0"
                                                            Text="Date:"
                                                            FontSize="13"
-                                                           Foreground="{DynamicResource TextMuted}" />
+                                                           Foreground="{DynamicResource TextMuted}"
+                                                           Margin="0,0,0,8" />
                                                 <TextBlock Grid.Row="1" Grid.Column="1"
                                                            Text="{Binding FundingDate}"
                                                            FontSize="13"
                                                            Foreground="{DynamicResource TextMuted}"
+                                                           HorizontalAlignment="Right"
+                                                           TextTrimming="CharacterEllipsis" />
+
+                                                <!-- Share of total -->
+                                                <TextBlock Grid.Row="2" Grid.Column="0"
+                                                           Text="{Binding ShareLabel}"
+                                                           FontSize="13"
+                                                           Foreground="{DynamicResource TextMuted}" />
+                                                <TextBlock Grid.Row="2" Grid.Column="1"
+                                                           Text="{Binding SharePercentageDisplay}"
+                                                           FontSize="14"
+                                                           FontWeight="Bold"
+                                                           Foreground="{DynamicResource PrimaryGreenBrush}"
                                                            HorizontalAlignment="Right"
                                                            TextTrimming="CharacterEllipsis" />
                                             </Grid>

--- a/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
@@ -513,6 +513,40 @@ public class InvestmentViewModel : INotifyPropertyChanged
         "subscription" => "Your Subscription",
         _ => "Your Investment"
     };
+
+    // ── Share / Statistics ──
+
+    /// <summary>Your share of total investment as a percentage (0-100)</summary>
+    public double SharePercentage { get; set; }
+
+    /// <summary>Formatted share percentage for display (e.g. "12.50%")</summary>
+    public string SharePercentageDisplay => SharePercentage > 0
+        ? $"{SharePercentage:F2}%"
+        : "—";
+
+    /// <summary>
+    /// Share label with context: for Fund projects notes that share is "as of now"
+    /// since new funds can always be added.
+    /// </summary>
+    public string ShareLabel => ProjectType switch
+    {
+        "fund" => "Your Share (as of now)",
+        _ => "Your Share"
+    };
+
+    /// <summary>Amount claimed by founder from your share (in BTC display format)</summary>
+    public string AmountClaimedByFounder { get; set; } = "0.00000000";
+
+    /// <summary>Percentage of your investment claimed by the founder</summary>
+    public double ClaimedPercentage { get; set; }
+
+    /// <summary>Formatted claimed percentage for display</summary>
+    public string ClaimedPercentageDisplay => ClaimedPercentage > 0
+        ? $"{ClaimedPercentage:F2}%"
+        : "—";
+
+    /// <summary>Whether there is any claimed amount to show</summary>
+    public bool HasClaimedAmount => ClaimedPercentage > 0;
 }
 
 /// <summary>
@@ -734,7 +768,11 @@ public partial class PortfolioViewModel : ReactiveObject, IDisposable, INetworkS
                     ProjectIdentifier = dto.Id ?? "",
                         InvestmentWalletId = wallet.Id.Value,
                         InvestmentTransactionId = dto.InvestmentId ?? "",
-                        CurrencySymbol = _currencyService.Symbol
+                        CurrencySymbol = _currencyService.Symbol,
+                        SharePercentage = dto.SharePercentage,
+                        ClaimedPercentage = dto.ClaimedPercentage,
+                        AmountClaimedByFounder = ((double)new Amount(dto.AmountClaimedByFounder).Sats.ToUnitBtc())
+                            .ToString("F8", CultureInfo.InvariantCulture)
                     };
 
                     // Carry over recovery state from previous load so per-investment recovery

--- a/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
+++ b/src/design/App/UI/Sections/Portfolio/PortfolioViewModel.cs
@@ -299,6 +299,8 @@ public class InvestmentViewModel : INotifyPropertyChanged
     public string InvestmentWalletId { get; set; } = "";
     /// <summary>Transaction ID/hash of the investment</summary>
     public string InvestmentTransactionId { get; set; } = "";
+    /// <summary>Investor's public key (hex) for identifying current user in breakdown</summary>
+    public string InvestorPublicKey { get; set; } = "";
     public ObservableCollection<InvestmentStageViewModel> Stages { get; set; } = new();
 
     // ── Recovery State (replaces simplified string-based PenaltyState) ──
@@ -772,7 +774,8 @@ public partial class PortfolioViewModel : ReactiveObject, IDisposable, INetworkS
                         SharePercentage = dto.SharePercentage,
                         ClaimedPercentage = dto.ClaimedPercentage,
                         AmountClaimedByFounder = ((double)new Amount(dto.AmountClaimedByFounder).Sats.ToUnitBtc())
-                            .ToString("F8", CultureInfo.InvariantCulture)
+                            .ToString("F8", CultureInfo.InvariantCulture),
+                        InvestorPublicKey = dto.InvestorPublicKey ?? ""
                     };
 
                     // Carry over recovery state from previous load so per-investment recovery

--- a/src/sdk/Angor.Sdk/Funding/Investor/InvestedProjectDto.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/InvestedProjectDto.cs
@@ -48,6 +48,22 @@ public class InvestedProjectDto
     /// Total number of unique investors in this project (from indexer stats).
     /// </summary>
     public int TotalInvestors { get; set; }
+
+    /// <summary>
+    /// This investor's share of the total project investment as a percentage (0-100).
+    /// For Fund projects, this is "as of now" since funds can always be added.
+    /// </summary>
+    public double SharePercentage { get; set; }
+
+    /// <summary>
+    /// Amount from this investor's share that has been claimed/spent by the founder (in sats).
+    /// </summary>
+    public long AmountClaimedByFounder { get; set; }
+
+    /// <summary>
+    /// Percentage of this investor's total that has been claimed by the founder (0-100).
+    /// </summary>
+    public double ClaimedPercentage { get; set; }
 }
 
 public enum FounderStatus

--- a/src/sdk/Angor.Sdk/Funding/Investor/InvestedProjectDto.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/InvestedProjectDto.cs
@@ -64,6 +64,12 @@ public class InvestedProjectDto
     /// Percentage of this investor's total that has been claimed by the founder (0-100).
     /// </summary>
     public double ClaimedPercentage { get; set; }
+
+    /// <summary>
+    /// The investor's public key (hex) for this investment, used to identify the current user
+    /// in the investor breakdown view.
+    /// </summary>
+    public string InvestorPublicKey { get; set; } = "";
 }
 
 public enum FounderStatus

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetInvestments.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetInvestments.cs
@@ -107,7 +107,12 @@ public static class GetInvestments
                         StartingDate = project.StartingDate,
                         EndDate = project.EndDate,
                         ProjectType = project.ProjectType,
-                        TotalInvestors = (int)(stats.stats?.InvestorCount ?? 0)
+                        TotalInvestors = (int)(stats.stats?.InvestorCount ?? 0),
+                        // Compute share percentage from already-fetched data.
+                        // For Fund projects this is "as of now" since new funds can be added.
+                        SharePercentage = ComputeSharePercentage(
+                            investment?.TotalAmount > 0 ? investment.TotalAmount : investmentRecord.InvestedAmountSats,
+                            stats.stats?.AmountInvested ?? 0)
                     };
 
                     if (investment != null && investment.TotalAmount > 0)
@@ -233,6 +238,14 @@ public static class GetInvestments
                 return InvestmentStatus.FounderSignaturesReceived;
 
             return InvestmentStatus.PendingFounderSignatures;
+        }
+
+        private static double ComputeSharePercentage(long myInvestment, long totalRaised)
+        {
+            if (totalRaised <= 0 || myInvestment <= 0)
+                return 0;
+
+            return Math.Round((double)myInvestment / totalRaised * 100, 2);
         }
     }
 }

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetInvestments.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetInvestments.cs
@@ -112,7 +112,8 @@ public static class GetInvestments
                         // For Fund projects this is "as of now" since new funds can be added.
                         SharePercentage = ComputeSharePercentage(
                             investment?.TotalAmount > 0 ? investment.TotalAmount : investmentRecord.InvestedAmountSats,
-                            stats.stats?.AmountInvested ?? 0)
+                            stats.stats?.AmountInvested ?? 0),
+                        InvestorPublicKey = investmentRecord.InvestorPubKey ?? ""
                     };
 
                     if (investment != null && investment.TotalAmount > 0)

--- a/src/sdk/Angor.Sdk/Funding/Projects/Dtos/InvestorShareDto.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/Dtos/InvestorShareDto.cs
@@ -1,0 +1,18 @@
+namespace Angor.Sdk.Funding.Projects.Dtos;
+
+/// <summary>
+/// Represents a single investor's share in a project.
+/// </summary>
+/// <param name="InvestorPublicKey">The investor's public key (hex).</param>
+/// <param name="InvestorNpub">The investor's Nostr npub, if available.</param>
+/// <param name="TotalInvested">Total amount invested by this investor (in sats).</param>
+/// <param name="SharePercentage">This investor's share of the total project investment (0-100).</param>
+/// <param name="AmountClaimedByFounder">Amount from this investor's share that has been claimed/spent by the founder (in sats).</param>
+/// <param name="ClaimedPercentage">Percentage of this investor's total that has been claimed by the founder (0-100).</param>
+public record InvestorShareDto(
+    string InvestorPublicKey,
+    string InvestorNpub,
+    long TotalInvested,
+    double SharePercentage,
+    long AmountClaimedByFounder,
+    double ClaimedPercentage);

--- a/src/sdk/Angor.Sdk/Funding/Projects/IProjectAppService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/IProjectAppService.cs
@@ -24,6 +24,12 @@ public interface IProjectAppService
     Task<Result<CreateProjectInfoResponse>> CreateProjectInfo(WalletId walletId, CreateProjectDto project, ProjectSeedDto projectSeedDto);
     Task<Result<CreateProjectResponse>> CreateProject(WalletId walletId, long selectedFee, CreateProjectDto project, string projectInfoEventId, ProjectSeedDto projectSeedDto);
     Task<Result<ProjectStatisticsDto>> GetProjectStatistics(ProjectId projectId);
+
+    /// <summary>
+    /// Gets per-investor share breakdown for a project, showing each investor's
+    /// total investment, share percentage, and amount claimed by the founder.
+    /// </summary>
+    Task<Result<GetInvestorShares.GetInvestorSharesResponse>> GetInvestorShares(ProjectId projectId);
     Task<Result<GetProjectRelays.GetProjectRelaysResponse>> GetRelaysForNpubAsync(string nostrPubKey);
     Task<Result<GetProjectInfoJson.GetProjectInfoJsonResponse>> GetProjectInfoJson(ProjectId projectId);
 

--- a/src/sdk/Angor.Sdk/Funding/Projects/Operations/GetInvestorShares.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/Operations/GetInvestorShares.cs
@@ -1,0 +1,103 @@
+using Angor.Sdk.Funding.Projects.Domain;
+using Angor.Sdk.Funding.Projects.Dtos;
+using Angor.Sdk.Funding.Shared;
+using CSharpFunctionalExtensions;
+using MediatR;
+
+namespace Angor.Sdk.Funding.Projects.Operations;
+
+/// <summary>
+/// Computes per-investor share breakdown for a project.
+/// Each investor's total investment, share percentage of the total pool,
+/// and the amount already claimed (spent) by the founder are calculated
+/// from on-chain stage data.
+///
+/// For "Fund" type projects, the share is labelled "as of now" because
+/// new funds can always be added, changing the total pool.
+/// For "Invest" type projects, the share also includes how much of the
+/// investor's share has been claimed by the founder.
+/// </summary>
+public static class GetInvestorShares
+{
+    public record GetInvestorSharesRequest(ProjectId ProjectId) : IRequest<Result<GetInvestorSharesResponse>>;
+
+    public record GetInvestorSharesResponse(
+        long TotalInvested,
+        int TotalInvestors,
+        IReadOnlyList<InvestorShareDto> Investors);
+
+    public class GetInvestorSharesHandler(IProjectInvestmentsService projectInvestmentsService)
+        : IRequestHandler<GetInvestorSharesRequest, Result<GetInvestorSharesResponse>>
+    {
+        public async Task<Result<GetInvestorSharesResponse>> Handle(
+            GetInvestorSharesRequest request, CancellationToken cancellationToken)
+        {
+            var stagesResult = await projectInvestmentsService.ScanFullInvestments(request.ProjectId.Value);
+
+            if (stagesResult.IsFailure)
+            {
+                return Result.Failure<GetInvestorSharesResponse>(stagesResult.Error);
+            }
+
+            var stages = stagesResult.Value.ToList();
+
+            if (!stages.Any())
+            {
+                return Result.Success(new GetInvestorSharesResponse(0, 0, Array.Empty<InvestorShareDto>()));
+            }
+
+            // Flatten all stage transaction items and group by investor public key
+            var allItems = stages.SelectMany(s => s.Items)
+                .Where(i => !string.IsNullOrEmpty(i.InvestorPublicKey))
+                .ToList();
+
+            var totalInvested = allItems.Sum(i => i.Amount);
+            var totalSpentByFounder = allItems.Where(i => i.IsSpent && IsFounderSpend(i.SpentType)).Sum(i => i.Amount);
+
+            var investorGroups = allItems
+                .GroupBy(i => i.InvestorPublicKey)
+                .Select(g =>
+                {
+                    var investorTotal = g.Sum(i => i.Amount);
+                    var investorSpent = g.Where(i => i.IsSpent && IsFounderSpend(i.SpentType)).Sum(i => i.Amount);
+                    var sharePercentage = totalInvested > 0
+                        ? Math.Round((double)investorTotal / totalInvested * 100, 2)
+                        : 0;
+                    var spentSharePercentage = investorTotal > 0
+                        ? Math.Round((double)investorSpent / investorTotal * 100, 2)
+                        : 0;
+
+                    return new InvestorShareDto(
+                        InvestorPublicKey: g.Key,
+                        InvestorNpub: g.First().InvestorNpub ?? "",
+                        TotalInvested: investorTotal,
+                        SharePercentage: sharePercentage,
+                        AmountClaimedByFounder: investorSpent,
+                        ClaimedPercentage: spentSharePercentage);
+                })
+                .OrderByDescending(i => i.TotalInvested)
+                .ToList();
+
+            return Result.Success(new GetInvestorSharesResponse(
+                totalInvested,
+                investorGroups.Count,
+                investorGroups));
+        }
+
+        /// <summary>
+        /// Determines if a spend type represents a founder claim/withdrawal
+        /// (as opposed to investor recovery or penalty).
+        /// </summary>
+        private static bool IsFounderSpend(string spentType)
+        {
+            if (string.IsNullOrEmpty(spentType))
+                return false;
+
+            // Founder spends are typically stage releases / withdrawals.
+            // Investor spends are recoveries, penalties, unfunded releases.
+            // The SpentType values come from the indexer and match ProjectScriptType names.
+            return spentType.Contains("Founder", StringComparison.OrdinalIgnoreCase)
+                   || spentType.Equals("AngorKey", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/sdk/Angor.Sdk/Funding/Projects/ProjectAppService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/ProjectAppService.cs
@@ -56,6 +56,11 @@ public class ProjectAppService(
         return mediator.Send(new ProjectStatistics.ProjectStatsRequest(projectId));
     }
 
+    public Task<Result<GetInvestorShares.GetInvestorSharesResponse>> GetInvestorShares(ProjectId projectId)
+    {
+        return mediator.Send(new GetInvestorShares.GetInvestorSharesRequest(projectId));
+    }
+
     public Task<Result<GetProjectRelays.GetProjectRelaysResponse>> GetRelaysForNpubAsync(string nostrPubKey)
     {
         return mediator.Send(new GetProjectRelays.GetProjectRelaysRequest(nostrPubKey));


### PR DESCRIPTION
﻿## Summary

Adds investment share calculations to the SDK and displays them in the design app's Funded tab, so investors can see their share of the total investment pool and founders can see the breakdown per investor.

## SDK Changes

- **New GetInvestorShares operation**: Computes per-investor share breakdown from on-chain stage data. For each investor, calculates total invested, share percentage, amount claimed by founder, and claimed percentage.
- **New InvestorShareDto**: Record type for per-investor share data.
- **Extended InvestedProjectDto**: Added SharePercentage, AmountClaimedByFounder, ClaimedPercentage fields.
- **Wired to IProjectAppService**: New GetInvestorShares method available for both desktop and web clients.

## UI Changes

- **Investment cards**: Show Your Share percentage. Fund projects label it as current snapshot.
- **Investment detail view**: New share stats row with Your Share %, Claimed by Founder %, and View All button.
- **Investor Breakdown modal**: All investors ranked by investment size with share and claimed percentages.

## Notes

- All calculations in SDK layer for web client reuse.
- Card share uses already-fetched indexer data. Modal calls GetInvestorShares for full on-chain scan.
