### PR TITLE
Add log-monitor tool: Discord notifications for log exports

### DIFF
--- a/src/tools/decrypt-log/.gitignore
+++ b/src/tools/decrypt-log/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
+.env
 fetch-config.json
 *.zip

--- a/src/tools/decrypt-log/.gitignore
+++ b/src/tools/decrypt-log/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+fetch-config.json
+*.zip

--- a/src/tools/decrypt-log/fetch-latest.cmd
+++ b/src/tools/decrypt-log/fetch-latest.cmd
@@ -1,0 +1,7 @@
+@echo off
+rem Double-click to fetch + decrypt the latest Angor log export.
+rem Requires fetch-config.json next to this file (see fetch-latest.mjs header).
+cd /d "%~dp0"
+if not exist node_modules call npm install --no-audit --no-fund
+node fetch-latest.mjs %*
+pause

--- a/src/tools/decrypt-log/fetch-latest.mjs
+++ b/src/tools/decrypt-log/fetch-latest.mjs
@@ -1,16 +1,13 @@
 #!/usr/bin/env node
 
-// Fetch and decrypt the latest Angor log export, with optional Discord upload.
+// Fetch and decrypt the latest Angor log export.
 //
 // Usage:
-//   node fetch-latest.mjs [--event <eventId>] [--no-upload] [output.zip]
+//   node fetch-latest.mjs [--event <eventId>] [output.zip]
 //
-// Config file (same directory, gitignored): fetch-config.json
-//   {
-//     "nsec": "nsec1...",                        // support nsec (required)
-//     "discordWebhookUrl": "https://discord...", // optional: enables upload prompt
-//     "outputDir": "C:\\Users\\me\\Downloads"    // optional: default save location
-//   }
+// Config: .env file in the same directory (gitignored):
+//   SUPPORT_NSEC=nsec1...
+//   OUTPUT_DIR=C:\Users\me\Downloads     (optional)
 
 import { nip04, nip44, nip19, getPublicKey } from 'nostr-tools';
 import { SimplePool } from 'nostr-tools/pool';
