### PR TITLE
Founder scan resilience + derivation fixes (split from #939)

### DIFF
--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/ScanFounderProjects.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/ScanFounderProjects.cs
@@ -27,6 +27,8 @@ public static class ScanFounderProjects
         IProjectService projectService,
         IFounderProjectsService founderProjectsService,
         IGenericDocumentCollection<DerivedProjectKeys> derivedProjectKeysCollection,
+        Wallet.Infrastructure.Interfaces.ISensitiveWalletDataProvider sensitiveWalletDataProvider,
+        Wallet.Infrastructure.Interfaces.IWalletFactory walletFactory,
         ILogger<ScanFounderProjectsHandler> logger) : IRequestHandler<ScanFounderProjectsRequest, Result<ScanFounderProjectsResponse>>
     {
         public async Task<Result<ScanFounderProjectsResponse>> Handle(ScanFounderProjectsRequest request, CancellationToken cancellationToken)
@@ -37,6 +39,38 @@ public static class ScanFounderProjects
             if (keysResult.IsFailure || keysResult.Value == null)
                 return Result.Failure<ScanFounderProjectsResponse>(
                     keysResult.IsFailure ? keysResult.Error : "No derived keys found for the given wallet.");
+
+            // Self-heal: builds affected by the ARM64 JIT derivation-collapse bug
+            // (docs/ai-docs/taproot-arm64-jit-bug.md) persisted key sets where every
+            // slot carries the same project identifier. Re-derive from the seed
+            // (OS-secured key store, no prompt) and persist the corrected set.
+            var distinctIds = keysResult.Value.Keys.Select(k => k.ProjectIdentifier).Distinct().Count();
+            if (distinctIds < keysResult.Value.Keys.Count)
+            {
+                logger.LogWarning(
+                    "ScanFounderProjects: wallet {WalletId} has collapsed derived keys ({Slots} slots, {Distinct} distinct ids) — rebuilding from seed",
+                    request.WalletId.Value, keysResult.Value.Keys.Count, distinctIds);
+
+                var sensitiveDataResult = await sensitiveWalletDataProvider.RequestSensitiveData(request.WalletId);
+                if (sensitiveDataResult.IsFailure)
+                    return Result.Failure<ScanFounderProjectsResponse>(
+                        $"Derived project keys are corrupted and the seed is unavailable to rebuild them: {sensitiveDataResult.Error}");
+
+                var rebuildResult = await walletFactory.RebuildFounderKeysAsync(
+                    sensitiveDataResult.Value.ToWalletWords(), request.WalletId);
+                if (rebuildResult.IsFailure)
+                    return Result.Failure<ScanFounderProjectsResponse>(
+                        $"Failed to rebuild derived project keys: {rebuildResult.Error}");
+
+                keysResult = await derivedProjectKeysCollection.FindByIdAsync(request.WalletId.Value);
+                if (keysResult.IsFailure || keysResult.Value == null)
+                    return Result.Failure<ScanFounderProjectsResponse>("Derived keys missing after rebuild.");
+
+                logger.LogInformation(
+                    "ScanFounderProjects: rebuilt derived keys for wallet {WalletId} — now {Distinct} distinct project ids",
+                    request.WalletId.Value,
+                    keysResult.Value.Keys.Select(k => k.ProjectIdentifier).Distinct().Count());
+            }
 
             var allDerivedIds = keysResult.Value.Keys
                 .Select(k => k.ProjectIdentifier)
@@ -50,6 +84,24 @@ public static class ScanFounderProjects
 
             // Step 3: Determine which derived keys we haven't checked yet
             var unknownIds = allDerivedIds.Except(knownIds).Select(id => new ProjectId(id)).ToArray();
+
+            logger.LogInformation(
+                "ScanFounderProjects: wallet {WalletId} — {DerivedCount} derived slots, {KnownCount} known locally, {UnknownCount} to scan. Derived ids: {DerivedIds}",
+                request.WalletId.Value, allDerivedIds.Count, knownIds.Count, unknownIds.Length,
+                string.Join(", ", allDerivedIds));
+
+            // Diagnostic for the ARM64 JIT derivation-collapse bug: all 15 slots deriving
+            // to the same key means BIP32/Angor-key derivation is broken on this runtime.
+            var storedKeys = keysResult.Value.Keys;
+            var distinctFounderKeys = storedKeys.Select(k => k.FounderKey).Distinct().Count();
+            var distinctNostr = storedKeys.Select(k => k.NostrPubKey).Distinct().Count();
+            if (allDerivedIds.Count < storedKeys.Count || distinctFounderKeys < storedKeys.Count)
+            {
+                logger.LogError(
+                    "ScanFounderProjects: DERIVATION COLLAPSE for wallet {WalletId} — {SlotCount} slots but only {DistinctIds} distinct project ids, {DistinctFounderKeys} distinct founder keys, {DistinctNostr} distinct nostr keys. First founder keys: {Keys}",
+                    request.WalletId.Value, storedKeys.Count, allDerivedIds.Count, distinctFounderKeys, distinctNostr,
+                    string.Join(", ", storedKeys.Take(3).Select(k => $"[{k.Index}]{k.FounderKey}")));
+            }
 
             // Step 4: Query the indexer/Nostr for the unknown keys to see if they exist on-chain
             var newRecords = new List<FounderProjectRecord>();

--- a/src/sdk/Angor.Sdk/Funding/Services/DocumentProjectService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Services/DocumentProjectService.cs
@@ -66,16 +66,30 @@ public class DocumentProjectService(
             if (ids.Length == localLookup.Count)
                 return Result.Success(localLookup.OrderByDescending(p => p.StartingDate).AsEnumerable()); //all ids are in the local database, return them
 
-            var tasks = stringIds
+            var missingIds = stringIds
                    .Except(localLookup.Select(p => p.Id.Value)) //ids that are not in the local database
+                   .ToList();
+
+            var tasks = missingIds
                    .Select(id => Result.Try(() => angorIndexerService.GetProjectByIdAsync(id)));
 
-            var results = await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(10));
+            // 30s budget: mobile networks + per-id address-history fetches regularly
+            // blow through the previous 10s, which made founder project scans come
+            // back empty on phones while working fine on desktop.
+            var results = await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(30));
 
