### PR TITLE
ci: sign Windows releases via SignPath.io

### DIFF
--- a/.github/workflows/release-avalonia.yml
+++ b/.github/workflows/release-avalonia.yml
@@ -66,6 +66,8 @@ jobs:
   build-windows:
     runs-on: windows-latest
     needs: [prepare, test]
+    outputs:
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
     steps:
       - uses: actions/checkout@v4
       
@@ -111,10 +113,52 @@ jobs:
           Copy-Item publish-win-arm64/Angor2.exe artifacts/Angor-${{ needs.prepare.outputs.version }}-win-arm64-Portable.exe
       
       - name: Upload Windows artifacts
+        id: upload
         uses: actions/upload-artifact@v4
         with:
           name: windows-installers
           path: artifacts/*.exe
+
+  # Sign Windows executables via SignPath.io (free OSS code signing).
+  # Requires:
+  #   - secret SIGNPATH_API_TOKEN  (CI user API token from SignPath)
+  #   - variable SIGNPATH_ORGANIZATION_ID
+  # If not configured the job cleanly no-ops and unsigned artifacts are released.
+  sign-windows:
+    runs-on: ubuntu-latest
+    needs: [prepare, build-windows]
+    permissions:
+      id-token: write # required by SignPath to verify the origin of the artifact
+      contents: read
+      actions: read # allow SignPath connector to download the build artifact
+    env:
+      HAS_SIGNPATH: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+    steps:
+      - name: Skip if SignPath not configured
+        if: env.HAS_SIGNPATH != 'true'
+        run: |
+          echo "SIGNPATH_API_TOKEN secret not set — skipping Windows code signing."
+          echo "Release will contain unsigned Windows executables."
+
+      - name: Submit SignPath signing request
+        if: env.HAS_SIGNPATH == 'true'
+        uses: signpath/github-action-submit-signing-request@v1.2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: angor
+          signing-policy-slug: release-signing
+          github-artifact-id: ${{ needs.build-windows.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed-artifacts
+
+      - name: Replace artifact with signed executables
+        if: env.HAS_SIGNPATH == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installers
+          path: signed-artifacts/*.exe
+          overwrite: true
 
   # Build Linux packages (.deb, .AppImage, .rpm). macOS DMGs build natively in build-macos.
   build-linux:
@@ -456,7 +500,7 @@ jobs:
   # Create GitHub Release and upload all artifacts
   release:
     runs-on: ubuntu-latest
-    needs: [prepare, build-windows, build-linux, build-macos, build-android, build-cli]
+    needs: [prepare, build-windows, sign-windows, build-linux, build-macos, build-android, build-cli]
     permissions:
       contents: write
     steps:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ If macOS reports the app as **"damaged and can't be opened"** (an older download
 xattr -dr com.apple.quarantine /Applications/Angor.app
 ```
 
+## Code Signing
+
+Free code signing on Windows provided by [SignPath.io](https://signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).
+
 ## Releasing
 
 To create a new release:


### PR DESCRIPTION
Adds Windows code signing to the release pipeline using SignPath.io's free open-source signing service, to remove SmartScreen warnings on the Windows installers and portable exes.

## Changes

- **release-avalonia.yml**: new `sign-windows` job between `build-windows` and `release`:
  - `build-windows` exposes its uploaded artifact ID as a job output
  - `sign-windows` submits the artifact to SignPath (`signpath/github-action-submit-signing-request`), waits for completion, and overwrites the `windows-installers` artifact with the signed exes
  - Cleanly no-ops if `SIGNPATH_API_TOKEN` is not configured (release ships unsigned, same pattern as the ZapStore job)
- **README.md**: SignPath Foundation attribution (required by their OSS program)

## Setup required before this takes effect

1. SignPath Foundation OSS certificate approval (application submitted)
2. SignPath project slug `angor`, signing policy slug `release-signing`
3. Repo secret `SIGNPATH_API_TOKEN` + repo variable `SIGNPATH_ORGANIZATION_ID`