@@ -18,7 +15,6 @@ import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
-import { createInterface } from 'readline/promises';
 import 'websocket-polyfill';
 
 const DEFAULT_RELAYS = [
@@ -29,33 +25,35 @@ const DEFAULT_RELAYS = [
 ];
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
-const configPath = join(scriptDir, 'fetch-config.json');
+const envPath = join(scriptDir, '.env');
 
-if (!existsSync(configPath)) {
-  console.error(`ERROR: config file not found: ${configPath}`);
-  console.error('Create it with: { "nsec": "nsec1...", "discordWebhookUrl": "https://discord.com/api/webhooks/..." }');
+// Minimal .env parser
+const config = {};
+if (existsSync(envPath)) {
+  for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+    const m = line.match(/^\s*([A-Z_]+)\s*=\s*(.+?)\s*$/);
+    if (m && !line.trim().startsWith('#')) config[m[1]] = m[2];
+  }
+}
+
+const nsec = process.env.SUPPORT_NSEC || config.SUPPORT_NSEC;
+if (!nsec || nsec.includes('PASTE')) {
+  console.error(`ERROR: SUPPORT_NSEC not set. Create ${envPath} containing:`);
+  console.error('SUPPORT_NSEC=nsec1...');
   process.exit(1);
 }
 
-const config = JSON.parse(readFileSync(configPath, 'utf8'));
-if (!config.nsec) {
-  console.error('ERROR: "nsec" missing from fetch-config.json');
-  process.exit(1);
-}
-
-const privateKeyHex = config.nsec.startsWith('nsec1')
-  ? Buffer.from(nip19.decode(config.nsec).data).toString('hex')
-  : config.nsec.toLowerCase();
+const privateKeyHex = nsec.startsWith('nsec1')
+  ? Buffer.from(nip19.decode(nsec).data).toString('hex')
+  : nsec.toLowerCase();
 const supportPubkey = getPublicKey(Buffer.from(privateKeyHex, 'hex'));
 
 // --- Args ---
 const args = process.argv.slice(2);
 let eventIdArg = null;
-let noUpload = false;
 let outputArg = null;
 for (let i = 0; i < args.length; i++) {
   if (args[i] === '--event') eventIdArg = args[++i];
-  else if (args[i] === '--no-upload') noUpload = true;
   else outputArg = args[i];
 }
 
@@ -124,33 +122,10 @@ if (blobContent.includes('?iv=')) {
 const zipBytes = Buffer.from(zipBase64, 'base64');
 
 const stamp = new Date(event.created_at * 1000).toISOString().replace(/[:T]/g, '-').slice(0, 19);
-const outDir = config.outputDir || join(homedir(), 'Downloads');
+const outDir = config.OUTPUT_DIR || join(homedir(), 'Downloads');
 const outputPath = outputArg || join(outDir, `angor-log-${stamp}.zip`);
 writeFileSync(outputPath, zipBytes);
 console.log(`Saved: ${outputPath} (${zipBytes.length} bytes)`);
-
-// --- Optional Discord upload ---
-if (config.discordWebhookUrl && !noUpload) {
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  const answer = await rl.question('Upload decrypted zip to Discord channel? [y/N] ');
-  rl.close();
-
-  if (answer.trim().toLowerCase() === 'y') {
-    if (zipBytes.length > 10 * 1024 * 1024) {
-      console.error('ERROR: zip exceeds Discord 10MB webhook limit; not uploading');
-    } else {
-      const meta = dmContent.split('\n').slice(1).join('\n');
-      const form = new FormData();
-      form.append('payload_json', JSON.stringify({
-        content: `📦 Decrypted log export\n${meta}`,
-      }));
-      form.append('files[0]', new Blob([zipBytes], { type: 'application/zip' }), `angor-log-${stamp}.zip`);
-      const up = await fetch(config.discordWebhookUrl, { method: 'POST', body: form });
-      if (up.ok) console.log('Uploaded to Discord.');
-      else console.error(`ERROR: Discord upload failed: ${up.status} ${await up.text().catch(() => '')}`);
-    }
-  }
-}
 
 pool.close(DEFAULT_RELAYS);
 process.exit(0);

--- a/src/tools/decrypt-log/fetch-latest.mjs
+++ b/src/tools/decrypt-log/fetch-latest.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+// Fetch and decrypt the latest Angor log export, with optional Discord upload.
+//
+// Usage:
+//   node fetch-latest.mjs [--event <eventId>] [--no-upload] [output.zip]
+//
+// Config file (same directory, gitignored): fetch-config.json
+//   {
+//     "nsec": "nsec1...",                        // support nsec (required)
+//     "discordWebhookUrl": "https://discord...", // optional: enables upload prompt
+//     "outputDir": "C:\\Users\\me\\Downloads"    // optional: default save location
+//   }
+
+import { nip04, nip44, nip19, getPublicKey } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import { createInterface } from 'readline/promises';
+import 'websocket-polyfill';
+
+const DEFAULT_RELAYS = [
+  'wss://relay.angor.io',
+  'wss://relay2.angor.io',
+  'wss://relay.damus.io',
+  'wss://nos.lol',
+];
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const configPath = join(scriptDir, 'fetch-config.json');
+
+if (!existsSync(configPath)) {
+  console.error(`ERROR: config file not found: ${configPath}`);
+  console.error('Create it with: { "nsec": "nsec1...", "discordWebhookUrl": "https://discord.com/api/webhooks/..." }');
+  process.exit(1);
+}
+
+const config = JSON.parse(readFileSync(configPath, 'utf8'));
+if (!config.nsec) {
+  console.error('ERROR: "nsec" missing from fetch-config.json');
+  process.exit(1);
+}
+
+const privateKeyHex = config.nsec.startsWith('nsec1')
+  ? Buffer.from(nip19.decode(config.nsec).data).toString('hex')
+  : config.nsec.toLowerCase();
+const supportPubkey = getPublicKey(Buffer.from(privateKeyHex, 'hex'));
+
+// --- Args ---
+const args = process.argv.slice(2);
+let eventIdArg = null;
+let noUpload = false;
+let outputArg = null;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--event') eventIdArg = args[++i];
+  else if (args[i] === '--no-upload') noUpload = true;
+  else outputArg = args[i];
+}
+
+// --- Decrypt helpers (NIP-44 / NIP-04 auto-detect) ---
+async function decryptContent(pubkey, content) {
+  if (content.includes('?iv=')) return await nip04.decrypt(privateKeyHex, pubkey, content);
+  const conversationKey = nip44.v2.utils.getConversationKey(Buffer.from(privateKeyHex, 'hex'), pubkey);
+  return nip44.v2.decrypt(content, conversationKey);
+}
+
+// --- Fetch event ---
+const pool = new SimplePool();
+let event;
+
+if (eventIdArg) {
+  let id = eventIdArg.startsWith('note1') ? nip19.decode(eventIdArg).data : eventIdArg;
+  console.log(`Fetching event ${id.slice(0, 12)}...`);
+  event = await pool.get(DEFAULT_RELAYS, { ids: [id], kinds: [4] });
+} else {
+  console.log('Fetching latest log-export DM...');
+  const events = await pool.querySync(DEFAULT_RELAYS, { kinds: [4], '#p': [supportPubkey], limit: 5 });
+  const sorted = [...new Map(events.map(e => [e.id, e])).values()].sort((a, b) => b.created_at - a.created_at);
+  event = sorted[0];
+}
+
+if (!event) {
+  console.error('ERROR: no DM found');
+  pool.close(DEFAULT_RELAYS);
+  process.exit(1);
+}
+
+console.log(`Event:  ${event.id}`);
+console.log(`Sender: ${nip19.npubEncode(event.pubkey)}`);
+console.log(`Date:   ${new Date(event.created_at * 1000).toISOString()}`);
+
+const dmContent = await decryptContent(event.pubkey, event.content);
+console.log('\n' + dmContent + '\n');
+
+const urlMatch = dmContent.match(/URL:\s*(https?:\/\/\S+)/);
+if (!urlMatch) {
+  console.error('ERROR: DM contains no blob URL (not a log export?)');
+  pool.close(DEFAULT_RELAYS);
+  process.exit(1);
+}
+
+// --- Download + decrypt blob ---
+const blobUrl = urlMatch[1];
+console.log(`Downloading ${blobUrl}...`);
+const res = await fetch(blobUrl);
+if (!res.ok) {
+  console.error(`ERROR: download failed: ${res.status} ${res.statusText}`);
+  pool.close(DEFAULT_RELAYS);
+  process.exit(1);
+}
+const blobContent = await res.text();
+
+let zipBase64;
+if (blobContent.includes('?iv=')) {
+  zipBase64 = await nip04.decrypt(privateKeyHex, event.pubkey, blobContent);
+} else {
+  const conversationKey = nip44.v2.utils.getConversationKey(Buffer.from(privateKeyHex, 'hex'), event.pubkey);
+  const chunks = blobContent.trim().split('\n');
+  console.log(`Decrypting ${chunks.length} chunk(s)...`);
+  zipBase64 = chunks.map(c => nip44.v2.decrypt(c.trim(), conversationKey)).join('');
+}
+const zipBytes = Buffer.from(zipBase64, 'base64');
+
+const stamp = new Date(event.created_at * 1000).toISOString().replace(/[:T]/g, '-').slice(0, 19);
+const outDir = config.outputDir || join(homedir(), 'Downloads');
+const outputPath = outputArg || join(outDir, `angor-log-${stamp}.zip`);
+writeFileSync(outputPath, zipBytes);
+console.log(`Saved: ${outputPath} (${zipBytes.length} bytes)`);
+
+// --- Optional Discord upload ---
+if (config.discordWebhookUrl && !noUpload) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await rl.question('Upload decrypted zip to Discord channel? [y/N] ');
+  rl.close();
+
+  if (answer.trim().toLowerCase() === 'y') {
+    if (zipBytes.length > 10 * 1024 * 1024) {
+      console.error('ERROR: zip exceeds Discord 10MB webhook limit; not uploading');
+    } else {
+      const meta = dmContent.split('\n').slice(1).join('\n');
+      const form = new FormData();
+      form.append('payload_json', JSON.stringify({
+        content: `📦 Decrypted log export\n${meta}`,
+      }));
+      form.append('files[0]', new Blob([zipBytes], { type: 'application/zip' }), `angor-log-${stamp}.zip`);
+      const up = await fetch(config.discordWebhookUrl, { method: 'POST', body: form });
+      if (up.ok) console.log('Uploaded to Discord.');
+      else console.error(`ERROR: Discord upload failed: ${up.status} ${await up.text().catch(() => '')}`);
+    }
+  }
+}
+
+pool.close(DEFAULT_RELAYS);
+process.exit(0);