-            var indexerResults = results //TODO log the failures, we don't need an all or nothing approach here
+            var failures = results.Where(r => r.IsFailure).ToList();
+            if (failures.Count > 0)
+                logger.LogWarning("GetAllAsync: {FailureCount}/{Total} indexer lookups failed: {Errors}",
+                    failures.Count, missingIds.Count, string.Join("; ", failures.Select(f => f.Error).Distinct()));
+
+            var indexerResults = results
                  .Where(r => r is { IsSuccess: true, Value: not null })
                  .Select(r => r.Value!)
                  .ToList();
+
+            logger.LogInformation("GetAllAsync: {Found}/{Missing} missing project ids found on indexer ({Local} already local)",
+                indexerResults.Count, missingIds.Count, localLookup.Count);
 
             if (indexerResults.Count == 0)
                 return Result.Success(localLookup.OrderByDescending(p => p.StartingDate).AsEnumerable());
@@ -83,11 +97,22 @@ public class DocumentProjectService(
             var nostrEventIds = indexerResults.Select(r => r!.NostrEventId).ToArray();
             var projectInfo = await ProjectInfos(nostrEventIds);
             if (projectInfo.IsFailure || !projectInfo.Value.Any())
-                return Result.Failure<IEnumerable<Project>>("Project info not found in relay");
+            {
+                // Relays are flaky (especially on mobile) — don't turn a partial outage
+                // into a total failure; return what we have locally and let the next
+                // scan retry the relay lookup.
+                logger.LogWarning("GetAllAsync: indexer found {Count} projects but relay project info lookup failed ({Error}) — returning local results only",
+                    indexerResults.Count, projectInfo.IsFailure ? projectInfo.Error : "no events returned");
+                return Result.Success(localLookup.OrderByDescending(p => p.StartingDate).AsEnumerable());
+            }
 
             var metadataResult = await ProjectMetadatas(projectInfo.Value.Select(p => p.NostrPubKey).ToArray());
             if (metadataResult.IsFailure || !metadataResult.Value.Any())
-                return Result.Failure<IEnumerable<Project>>("Project metadata not found in relay");
+            {
+                logger.LogWarning("GetAllAsync: relay metadata lookup failed ({Error}) — returning local results only",
+                    metadataResult.IsFailure ? metadataResult.Error : "no metadata returned");
+                return Result.Success(localLookup.OrderByDescending(p => p.StartingDate).AsEnumerable());
+            }
 
             var lookupList = indexerResults.Select(data =>
                      {

--- a/src/shared/Angor.Shared/Bip32PublicDerivationHelper.cs
+++ b/src/shared/Angor.Shared/Bip32PublicDerivationHelper.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Security.Cryptography;
+using NBitcoin;
+using NBitcoin.Secp256k1;
+
+namespace Angor.Shared;
+
+/// <summary>
+/// Workaround for a .NET 10 ARM64 Android JIT bug where non-hardened public child
+/// derivation (<see cref="ExtPubKey.Derive(uint)"/>, BIP32 CKDpub) inside NBitcoin.dll
+/// returns the same child key regardless of the derivation index. This collapsed all
+/// founder project identifiers on Android (every DeriveAngorKey slot produced the same
+/// angor1... id), so founder project scans could never find real projects on mobile.
+///
+/// Same bug class as <c>TaprootKeyHelper</c> (see docs/ai-docs/taproot-arm64-jit-bug.md):
+/// the EC tweak-add path is miscompiled when the call site lives in the net6.0
+/// NBitcoin assembly, but produces correct results when the identical primitives are
+/// invoked from Angor's own assembly. This helper replicates CKDpub here.
+///
+/// TODO: Remove once NBitcoin ships a net8.0 TFM build that avoids the Mono/ARM64 JIT
+/// bug (tracked with the TaprootKeyHelper removal in GitHub issue #838).
+/// </summary>
+public static class Bip32PublicDerivationHelper
+{
+    /// <summary>
+    /// BIP32 CKDpub: derives the non-hardened child public key
+    /// <c>K_i = point(parse256(I_L)) + K_par</c> with
+    /// <c>I = HMAC-SHA512(chainCode, serP(K_par) || ser32(i))</c>.
+    /// Equivalent to <c>parent.Derive(index).PubKey</c>.
+    /// </summary>
+    public static PubKey DerivePublicChild(ExtPubKey parent, uint index)
+    {
+        if (index >= 0x80000000)
+            throw new ArgumentOutOfRangeException(nameof(index), "Hardened derivation requires the private key");
+
+        var data = new byte[37];
+        parent.PubKey.ToBytes().CopyTo(data, 0);
+        data[33] = (byte)(index >> 24);
+        data[34] = (byte)(index >> 16);
+        data[35] = (byte)(index >> 8);
+        data[36] = (byte)index;
+
+        using var hmac = new HMACSHA512(parent.ChainCode);
+        var i = hmac.ComputeHash(data);
+
+        // I_L tweaks the parent point; I_R (child chain code) is not needed for a leaf.
+        var il = new byte[32];
+        Array.Copy(i, 0, il, 0, 32);
+
+        if (!ECPubKey.TryCreate(parent.PubKey.ToBytes(), null, out _, out var parentEc) || parentEc is null)
+            throw new InvalidOperationException("Invalid parent public key");
+
+        if (!parentEc.TryAddTweak(il, out var childEc) || childEc is null)
+            throw new InvalidOperationException("BIP32 public derivation produced an invalid child key (tweak overflow)");
+
+        return new PubKey(childEc.ToBytes());
+    }
+}

--- a/src/shared/Angor.Shared/DerivationOperations.cs
+++ b/src/shared/Angor.Shared/DerivationOperations.cs
@@ -59,6 +59,18 @@ public class DerivationOperations : IDerivationOperations
             });
         }
 
+        // Guard against the ARM64 JIT derivation-collapse bug (and any future
+        // regression): 15 slots must yield 15 distinct project identifiers.
+        // Persisting collapsed keys silently breaks founder project discovery,
+        // so fail loudly instead — this is mainnet key material.
+        var distinctIds = founderKeyCollection.Keys.Select(k => k.ProjectIdentifier).Distinct().Count();
+        if (distinctIds != founderKeyCollection.Keys.Count)
+        {
+            throw new InvalidOperationException(
+                $"Project key derivation collapsed: {founderKeyCollection.Keys.Count} slots produced only {distinctIds} distinct project identifiers. " +
+                "Refusing to persist corrupted keys (see docs/ai-docs/taproot-arm64-jit-bug.md).");
+        }
+
         return founderKeyCollection;
 
     }
@@ -384,7 +396,12 @@ public class DerivationOperations : IDerivationOperations
         if (projectVersion >= 3)
         {
             var (hi, lo) = DeriveProjectIndicesV2(founderKey);
-            var angorKey = extKey.Derive(hi).Derive(lo).PubKey;
+            // Bip32PublicDerivationHelper instead of ExtPubKey.Derive: the ARM64 JIT
+            // miscompiles NBitcoin's CKDpub and returns index-independent children,
+            // collapsing every project id to the same value on Android.
+            var hiKey = Bip32PublicDerivationHelper.DerivePublicChild(extKey, hi);
+            var hiExt = new ExtPubKey(hiKey, DeriveChildChainCode(extKey, hi));
+            var angorKey = Bip32PublicDerivationHelper.DerivePublicChild(hiExt, lo);
 
             var encoder = Encoders.Bech32("angor");
             var address = encoder.Encode(0, angorKey.WitHash.ToBytes());
@@ -394,7 +411,7 @@ public class DerivationOperations : IDerivationOperations
         }
 
         var upi = this.DeriveUniqueProjectIdentifier(founderKey);