--- a/src/tools/decrypt-log/list-dms.mjs
+++ b/src/tools/decrypt-log/list-dms.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+// List recent kind-4 DMs sent to a pubkey (most recent first): id, sender, created_at
+import { nip19 } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import 'websocket-polyfill';
+
+const npub = process.argv[2];
+const hex = npub.startsWith('npub1') ? nip19.decode(npub).data : npub;
+const relays = ['wss://relay.angor.io', 'wss://relay2.angor.io', 'wss://relay.damus.io', 'wss://nos.lol'];
+const pool = new SimplePool();
+const events = await pool.querySync(relays, { kinds: [4], '#p': [hex], limit: 10 });
+const unique = [...new Map(events.map(e => [e.id, e])).values()]
+  .sort((a, b) => b.created_at - a.created_at);
+for (const e of unique) {
+  console.log(`${new Date(e.created_at * 1000).toISOString()}  ${e.id}  from ${e.pubkey}`);
+}
+pool.close(relays);
+process.exit(0);

--- a/src/tools/log-monitor/.gitignore
+++ b/src/tools/log-monitor/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+seen-events.json
+*.log

--- a/src/tools/log-monitor/monitor-logs.mjs
+++ b/src/tools/log-monitor/monitor-logs.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+// Monitor Nostr relays for Angor log-export DMs and post to Discord.
+//
+// Watches for kind-4 DMs addressed to the Angor support npub. When a new
+// log export arrives, posts a notification to a Discord webhook.
+//
+// If the support nsec is provided, the DM content is decrypted and the
+// notification includes the metadata (blob URL, app version, platform,
+// network, timestamp). Otherwise a notify-only message is posted with
+// just the sender pubkey and event id.
+//
+// Usage:
+//   node monitor-logs.mjs
+//
+// Configuration (env vars):
+//   DISCORD_WEBHOOK_URL   (required)  Discord webhook(s) to post to;
+//                                     comma-separated for multiple channels
+//                                     (e.g. main Discord + Armada Angor channel)
+//   SUPPORT_NPUB          (required*) support npub (npub1... or 64-char hex)
+//   SUPPORT_NSEC          (optional)  support nsec (nsec1... or 64-char hex);
+//                                     enables decryption. *If set, SUPPORT_NPUB
+//                                     is derived from it and may be omitted.
+//   RELAYS                (optional)  comma-separated relay URLs
+//   LOOKBACK_HOURS        (optional)  how far back to scan on startup (default 1)
+//   STATE_FILE            (optional)  path to seen-events state file
+//                                     (default ./seen-events.json)
+
+import { nip04, nip44, nip19, getPublicKey } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import 'websocket-polyfill';
+
+const DEFAULT_RELAYS = [
+  'wss://relay.angor.io',
+  'wss://relay2.angor.io',
+  'wss://relay.damus.io',
+  'wss://nos.lol',
+];
+
+// --- Config ---------------------------------------------------------------
+
+function parseKey(input, prefix) {
+  if (!input) return null;
+  input = input.trim();
+  if (input.startsWith(prefix)) {
+    const decoded = nip19.decode(input);
+    // nsec decodes to Uint8Array, npub decodes to hex string
+    return typeof decoded.data === 'string'
+      ? decoded.data.toLowerCase()
+      : Buffer.from(decoded.data).toString('hex');
+  }
+  if (/^[0-9a-f]{64}$/i.test(input)) return input.toLowerCase();
+  throw new Error(`Key must be bech32 (${prefix}...) or 64-char hex`);
+}
+
+const webhookUrls = (process.env.DISCORD_WEBHOOK_URL || '')
+  .split(',')
+  .map(u => u.trim())
+  .filter(Boolean);
+if (webhookUrls.length === 0) {
+  console.error('ERROR: DISCORD_WEBHOOK_URL is required (comma-separated for multiple)');
+  process.exit(1);
+}
+
+let supportNsecHex = null;
+try {
+  supportNsecHex = parseKey(process.env.SUPPORT_NSEC, 'nsec1');
+} catch (err) {
+  console.error(`ERROR: invalid SUPPORT_NSEC: ${err.message}`);
+  process.exit(1);
+}
+
+let supportNpubHex;
+if (supportNsecHex) {
+  supportNpubHex = getPublicKey(Buffer.from(supportNsecHex, 'hex'));
+} else {
+  try {
+    supportNpubHex = parseKey(process.env.SUPPORT_NPUB, 'npub1');
+  } catch (err) {
+    console.error(`ERROR: invalid SUPPORT_NPUB: ${err.message}`);
+    process.exit(1);
+  }
+  if (!supportNpubHex) {
+    console.error('ERROR: SUPPORT_NPUB (or SUPPORT_NSEC) is required');
+    process.exit(1);
+  }
+}
+
+const relays = (process.env.RELAYS || '')
+  .split(',')
+  .map(r => r.trim())
+  .filter(Boolean);
+const relayUrls = relays.length > 0 ? relays : DEFAULT_RELAYS;
+
+const lookbackHours = Number(process.env.LOOKBACK_HOURS || 1);
+const stateFile = process.env.STATE_FILE || fileURLToPath(new URL('./seen-events.json', import.meta.url));
+
+// --- Seen-event state (dedup across restarts + multi-relay) ----------------
+
+const seen = new Set();
+try {
+  if (existsSync(stateFile)) {
+    for (const id of JSON.parse(readFileSync(stateFile, 'utf8'))) seen.add(id);
+  }
+} catch (err) {
+  console.warn(`WARN: could not read state file: ${err.message}`);
+}
+
+function persistSeen() {
+  try {
+    // keep the most recent 5000 ids
+    writeFileSync(stateFile, JSON.stringify([...seen].slice(-5000)));
+  } catch (err) {
+    console.warn(`WARN: could not write state file: ${err.message}`);
+  }
+}
+
+// --- Decryption (same auto-detect as decrypt-log.mjs) -----------------------
+
+async function decryptContent(privateKeyHex, pubkey, content) {
+  if (content.includes('?iv=')) {
+    return await nip04.decrypt(privateKeyHex, pubkey, content);
+  }
+  const privKeyBytes = Buffer.from(privateKeyHex, 'hex');
+  const conversationKey = nip44.v2.utils.getConversationKey(privKeyBytes, pubkey);
+  return nip44.v2.decrypt(content, conversationKey);
+}
+
+function parseDmMetadata(dmContent) {
+  const get = re => dmContent.match(re)?.[1]?.trim() ?? null;
+  return {
+    isLogExport: /^Log Export/m.test(dmContent),
+    url: get(/URL:\s*(https?:\/\/\S+)/),
+    version: get(/Version:\s*(.+)/),
+    platform: get(/Platform:\s*(.+)/),
+    network: get(/Network:\s*(.+)/),
+    timestamp: get(/Timestamp:\s*(.+)/),
+  };
+}
+
+// --- Discord ---------------------------------------------------------------
+
+async function postToDiscord(embed) {
+  const errors = [];
+  for (const url of webhookUrls) {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ embeds: [embed] }),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        errors.push(`webhook ${url.slice(0, 60)}...: ${res.status} ${res.statusText} ${body}`);
+      }
+    } catch (err) {
+      errors.push(`webhook ${url.slice(0, 60)}...: ${err.message}`);
+    }
+  }
+  // Fail (and allow retry) only if ALL webhooks failed
+  if (errors.length === webhookUrls.length) {
+    throw new Error(`All Discord webhooks failed: ${errors.join('; ')}`);
+  }
+  for (const e of errors) console.warn(`  WARN: ${e}`);
+}
+
+function buildEmbed(event, meta) {
+  const npub = nip19.npubEncode(event.pubkey);
+  const fields = [
+    { name: 'Sender', value: `\`${npub}\``, inline: false },
+    { name: 'Event ID', value: `\`${event.id}\``, inline: false },
+    { name: 'Received', value: new Date(event.created_at * 1000).toISOString(), inline: true },
+  ];
+
+  if (meta) {
+    if (meta.version) fields.push({ name: 'Version', value: meta.version, inline: true });
+    if (meta.network) fields.push({ name: 'Network', value: meta.network, inline: true });
+    if (meta.platform) fields.push({ name: 'Platform', value: meta.platform, inline: false });
+    if (meta.url) fields.push({ name: 'Blob URL', value: meta.url, inline: false });
+    if (meta.timestamp) fields.push({ name: 'Exported At', value: meta.timestamp, inline: true });
+  }
+
+  return {
+    title: meta ? '📋 New Angor Log Export' : '📋 New DM to Angor Support (possible log export)',
+    color: 0xf7931a,
+    fields,
+    footer: { text: 'Angor log monitor' },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// --- Event handling ----------------------------------------------------------
+
+async function handleEvent(event) {
+  if (seen.has(event.id)) return;
+  seen.add(event.id);
+  persistSeen();
+
+  console.log(`[${new Date().toISOString()}] DM ${event.id.slice(0, 12)}... from ${event.pubkey.slice(0, 12)}...`);
+
+  let meta = null;
+  if (supportNsecHex) {
+    try {
+      const dmContent = await decryptContent(supportNsecHex, event.pubkey, event.content);
+      meta = parseDmMetadata(dmContent);
+      if (!meta.isLogExport) {
+        console.log('  Decrypted DM is not a log export; posting generic notification');
+        meta = null;
+      }
+    } catch (err) {
+      console.warn(`  Decryption failed (${err.message}); posting notify-only`);
+    }
+  }
+
+  try {
+    await postToDiscord(buildEmbed(event, meta));
+    console.log('  Posted to Discord');
+  } catch (err) {
+    console.error(`  ${err.message}`);
+    // allow retry if the same event arrives from another relay
+    seen.delete(event.id);
+    persistSeen();
+  }
+}
+
+// --- Main --------------------------------------------------------------------
+
+console.log('Angor log monitor starting');
+console.log(`  Support pubkey: ${nip19.npubEncode(supportNpubHex)}`);
+console.log(`  Decryption:     ${supportNsecHex ? 'enabled (nsec provided)' : 'disabled (notify-only)'}`);
+console.log(`  Relays:         ${relayUrls.join(', ')}`);
+console.log(`  Lookback:       ${lookbackHours}h, state file: ${stateFile}`);
+console.log(`  Webhooks:       ${webhookUrls.length} Discord channel(s)`);
+
+const pool = new SimplePool();
+const since = Math.floor(Date.now() / 1000) - lookbackHours * 3600;
+
+pool.subscribeMany(
+  relayUrls,
+  { kinds: [4], '#p': [supportNpubHex], since },
+  {
+    onevent: ev => { handleEvent(ev).catch(err => console.error(`ERROR: ${err.message}`)); },
+    oneose: () => console.log('Initial sync complete; watching for new events...'),
+  },
+);
+
+process.on('SIGINT', () => {
+  console.log('\nShutting down');
+  pool.close(relayUrls);
+  persistSeen();
+  process.exit(0);
+});

--- a/src/tools/log-monitor/package-lock.json
+++ b/src/tools/log-monitor/package-lock.json
@@ -1,0 +1,213 @@
+{
+  "name": "log-monitor",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "log-monitor",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^2.2.0",
+        "nostr-tools": "^2.23.3",
+        "websocket-polyfill": "^1.0.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
+      "integrity": "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.0.1.tgz",
+      "integrity": "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.0.1",
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.0.1.tgz",
+      "integrity": "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/import2": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/import2/-/import2-1.0.3.tgz",
+      "integrity": "sha512-X7KHNp1fovFaiah9Q+njdxXJKIV9/XippWGZwHL9ZdJYnQPBs+4wLd4PuCigbxz2IWNm5YvFycSjRA/1lgmdGw==",
+      "license": "MIT"
+    },
+    "node_modules/nostr-tools": {
+      "version": "2.23.12",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.23.12.tgz",
+      "integrity": "sha512-dLE9r0b4pCmrOKLUPD0KhUj9IXeh6RwiYoonEWeBh2AaDmlczUjJqJC8pQfggXzKUZ7+uZvhcrKkfwuZk0/e1g==",
+      "license": "Unlicense",
+      "dependencies": {
+        "@noble/ciphers": "2.1.1",
+        "@noble/curves": "2.0.1",
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0",
+        "@scure/bip32": "2.0.1",
+        "@scure/bip39": "2.0.1",
+        "nostr-wasm": "0.1.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nostr-tools/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/nostr-wasm": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/nostr-wasm/-/nostr-wasm-0.1.0.tgz",
+      "integrity": "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==",
+      "license": "MIT"
+    },
+    "node_modules/tstl": {
+      "version": "2.5.16",
+      "resolved": "https://registry.npmjs.org/tstl/-/tstl-2.5.16.tgz",
+      "integrity": "sha512-+O2ybLVLKcBwKm4HymCEwZIT0PpwS3gCYnxfSDEjJEKADvIFruaQjd3m7CAKNU1c7N3X3WjVz87re7TA2A5FUw==",
+      "license": "MIT"
+    },
+    "node_modules/websocket-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/websocket-polyfill/-/websocket-polyfill-1.0.0.tgz",
+      "integrity": "sha512-QwfEy8jcOOCVO9su9UP+msEmhZa4a9WSJfePIdCT8GxwVl2Z9toM7nCqFfDDxA/sRmxgf1KNiwL6PXvjJ9qRxw==",
+      "dependencies": {
+        "import2": "^1.0.3",
+        "tstl": "^2.5.13",
+        "ws": "^8.16.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/src/tools/log-monitor/package.json
+++ b/src/tools/log-monitor/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "log-monitor",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "monitor-logs.mjs",
+  "scripts": {
+    "start": "node monitor-logs.mjs"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "Monitors Nostr relays for Angor log-export DMs and posts notifications to Discord",
+  "dependencies": {
+    "@noble/hashes": "^2.2.0",
+    "nostr-tools": "^2.23.3",
+    "websocket-polyfill": "^1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
Adds `src/tools/log-monitor`, a small Node tool (companion to `src/tools/decrypt-log`) that watches Nostr relays for Angor log-export DMs (kind 4, tagged to the support npub) and posts a notification embed to one or more Discord webhooks.

## Features
- Subscribes to the Angor relays (configurable via `RELAYS`) with startup backfill (`LOOKBACK_HOURS`)
- Optional decryption: if `SUPPORT_NSEC` is set, the DM is decrypted (auto-detects NIP-44/NIP-04, same logic as decrypt-log) and the embed includes app version, platform, network, blob URL, export timestamp; otherwise notify-only (sender npub + event id)
- Multiple Discord channels: `DISCORD_WEBHOOK_URL` accepts a comma-separated list
- Dedup across relays/restarts via a persisted `seen-events.json`; Discord post retried only if all webhooks fail

## Usage
```
DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/... \
SUPPORT_NPUB=npub1... \
node src/tools/log-monitor/monitor-logs.mjs
```

## Deployment
Already running as systemd service `angor-log-monitor` on the Blossom server (lnvps), with decryption enabled.

## Testing
- Validated live against relay.angor.io / relay2.angor.io / damus / nos.lol
- Backfill picked up 2 real log-export DMs and posted them to Discord successfully