-        var legacyAngorKey = extKey.Derive(upi).PubKey;
+        var legacyAngorKey = Bip32PublicDerivationHelper.DerivePublicChild(extKey, upi);
 
         var legacyEncoder = Encoders.Bech32("angor");
         var legacyAddress = legacyEncoder.Encode(0, legacyAngorKey.WitHash.ToBytes());
@@ -402,6 +419,22 @@ public class DerivationOperations : IDerivationOperations
         _logger.LogDebug("DeriveAngorKey - founderKey={FounderKey}, upi={Upi}, address={Address}", founderKey, upi, legacyAddress);
 
         return legacyAddress;
+    }
+
+    /// <summary>BIP32 CKDpub chain-code half (I_R) — needed to chain two non-hardened levels.</summary>
+    private static byte[] DeriveChildChainCode(ExtPubKey parent, uint index)
+    {
+        var data = new byte[37];
+        parent.PubKey.ToBytes().CopyTo(data, 0);
+        data[33] = (byte)(index >> 24);
+        data[34] = (byte)(index >> 16);
+        data[35] = (byte)(index >> 8);
+        data[36] = (byte)index;
+        using var hmac = new System.Security.Cryptography.HMACSHA512(parent.ChainCode);
+        var i = hmac.ComputeHash(data);
+        var ir = new byte[32];
+        Array.Copy(i, 32, ir, 0, 32);
+        return ir;
     }
 
     public Script AngorKeyToScript(string angorKey)


### PR DESCRIPTION
Splits the SDK and shared-library changes out of #939 so the UI/test PR stays focused.

## Changes

### ScanFounderProjects.cs
- Self-heal: detects collapsed derived project keys (ARM64 JIT derivation bug) and rebuilds them from the seed
- Adds diagnostics logging for derivation collapse

### DocumentProjectService.cs
- Indexer lookup timeout extended 10s -> 30s (mobile networks regularly exceeded 10s, making founder scans come back empty on phones)
- Logs indexer lookup failures instead of silently dropping them
- Relay outages now degrade to returning local results instead of failing the whole call

### Angor.Shared
- New Bip32PublicDerivationHelper
- DerivationOperations fixes

Split out of #939 per review feedback.