### PR TITLE
Fix stage date-bucket collision losing UTXOs in founder claim view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,11 @@
 ## Project Overview
 
 Angor is a Bitcoin investment platform with two frontends:
-- **Avalonia desktop/mobile app** (primary, .NET 9) in `src/avalonia/`
-- **Blazor WASM web app** (legacy, .NET 8) in `src/webapp/`
+- **App** (primary, new Avalonia rewrite, .NET 9) in `src/design/` — full founder + investor functionality
+- **Blazor WASM web app** (legacy, .NET 8) in `src/webapp/` — investor-only (investing flow); founder spend/claim is NOT used here
+- **Avalonia desktop/mobile app** (dead code, .NET 9) in `src/avalonia/` — superseded by `src/design/`, do not modify
 - **Shared library** (.NET 8) in `src/shared/`
 - **SDK** (.NET 9) in `src/sdk/`
-- **App** (new Avalonia rewrite) in `src/design/`
 - **CLI / MCP server** (.NET 10) in `src/cli/`
 
 ## Repository Structure

--- a/src/avalonia/AngorApp/UI/Sections/MyProjects/ManageFunds/Investment/Claim/Stage/ClaimStage.cs
+++ b/src/avalonia/AngorApp/UI/Sections/MyProjects/ManageFunds/Investment/Claim/Stage/ClaimStage.cs
@@ -169,7 +169,8 @@ namespace AngorApp.UI.Sections.MyProjects.ManageFunds.Investment.Claim.Stage
                 .Select(t => new SpendTransactionDto
                 {
                     InvestorAddress = t.Address,
-                    StageId = t.StageId
+                    StageId = t.StageId,
+                    InvestmentStageIndex = t.StageId
                 })
                 .ToList();
 

--- a/src/cli/Angor.Cli/Commands/Founder/FounderCommands.cs
+++ b/src/cli/Angor.Cli/Commands/Founder/FounderCommands.cs
@@ -282,7 +282,7 @@ public static class FounderCommands
         cmd.SetHandler(async (string walletId, string projectId, long feeRate, int stageId, string[] addresses) =>
         {
             var fee = new FeeEstimation { FeeRate = feeRate * 1000, Confirmations = 1 };
-            var toSpend = addresses.Select(a => new SpendTransactionDto { InvestorAddress = a, StageId = stageId }).ToArray();
+            var toSpend = addresses.Select(a => new SpendTransactionDto { InvestorAddress = a, StageId = stageId, InvestmentStageIndex = stageId }).ToArray();
 
             var result = await founderService.SpendStageFunds(
                 new SpendStageFunds.SpendStageFundsRequest(new WalletId(walletId), new ProjectId(projectId), fee, toSpend));

--- a/src/cli/Angor.Cli/McpTools/FounderTools.cs
+++ b/src/cli/Angor.Cli/McpTools/FounderTools.cs
@@ -103,12 +103,12 @@ public class FounderTools(IFounderAppService founderService, IProjectAppService 
             : $"Error: {result.Error}";
     }
 
-    [McpServerTool, Description("Spend funds from a project stage. Creates a transaction draft.")]
+    [McpServerTool, Description("Spend funds from a project stage. Creates a transaction draft. For Fund/Subscribe projects, investmentStageIndex is the 0-based stage index within the investment transaction (defaults to stageId).")]
     public async Task<string> FounderSpendStage(string walletId, string projectId, long feeRateSatPerVb,
-        int stageId, string investorAddress)
+        int stageId, string investorAddress, int? investmentStageIndex = null)
     {
         var fee = new FeeEstimation { FeeRate = feeRateSatPerVb * 1000, Confirmations = 1 };
-        var toSpend = new[] { new SpendTransactionDto { InvestorAddress = investorAddress, StageId = stageId } };
+        var toSpend = new[] { new SpendTransactionDto { InvestorAddress = investorAddress, StageId = stageId, InvestmentStageIndex = investmentStageIndex ?? stageId } };
 
         var result = await founderService.SpendStageFunds(
             new SpendStageFunds.SpendStageFundsRequest(new WalletId(walletId), new ProjectId(projectId), fee, toSpend));

--- a/src/design/App/UI/Sections/MyProjects/ManageProjectView.axaml
+++ b/src/design/App/UI/Sections/MyProjects/ManageProjectView.axaml
@@ -186,6 +186,31 @@
                     </Button>
                 </Border>
 
+                <!-- Debug Info button (icon only) — decoded OP_RETURN + per-investment stage dates -->
+                <Border Classes="FloatingBtn"
+                        Background="{DynamicResource FloatingBtnBg}"
+                        BorderBrush="{DynamicResource FloatingBtnBorder}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        BoxShadow="{DynamicResource FloatingBtnShadow}"
+                        Width="44" Height="44"
+                        VerticalAlignment="Center"
+                        Cursor="Hand"
+                        RenderTransform="translate(0px, 0px)">
+                    <Border.Transitions>
+                        <Transitions>
+                            <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.2" />
+                            <BoxShadowsTransition Property="BoxShadow" Duration="0:0:0.2" />
+                        </Transitions>
+                    </Border.Transitions>
+                    <Button Name="DebugInfoButton" Classes="NavBtn" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Cursor="Hand"
+                            ToolTip.Tip="Debug: decoded investment data"
+                            AutomationProperties.AutomationId="ManageProjectDebugButton">
+                        <i:Icon Value="fa-solid fa-bug" FontSize="14" Foreground="{DynamicResource TextStrong}"
+                                HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Button>
+                </Border>
+
                 <!-- Share button (icon only) -->
                 <!-- Vue: .share-button-floating — w44 h44 -->
                 <Border Classes="FloatingBtn"

--- a/src/design/App/UI/Sections/MyProjects/ManageProjectView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/ManageProjectView.axaml.cs
@@ -60,6 +60,10 @@ public partial class ManageProjectView : UserControl
         var shareBtn = this.FindControl<Button>("ShareButton");
         if (shareBtn != null) shareBtn.Click += OnShareClick;
 
+        // ── Debug Info button ──
+        var debugBtn = this.FindControl<Button>("DebugInfoButton");
+        if (debugBtn != null) debugBtn.Click += (_, _) => Vm?.OpenDebugModal();
+
         // ── Refresh button ──
         var refreshBtn = this.FindControl<Button>("RefreshButton");
         if (refreshBtn != null) refreshBtn.Click += OnRefreshClick;

--- a/src/design/App/UI/Sections/MyProjects/ManageProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/ManageProjectViewModel.cs
@@ -19,6 +19,29 @@ using App.UI.Shared;
 namespace App.UI.Sections.MyProjects;
 
 /// <summary>
+/// One investment transaction in the Debug Info modal — decoded OP_RETURN data
+/// (start date, pattern) plus the per-stage release schedule for that investment.
+/// </summary>
+public class DebugInvestmentViewModel
+{
+    public string TransactionId { get; set; } = "";
+    public string InvestorKey { get; set; } = "";
+    public string InvestmentStartDate { get; set; } = "";
+    public string PatternId { get; set; } = "";
+    public ObservableCollection<DebugStageRowViewModel> Stages { get; } = new();
+}
+
+/// <summary>A single stage row inside a Debug Info investment card.</summary>
+public class DebugStageRowViewModel
+{
+    public string StageLabel { get; set; } = "";
+    public string ReleaseDate { get; set; } = "";
+    public string Amount { get; set; } = "";
+    public string Status { get; set; } = "";
+    public string DisplayBucket { get; set; } = "";
+}
+
+/// <summary>
 /// Represents a single UTXO transaction in the claim/release/spent modals.
 /// Vue ref: ManageFunds.vue lines ~300-400 (available-transaction-item, spent-transaction-item).
 /// </summary>
@@ -184,6 +207,10 @@ public partial class ManageProjectViewModel : ReactiveObject
     // ── Spent/Returned Modals ──
     [Reactive] public partial bool ShowSpentModal { get; set; }
 
+    // ── Debug Info Modal ──
+    [Reactive] public partial bool ShowDebugModal { get; set; }
+    public ObservableCollection<DebugInvestmentViewModel> DebugInvestments { get; } = new();
+
     // ── Form State ──
     [Reactive] public partial string WalletPassword { get; set; }
     [Reactive] public partial bool IsClaiming { get; set; }
@@ -196,6 +223,51 @@ public partial class ManageProjectViewModel : ReactiveObject
         SelectedStageIndex >= 0 && SelectedStageIndex < Stages.Count
             ? Stages[SelectedStageIndex]
             : null;
+
+    /// <summary>Raw claimable DTOs from the last SDK load — used to build the debug view.</summary>
+    private List<ClaimableTransactionDto> lastClaimableTransactions = new();
+
+    /// <summary>
+    /// Builds the debug info (per-investment decoded OP_RETURN data + stage schedule)
+    /// from the last loaded claimable transactions and opens the Debug Info modal.
+    /// </summary>
+    public void OpenDebugModal()
+    {
+        DebugInvestments.Clear();
+
+        var byInvestment = lastClaimableTransactions
+            .GroupBy(t => t.TransactionId ?? t.InvestorAddress)
+            .OrderBy(g => g.Min(t => t.DynamicReleaseDate ?? DateTime.MaxValue));
+
+        foreach (var group in byInvestment)
+        {
+            var first = group.First();
+
+            var investment = new DebugInvestmentViewModel
+            {
+                TransactionId = first.TransactionId ?? "(unknown)",
+                InvestorKey = first.InvestorAddress,
+                InvestmentStartDate = first.InvestmentStartDate?.ToString("yyyy-MM-dd") ?? "n/a (fixed stages)",
+                PatternId = first.PatternId?.ToString() ?? "n/a"
+            };
+
+            foreach (var tx in group.OrderBy(t => t.InvestmentStageIndex))
+            {
+                investment.Stages.Add(new DebugStageRowViewModel
+                {
+                    StageLabel = $"Stage {tx.InvestmentStageIndex + 1}",
+                    ReleaseDate = tx.DynamicReleaseDate?.ToString("yyyy-MM-dd") ?? "",
+                    Amount = tx.Amount.Sats.ToUnitBtc().ToString("F8", CultureInfo.InvariantCulture),
+                    Status = tx.ClaimStatus.ToString(),
+                    DisplayBucket = $"shown as Stage {tx.StageNumber}"
+                });
+            }
+
+            DebugInvestments.Add(investment);
+        }
+
+        ShowDebugModal = true;
+    }
 
     public ManageProjectViewModel(
         MyProjectItemViewModel project,
@@ -434,6 +506,7 @@ public partial class ManageProjectViewModel : ReactiveObject
 
             Stages.Clear();
             var transactions = result.Value.Transactions.ToList();
+            lastClaimableTransactions = transactions;
             double totalAmount = 0;
             double availableAmount = 0;
             int spentCount = 0;

--- a/src/design/App/UI/Sections/MyProjects/ManageProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/ManageProjectViewModel.cs
@@ -28,6 +28,13 @@ public class UtxoTransactionViewModel : INotifyPropertyChanged
     public string Amount { get; set; } = "0";
     public bool IsSpent { get; set; }
 
+    /// <summary>
+    /// Stage index within the investment transaction itself (0-based).
+    /// Can differ from the displayed stage number for Fund/Subscribe projects,
+    /// where stages are grouped by release date across investments.
+    /// </summary>
+    public int InvestmentStageIndex { get; set; }
+
     private bool _isSelected;
     public bool IsSelected
     {
@@ -479,7 +486,8 @@ public partial class ManageProjectViewModel : ReactiveObject
                     {
                         TxId = tx.InvestorAddress,
                         Amount = tx.Amount.Sats.ToUnitBtc().ToString("F8", CultureInfo.InvariantCulture),
-                        IsSpent = false
+                        IsSpent = false,
+                        InvestmentStageIndex = tx.InvestmentStageIndex
                     });
                 }
 
@@ -489,7 +497,8 @@ public partial class ManageProjectViewModel : ReactiveObject
                     {
                         TxId = tx.InvestorAddress,
                         Amount = tx.Amount.Sats.ToUnitBtc().ToString("F8", CultureInfo.InvariantCulture),
-                        IsSpent = true
+                        IsSpent = true,
+                        InvestmentStageIndex = tx.InvestmentStageIndex
                     });
                 }
 
@@ -536,7 +545,8 @@ public partial class ManageProjectViewModel : ReactiveObject
             var toSpend = selectedTransactions.Select(t => new SpendTransactionDto
             {
                 InvestorAddress = t.TxId,
-                StageId = stageIndex
+                StageId = stageIndex,
+                InvestmentStageIndex = t.InvestmentStageIndex
             });
 
             // FeeEstimation.FeeRate is in sat/kB; the UI fee picker returns sat/vByte.

--- a/src/design/App/UI/Sections/MyProjects/Modals/ManageProjectModalsView.axaml
+++ b/src/design/App/UI/Sections/MyProjects/Modals/ManageProjectModalsView.axaml
@@ -801,5 +801,136 @@
             </Border>
         </Panel>
 
+        <!-- ═══ MODAL 8: DEBUG INFO (decoded OP_RETURN + per-investment stage schedule) ═══ -->
+        <Panel Name="DebugModalOverlay"
+               IsVisible="{Binding ShowDebugModal}"
+               ZIndex="200"
+               Background="{DynamicResource ModalBackdrop}">
+            <Border Classes="ModalCard Wide"
+                    Background="{DynamicResource DetailCardBg}"
+                    BorderBrush="{DynamicResource ModalHeaderBorder}"
+                    BorderThickness="1"
+                    CornerRadius="16"
+                    BoxShadow="0 8 32 0 #40000000"
+                    ClipToBounds="True">
+                <StackPanel>
+                    <!-- Header -->
+                    <Border Padding="24"
+                            BorderBrush="{DynamicResource ModalHeaderBorder}"
+                            BorderThickness="0,0,0,1">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                <i:Icon Value="fa-solid fa-bug" FontSize="16" Foreground="{DynamicResource TextStrong}" />
+                                <TextBlock Text="Debug: Investment Data"
+                                           FontSize="20" FontWeight="Bold"
+                                           Foreground="{DynamicResource TextStrong}"
+                                           VerticalAlignment="Center" />
+                            </StackPanel>
+                            <Button Name="DebugModalCloseBtn" Classes="ModalCloseBtn" Grid.Column="1" />
+                        </Grid>
+                    </Border>
+
+                    <!-- Body -->
+                    <StackPanel Margin="24" Spacing="16">
+                        <TextBlock Text="Decoded OP_RETURN data and per-investment stage schedule. Each investor's timeline starts from their own investment date, so the same displayed stage can contain different per-investment stage indices."
+                                   FontSize="13"
+                                   Foreground="{DynamicResource ModalDescriptionText}"
+                                   TextWrapping="Wrap" />
+
+                        <ScrollViewer MaxHeight="480" VerticalScrollBarVisibility="Auto">
+                            <ItemsControl ItemsSource="{Binding DebugInvestments}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="mp:DebugInvestmentViewModel">
+                                        <Border Background="{DynamicResource StageCardBg}"
+                                                BorderBrush="{DynamicResource StageCardBorder}"
+                                                BorderThickness="1"
+                                                CornerRadius="8"
+                                                Padding="16"
+                                                Margin="0,0,0,12">
+                                            <StackPanel Spacing="8">
+                                                <!-- Investment header -->
+                                                <StackPanel Spacing="2">
+                                                    <TextBlock Text="{Binding TransactionId, StringFormat=Tx: {0}}"
+                                                               FontSize="12"
+                                                               FontFamily="Courier New, monospace"
+                                                               Foreground="{DynamicResource TextStrong}"
+                                                               TextWrapping="Wrap"
+                                                               Classes="ExplorerTxLink"
+                                                               Cursor="Hand" />
+                                                    <TextBlock Text="{Binding InvestorKey, StringFormat=Investor: {0}}"
+                                                               FontSize="11"
+                                                               FontFamily="Courier New, monospace"
+                                                               Foreground="{DynamicResource TransactionStatLabel}"
+                                                               TextWrapping="Wrap" />
+                                                    <StackPanel Orientation="Horizontal" Spacing="16">
+                                                        <TextBlock Text="{Binding InvestmentStartDate, StringFormat=Start date: {0}}"
+                                                                   FontSize="12" FontWeight="SemiBold"
+                                                                   Foreground="{DynamicResource StageCardValue}" />
+                                                        <TextBlock Text="{Binding PatternId, StringFormat=Pattern: {0}}"
+                                                                   FontSize="12" FontWeight="SemiBold"
+                                                                   Foreground="{DynamicResource StageCardValue}" />
+                                                    </StackPanel>
+                                                </StackPanel>
+
+                                                <!-- Stage rows -->
+                                                <ItemsControl ItemsSource="{Binding Stages}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate x:DataType="mp:DebugStageRowViewModel">
+                                                            <Grid ColumnDefinitions="80,100,110,*,Auto" Margin="0,2,0,2">
+                                                                <TextBlock Grid.Column="0"
+                                                                           Text="{Binding StageLabel}"
+                                                                           FontSize="12" FontWeight="SemiBold"
+                                                                           Foreground="{DynamicResource TextStrong}" />
+                                                                <TextBlock Grid.Column="1"
+                                                                           Text="{Binding ReleaseDate}"
+                                                                           FontSize="12"
+                                                                           FontFamily="Courier New, monospace"
+                                                                           Foreground="{DynamicResource StageCardValue}" />
+                                                                <TextBlock Grid.Column="2"
+                                                                           Text="{Binding Amount}"
+                                                                           FontSize="12"
+                                                                           FontFamily="Courier New, monospace"
+                                                                           Foreground="{DynamicResource StageCardValue}" />
+                                                                <TextBlock Grid.Column="3"
+                                                                           Text="{Binding DisplayBucket}"
+                                                                           FontSize="11"
+                                                                           Foreground="{DynamicResource TransactionStatLabel}" />
+                                                                <TextBlock Grid.Column="4"
+                                                                           Text="{Binding Status}"
+                                                                           FontSize="12" FontWeight="SemiBold"
+                                                                           Foreground="{DynamicResource StagePillText}" />
+                                                            </Grid>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+
+                        <!-- Close button (green gradient, full width) -->
+                        <Button Name="DebugModalDoneBtn"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Center"
+                                Padding="24,12"
+                                CornerRadius="8"
+                                BorderThickness="0"
+                                Foreground="White"
+                                FontSize="16" FontWeight="SemiBold">
+                            <Button.Background>
+                                <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                    <GradientStop Color="{StaticResource PrimaryGreen}" Offset="0" />
+                                    <GradientStop Color="#3D6448" Offset="1" />
+                                </LinearGradientBrush>
+                            </Button.Background>
+                            <TextBlock Text="Close" FontWeight="SemiBold" />
+                        </Button>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </Panel>
+
     </Panel>
 </UserControl>

--- a/src/design/App/UI/Sections/MyProjects/Modals/ManageProjectModalsView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/Modals/ManageProjectModalsView.axaml.cs
@@ -64,6 +64,10 @@ public partial class ManageProjectModalsView : UserControl
         WireClick("SpentModalCloseBtn", () => { if (Vm != null) Vm.ShowSpentModal = false; });
         WireClick("SpentModalDoneBtn", () => { if (Vm != null) Vm.ShowSpentModal = false; });
 
+        // ── Debug Info ──
+        WireClick("DebugModalCloseBtn", () => { if (Vm != null) Vm.ShowDebugModal = false; });
+        WireClick("DebugModalDoneBtn", () => { if (Vm != null) Vm.ShowDebugModal = false; });
+
         // ── Modal backdrop clicks (close on click outside the card) ──
         WireBackdropClose("ClaimModalOverlay", () => { if (Vm != null) Vm.ShowClaimModal = false; });
         WireBackdropClose("PasswordModalOverlay", () => { if (Vm != null) Vm.ShowPasswordModal = false; });
@@ -72,6 +76,7 @@ public partial class ManageProjectModalsView : UserControl
         WireBackdropClose("ReleasePasswordModalOverlay", () => { if (Vm != null) Vm.ShowReleaseFundsPasswordModal = false; });
         WireBackdropClose("ReleaseSuccessModalOverlay", () => { if (Vm != null) Vm.ShowReleaseFundsSuccessModal = false; });
         WireBackdropClose("SpentModalOverlay", () => { if (Vm != null) Vm.ShowSpentModal = false; });
+        WireBackdropClose("DebugModalOverlay", () => { if (Vm != null) Vm.ShowDebugModal = false; });
 
         // ── UTXO item toggle (click on row toggles selection in claim modal) ──
         var claimList = this.FindControl<ItemsControl>("ClaimUtxoList");

--- a/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml
+++ b/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml
@@ -967,9 +967,9 @@
                     <!-- YOUR SHARE STATISTICS                    -->
                     <!-- Shows investor's share of total pool     -->
                     <!-- ═══════════════════════════════════════ -->
-                    <Grid ColumnDefinitions="*,*,*" Margin="0,0,0,0">
+                    <Grid x:Name="ShareStatsGrid" ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto,Auto" Margin="0,0,0,0">
                         <!-- Your Share -->
-                        <Border Grid.Column="0"
+                        <Border x:Name="ShareCard0" Grid.Column="0"
                                 Background="{DynamicResource StatsDetailInnerBackground}"
                                 CornerRadius="12"
                                 Padding="20"
@@ -992,7 +992,7 @@
                         </Border>
 
                         <!-- Claimed by Founder -->
-                        <Border Grid.Column="1"
+                        <Border x:Name="ShareCard1" Grid.Column="1"
                                 Background="{DynamicResource StatsDetailInnerBackground}"
                                 CornerRadius="12"
                                 Padding="20"
@@ -1020,7 +1020,7 @@
                         </Border>
 
                         <!-- View Investors Button -->
-                        <Border Grid.Column="2"
+                        <Border x:Name="ShareCard2" Grid.Column="2"
                                 Background="{DynamicResource StatsDetailInnerBackground}"
                                 CornerRadius="12"
                                 Padding="20"

--- a/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml.cs
+++ b/src/design/App/UI/Sections/Portfolio/InvestmentDetailView.axaml.cs
@@ -34,6 +34,10 @@ public partial class InvestmentDetailView : UserControl
     private Border? _info4Card1;
     private Border? _info4Card2;
     private Border? _info4Card3;
+    private Grid? _shareStatsGrid;
+    private Border? _shareCard0;
+    private Border? _shareCard1;
+    private Border? _shareCard2;
     private StackPanel? _stagesTableDesktop;
     private ItemsControl? _stagesCardsMobile;
     private StackPanel? _contentStack;
@@ -62,6 +66,10 @@ public partial class InvestmentDetailView : UserControl
         _info4Card1 = this.FindControl<Border>("Info4Card1");
         _info4Card2 = this.FindControl<Border>("Info4Card2");
         _info4Card3 = this.FindControl<Border>("Info4Card3");
+        _shareStatsGrid = this.FindControl<Grid>("ShareStatsGrid");
+        _shareCard0 = this.FindControl<Border>("ShareCard0");
+        _shareCard1 = this.FindControl<Border>("ShareCard1");
+        _shareCard2 = this.FindControl<Border>("ShareCard2");
         _stagesTableDesktop = this.FindControl<StackPanel>("StagesTableDesktop");
         _stagesCardsMobile = this.FindControl<ItemsControl>("StagesCardsMobile");
         _contentStack = this.FindControl<StackPanel>("ContentStack");
@@ -132,6 +140,16 @@ public partial class InvestmentDetailView : UserControl
             SetInfoCardCompact(_info4Card2, 2);
             SetInfoCardCompact(_info4Card3, 3);
 
+            // Share stats grid: collapse cols 1-2, stack cards vertically
+            if (_shareStatsGrid != null)
+            {
+                for (int i = 1; i < _shareStatsGrid.ColumnDefinitions.Count; i++)
+                    _shareStatsGrid.ColumnDefinitions[i].Width = new GridLength(0);
+            }
+            SetStatCardCompact(_shareCard0, 0);
+            SetStatCardCompact(_shareCard1, 1);
+            SetStatCardCompact(_shareCard2, 2);
+
             if (_stagesTableDesktop != null) _stagesTableDesktop.IsVisible = false;
             if (_stagesCardsMobile != null) _stagesCardsMobile.IsVisible = true;
 
@@ -189,6 +207,16 @@ public partial class InvestmentDetailView : UserControl
             SetInfoCardDesktop(_info4Card1, 1, new Thickness(8, 0, 8, 0));
             SetInfoCardDesktop(_info4Card2, 2, new Thickness(8, 0, 8, 0));
             SetInfoCardDesktop(_info4Card3, 3, new Thickness(8, 0, 0, 0));
+
+            // Share stats grid: restore cols to Star, cards back to their columns
+            if (_shareStatsGrid != null)
+            {
+                for (int i = 1; i < _shareStatsGrid.ColumnDefinitions.Count; i++)
+                    _shareStatsGrid.ColumnDefinitions[i].Width = GridLength.Star;
+            }
+            SetStatCardDesktop(_shareCard0, 0, new Thickness(0, 0, 8, 0));
+            SetStatCardDesktop(_shareCard1, 1, new Thickness(8, 0, 8, 0));
+            SetStatCardDesktop(_shareCard2, 2, new Thickness(8, 0, 0, 0));
 
             if (_stagesTableDesktop != null) _stagesTableDesktop.IsVisible = true;
             if (_stagesCardsMobile != null) _stagesCardsMobile.IsVisible = false;

--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/GetClaimableTransactionsTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/GetClaimableTransactionsTests.cs
@@ -530,4 +530,63 @@ public class GetClaimableTransactionsTests
         result.Value.Transactions.First().ClaimStatus.Should().Be(ClaimStatus.SpentByFounder,
             "Spent status should take priority over future release date");
     }
+
+    [Fact]
+    public async Task Handle_MixedDateBucket_ExposesPerInvestmentStageIndex()
+    {
+        // Arrange — a Fund/Subscribe date bucket can mix items with different per-investment
+        // stage indices (a later investor's stage 1 shares the release date with an earlier
+        // investor's stage 2). The DTO must expose the per-item index for spending, while
+        // StageId/StageNumber reflect the display bucket.
+        var walletId = new WalletId("wallet-1");
+        var projectId = new ProjectId("project-1");
+        var request = new GetClaimableTransactions.GetClaimableTransactionsRequest(walletId, projectId);
+
+        var stageData = new StageData
+        {
+            StageIndex = 1, // second date bucket
+            StageDate = DateTime.UtcNow.AddDays(-1),
+            IsDynamic = true,
+            Items = new List<StageDataTrx>
+            {
+                new StageDataTrx
+                {
+                    Amount = 10_000,
+                    IsSpent = false,
+                    InvestorPublicKey = "early-investor",
+                    StageIndex = 1 // their second stage
+                },
+                new StageDataTrx
+                {
+                    Amount = 20_000,
+                    IsSpent = false,
+                    InvestorPublicKey = "late-investor",
+                    StageIndex = 0 // their first stage, shifted schedule
+                }
+            }
+        };
+
+        _mockProjectInvestmentsService
+            .Setup(x => x.ScanFullInvestments(projectId.Value))
+            .ReturnsAsync(Result.Success<IEnumerable<StageData>>(new[] { stageData }));
+
+        // Act
+        var result = await _sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var transactions = result.Value.Transactions.ToList();
+        transactions.Should().HaveCount(2);
+
+        var earlyInvestorTx = transactions.Single(t => t.InvestorAddress == "early-investor");
+        earlyInvestorTx.StageId.Should().Be(1);
+        earlyInvestorTx.StageNumber.Should().Be(2);
+        earlyInvestorTx.InvestmentStageIndex.Should().Be(1);
+
+        var lateInvestorTx = transactions.Single(t => t.InvestorAddress == "late-investor");
+        lateInvestorTx.StageId.Should().Be(1, "both items belong to the same date bucket");
+        lateInvestorTx.StageNumber.Should().Be(2);
+        lateInvestorTx.InvestmentStageIndex.Should().Be(0,
+            "the late investor's first stage landed in the second date bucket");
+    }
 }

--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/SpendStageFundsTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/SpendStageFundsTests.cs
@@ -248,6 +248,89 @@ public class SpendStageFundsTests
         result.Value.TransactionDraft.TransactionFee.Should().Be(new Amount(1500));
     }
 
+    [Fact]
+    public async Task Handle_MixedBucket_BuildsPerInputStageNumbers()
+    {
+        // Arrange — two UTXOs from the same date bucket (same StageId) but with different
+        // per-investment stage indices: the early investor's stage 2 shares a release date
+        // with the late investor's stage 1. Each input must carry its own stage number so
+        // the correct taproot script is rebuilt per investment.
+        var toSpend = new List<SpendTransactionDto>
+        {
+            new SpendTransactionDto { InvestorAddress = "early-investor", StageId = 1, InvestmentStageIndex = 1 },
+            new SpendTransactionDto { InvestorAddress = "late-investor", StageId = 1, InvestmentStageIndex = 0 }
+        };
+
+        var request = new SpendStageFunds.SpendStageFundsRequest(
+            new WalletId("wallet-1"),
+            new ProjectId("project-1"),
+            new FeeEstimation { Confirmations = 1, FeeRate = 10_000 },
+            toSpend);
+
+        var network = SetupNetwork();
+        SetupProject();
+        SetupProjectKeys();
+        SetupSeedwords();
+
+        _mockAngorIndexerService
+            .Setup(x => x.GetInvestmentAsync(It.IsAny<string>(), "early-investor"))
+            .ReturnsAsync(new ProjectInvestment { TransactionId = "tx-early" });
+        _mockAngorIndexerService
+            .Setup(x => x.GetInvestmentAsync(It.IsAny<string>(), "late-investor"))
+            .ReturnsAsync(new ProjectInvestment { TransactionId = "tx-late" });
+
+        _mockTransactionService
+            .Setup(x => x.GetTransactionHexByIdAsync("tx-early"))
+            .ReturnsAsync("hex-early");
+        _mockTransactionService
+            .Setup(x => x.GetTransactionHexByIdAsync("tx-late"))
+            .ReturnsAsync("hex-late");
+
+        var balanceInfo = new AccountBalanceInfo();
+        var accountInfo = new AccountInfo
+        {
+            ChangeAddressesInfo = new List<AddressInfo>
+            {
+                new AddressInfo { Address = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx", HasHistory = false }
+            }
+        };
+        balanceInfo.UpdateAccountBalanceInfo(accountInfo, new List<UtxoData>());
+        _mockWalletAccountBalanceService
+            .Setup(x => x.RefreshAccountBalanceInfoAsync(It.IsAny<WalletId>()))
+            .ReturnsAsync(Result.Success(balanceInfo));
+
+        List<StageTransactionInput>? capturedInputs = null;
+        var signedTx = network.CreateTransaction();
+        _mockFounderTransactionActions
+            .Setup(x => x.SpendFounderStage(
+                It.IsAny<ProjectInfo>(),
+                It.IsAny<IEnumerable<StageTransactionInput>>(),
+                It.IsAny<Script>(),
+                It.IsAny<AngorKey>(),
+                It.IsAny<FeeEstimation>()))
+            .Callback<ProjectInfo, IEnumerable<StageTransactionInput>, Script, AngorKey, FeeEstimation>(
+                (_, inputs, _, _, _) => capturedInputs = inputs.ToList())
+            .Returns(new Angor.Shared.Models.TransactionInfo
+            {
+                Transaction = signedTx,
+                TransactionFee = 1500
+            });
+
+        // Act
+        var result = await _sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        capturedInputs.Should().NotBeNull();
+        capturedInputs.Should().HaveCount(2);
+
+        var earlyInput = capturedInputs!.Single(i => i.TransactionHex == "hex-early");
+        earlyInput.StageNumber.Should().Be(2, "the early investor's UTXO is their second stage");
+
+        var lateInput = capturedInputs!.Single(i => i.TransactionHex == "hex-late");
+        lateInput.StageNumber.Should().Be(1, "the late investor's UTXO is their first stage");
+    }
+
     private static SpendStageFunds.SpendStageFundsRequest CreateRequest()
     {
         var toSpend = new List<SpendTransactionDto>

--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/SpendStageFundsTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/SpendStageFundsTests.cs
@@ -68,8 +68,8 @@ public class SpendStageFundsTests
         // Arrange
         var toSpend = new List<SpendTransactionDto>
         {
-            new SpendTransactionDto { InvestorAddress = "addr1", StageId = 0 },
-            new SpendTransactionDto { InvestorAddress = "addr2", StageId = 1 }
+            new SpendTransactionDto { InvestorAddress = "addr1", StageId = 0, InvestmentStageIndex = 0 },
+            new SpendTransactionDto { InvestorAddress = "addr2", StageId = 1, InvestmentStageIndex = 1 }
         };
 
         var request = new SpendStageFunds.SpendStageFundsRequest(
@@ -176,7 +176,7 @@ public class SpendStageFundsTests
 
         _mockAngorIndexerService
             .Setup(x => x.GetInvestmentAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((ProjectInvestment?)null);
+            .ReturnsAsync(new ProjectInvestment { TransactionId = "tx-id-1" });
 
         _mockTransactionService
             .Setup(x => x.GetTransactionHexByIdAsync(It.IsAny<string>()))
@@ -229,8 +229,7 @@ public class SpendStageFundsTests
         _mockFounderTransactionActions
             .Setup(x => x.SpendFounderStage(
                 It.IsAny<ProjectInfo>(),
-                It.IsAny<IEnumerable<string>>(),
-                It.IsAny<int>(),
+                It.IsAny<IEnumerable<StageTransactionInput>>(),
                 It.IsAny<Script>(),
                 It.IsAny<AngorKey>(),
                 It.IsAny<FeeEstimation>()))
@@ -253,7 +252,7 @@ public class SpendStageFundsTests
     {
         var toSpend = new List<SpendTransactionDto>
         {
-            new SpendTransactionDto { InvestorAddress = "investor-addr-1", StageId = 0 }
+            new SpendTransactionDto { InvestorAddress = "investor-addr-1", StageId = 0, InvestmentStageIndex = 0 }
         };
 
         return new SpendStageFunds.SpendStageFundsRequest(

--- a/src/sdk/Angor.Sdk.Tests/Funding/Projects/ProjectInvestmentsServiceTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Projects/ProjectInvestmentsServiceTests.cs
@@ -364,6 +364,166 @@ public class ProjectInvestmentsServiceTests : IClassFixture<TestNetworkFixture>
 
     #endregion
 
+    #region ScanDynamicTypeInvestments Tests
+
+    /// <summary>
+    /// Regression test: a Fund investor who invests after the payout day gets a shifted
+    /// schedule, so their stages land in different date buckets than earlier investors'.
+    /// Each distinct release date must become its own stage with a sequential StageIndex —
+    /// previously two buckets could share an index (e.g. the last bucket of each investor),
+    /// which merged/lost a stage when consumers grouped by stage number.
+    /// </summary>
+    [Fact]
+    public async Task ScanFullInvestments_FundInvestorsWithShiftedSchedules_CreatesDistinctStagePerReleaseDate()
+    {
+        // Arrange
+        var (project, projectInfo) = CreateFundProject();
+
+        // Investor A starts Feb 1 → stages Feb 15, Mar 15, Apr 15
+        // Investor B starts Feb 20 (after the payout day) → stages Mar 15, Apr 15, May 15
+        var (trxA, investorKeyA) = CreateFundInvestment(projectInfo, new DateTime(2030, 2, 1, 0, 0, 0, DateTimeKind.Utc));
+        var (trxB, investorKeyB) = CreateFundInvestment(projectInfo, new DateTime(2030, 2, 20, 0, 0, 0, DateTimeKind.Utc));
+
+        SetupMocksForInvestments(project, (trxA, investorKeyA), (trxB, investorKeyB));
+
+        // Act
+        var result = await _sut.ScanFullInvestments(project.Id.Value);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var stages = result.Value.ToList();
+
+        // 4 distinct release dates: Feb 15 (A only), Mar 15 (A+B), Apr 15 (A+B), May 15 (B only)
+        stages.Should().HaveCount(4);
+
+        // Stage indices must be sequential after ordering by date so no two buckets collide
+        stages.Select(s => s.StageIndex).Should().Equal(0, 1, 2, 3);
+
+        stages[0].StageDate.Date.Should().Be(new DateTime(2030, 2, 15));
+        stages[1].StageDate.Date.Should().Be(new DateTime(2030, 3, 15));
+        stages[2].StageDate.Date.Should().Be(new DateTime(2030, 4, 15));
+        stages[3].StageDate.Date.Should().Be(new DateTime(2030, 5, 15));
+
+        stages[0].Items.Should().HaveCount(1, "only investor A has a Feb 15 stage");
+        stages[1].Items.Should().HaveCount(2, "A's stage 2 and B's stage 1 share Mar 15");
+        stages[2].Items.Should().HaveCount(2, "A's stage 3 and B's stage 2 share Apr 15");
+        stages[3].Items.Should().HaveCount(1, "only investor B has a May 15 stage");
+
+        // Total UTXOs must be preserved: 2 investors x 3 stages
+        stages.Sum(s => s.Items.Count).Should().Be(6);
+    }
+
+    [Fact]
+    public async Task ScanFullInvestments_FundMixedBucket_ItemsKeepPerInvestmentStageIndex()
+    {
+        // Arrange
+        var (project, projectInfo) = CreateFundProject();
+
+        var (trxA, investorKeyA) = CreateFundInvestment(projectInfo, new DateTime(2030, 2, 1, 0, 0, 0, DateTimeKind.Utc));
+        var (trxB, investorKeyB) = CreateFundInvestment(projectInfo, new DateTime(2030, 2, 20, 0, 0, 0, DateTimeKind.Utc));
+
+        SetupMocksForInvestments(project, (trxA, investorKeyA), (trxB, investorKeyB));
+
+        // Act
+        var result = await _sut.ScanFullInvestments(project.Id.Value);
+
+        // Assert — in the shared Mar 15 bucket, each item keeps the stage index of its own
+        // investment transaction (required to rebuild the correct taproot script for spending)
+        result.IsSuccess.Should().BeTrue();
+        var marchBucket = result.Value.Single(s => s.StageDate.Date == new DateTime(2030, 3, 15));
+
+        var itemA = marchBucket.Items.Single(i => i.InvestorPublicKey == investorKeyA);
+        itemA.StageIndex.Should().Be(1, "Mar 15 is investor A's second stage (0-based index 1)");
+
+        var itemB = marchBucket.Items.Single(i => i.InvestorPublicKey == investorKeyB);
+        itemB.StageIndex.Should().Be(0, "Mar 15 is investor B's first stage (0-based index 0)");
+    }
+
+    private (Project project, ProjectInfo projectInfo) CreateFundProject()
+    {
+        const string angorRootKey =
+            "tpubD8JfN1evVWPoJmLgVg6Usq2HEW9tLqm6CyECAADnH5tyQosrL6NuhpL9X1cQCbSmndVrgLSGGdbRqLfUbE6cRqUbrHtDJgSyQEY2Uu7WwTL";
+
+        var words = new WalletWords { Words = TestNetworkFixture.TestWalletWords };
+        var founderKey = _fixture.DerivationOperations.DeriveFounderKey(words, 1);
+        var founderRecoveryKey = _fixture.DerivationOperations.DeriveFounderRecoveryKey(words, founderKey);
+        var projectIdentifier = _fixture.DerivationOperations.DeriveAngorKey(angorRootKey, founderKey);
+
+        var project = TestDataBuilder.CreateProject()
+            .WithId(projectIdentifier)
+            .WithProjectType(ProjectType.Fund)
+            .WithFounderKey(founderKey)
+            .WithFounderRecoveryKey(founderRecoveryKey)
+            .WithDynamicStagePatterns(new List<DynamicStagePattern>
+            {
+                new DynamicStagePattern
+                {
+                    PatternId = 0,
+                    Name = "3-Month Fund (15th of month)",
+                    Frequency = StageFrequency.Monthly,
+                    StageCount = 3,
+                    PayoutDayType = PayoutDayType.SpecificDayOfMonth,
+                    PayoutDay = 15
+                }
+            })
+            .Build();
+
+        return (project, project.ToProjectInfo());
+    }
+
+    private (Transaction trx, string investorKey) CreateFundInvestment(ProjectInfo projectInfo, DateTime investmentStartDate)
+    {
+        var investorKey = NBitcoin.DataEncoders.Encoders.Hex.EncodeData(new Key().PubKey.ToBytes());
+
+        var parameters = FundingParameters.CreateForFund(
+            projectInfo,
+            investorKey,
+            Money.Coins(0.1m).Satoshi,
+            0, // patternId
+            investmentStartDate);
+
+        var trx = _fixture.InvestorTransactionActions.CreateInvestmentTransaction(projectInfo, parameters);
+
+        return (trx, investorKey);
+    }
+
+    private void SetupMocksForInvestments(Project project, params (Transaction trx, string investorKey)[] investments)
+    {
+        _mockProjectService
+            .Setup(x => x.GetAsync(It.Is<ProjectId>(p => p.Value == project.Id.Value)))
+            .ReturnsAsync(Result.Success(project));
+
+        _mockAngorIndexerService
+            .Setup(x => x.GetInvestmentsAsync(project.Id.Value))
+            .ReturnsAsync(investments.Select(i => new ProjectInvestment
+            {
+                TransactionId = i.trx.GetHash().ToString(),
+                InvestorPublicKey = i.investorKey
+            }).ToList());
+
+        foreach (var (trx, _) in investments)
+        {
+            var txId = trx.GetHash().ToString();
+
+            _mockTransactionService
+                .Setup(x => x.GetTransactionHexByIdAsync(txId))
+                .ReturnsAsync(trx.ToHex());
+
+            // Build a QueryTransaction with all outputs unspent
+            var queryBuilder = TestDataBuilder.CreateQueryTransaction().WithTransactionId(txId);
+            for (int i = 0; i < trx.Outputs.Count; i++)
+            {
+                queryBuilder.AddOutput(i, trx.Outputs[i].Value.Satoshi);
+            }
+
+            _mockTransactionService
+                .Setup(x => x.GetTransactionInfoByIdAsync(txId))
+                .ReturnsAsync(queryBuilder.Build());
+        }
+    }
+
+    #endregion
+
     #region Helper Methods
 
     /// <summary>

--- a/src/sdk/Angor.Sdk/Funding/Founder/Dtos/ClaimableTransactionDto.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Dtos/ClaimableTransactionDto.cs
@@ -22,4 +22,15 @@ public record ClaimableTransactionDto
     public ClaimStatus ClaimStatus { get; set; }
     public DateTime? DynamicReleaseDate { get; set; }
 
+    // ── Debug/diagnostic data (decoded from the investment transaction OP_RETURN) ──
+
+    /// <summary>The investment transaction id this UTXO belongs to.</summary>
+    public string? TransactionId { get; init; }
+
+    /// <summary>Decoded investment start date from the OP_RETURN (Fund/Subscribe only).</summary>
+    public DateTime? InvestmentStartDate { get; init; }
+
+    /// <summary>Decoded pattern id from the OP_RETURN (Fund/Subscribe only).</summary>
+    public byte? PatternId { get; init; }
+
 }

--- a/src/sdk/Angor.Sdk/Funding/Founder/Dtos/ClaimableTransactionDto.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Dtos/ClaimableTransactionDto.cs
@@ -7,6 +7,16 @@ public record ClaimableTransactionDto
 {
     public required int StageId { get; init; }
     public required int StageNumber { get; init; }
+
+    /// <summary>
+    /// The stage index within the investment transaction itself (0-based).
+    /// For Fund/Subscribe projects this can differ from <see cref="StageId"/>:
+    /// stages are grouped by release date, and a later investor's first stage
+    /// can share a date bucket with an earlier investor's second stage.
+    /// This index is required to rebuild the correct taproot script when spending.
+    /// </summary>
+    public required int InvestmentStageIndex { get; init; }
+
     public required string InvestorAddress { get; init; }
     public required Amount Amount { get; init; }
     public ClaimStatus ClaimStatus { get; set; }

--- a/src/sdk/Angor.Sdk/Funding/Founder/Dtos/SpendTransactionDto.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Dtos/SpendTransactionDto.cs
@@ -4,4 +4,11 @@ public record SpendTransactionDto
 {
     public required string InvestorAddress { get; init; }
     public required int StageId { get; init; }
+
+    /// <summary>
+    /// The stage index within the investment transaction itself (0-based).
+    /// Required to spend the correct taproot output when a date bucket mixes
+    /// different per-investment stage indices (Fund/Subscribe projects).
+    /// </summary>
+    public required int InvestmentStageIndex { get; init; }
 }

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetClaimableTransactions.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetClaimableTransactions.cs
@@ -37,6 +37,9 @@ public static class GetClaimableTransactions
                            DynamicReleaseDate = stageData.StageDate,
                            InvestorAddress = item.InvestorPublicKey,
                            ClaimStatus = DetermineClaimStatus(item, stageData),
+                           TransactionId = item.Trxid,
+                           InvestmentStartDate = item.InvestmentStartDate,
+                           PatternId = item.PatternId,
                        }));
 
             return Result.Success(new GetClaimableTransactionsResponse(list));

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetClaimableTransactions.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetClaimableTransactions.cs
@@ -32,6 +32,7 @@ public static class GetClaimableTransactions
                        {
                            StageId = stageData.StageIndex,
                            StageNumber = stageData.StageIndex + 1,
+                           InvestmentStageIndex = item.StageIndex,
                            Amount = new Amount(item.Amount),
                            DynamicReleaseDate = stageData.StageDate,
                            InvestorAddress = item.InvestorPublicKey,

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/SpendStageFunds.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/SpendStageFunds.cs
@@ -42,8 +42,7 @@ public static class SpendStageFunds
             var groupedByStage = request.ToSpend.GroupBy(x => x.StageId).ToList();
             if (groupedByStage.Count > 1)
                 return Result.Failure<SpendStageFundsResponse>("You can only spend one stage at a time.");
-            
-            var selectedStageId = groupedByStage.First().Key;
+
             var network = networkConfiguration.GetNetwork();
 
             var project = await projectService.GetAsync(request.ProjectId);
@@ -58,21 +57,37 @@ public static class SpendStageFunds
             
             var founderContext = new FounderContext { ProjectInfo = project.Value.ToProjectInfo(), ProjectSeeders = new ProjectSeeders() };
 
-            var tasks = request.ToSpend.Select(x => GetInvestmentByInvestorKey(request.ProjectId.Value, x));
-            
-            var investmentTransactions = await Task.WhenAll(tasks);
-            founderContext.InvestmentTrasnactionsHex = investmentTransactions.Where(hex => hex != string.Empty).ToList();
-            
+            // Build one StageTransactionInput per selected UTXO, each carrying its own
+            // per-investment stage number. For Fund/Subscribe projects a date bucket can mix
+            // different per-investment stage indices (a later investor's stage 1 shares the
+            // release date with an earlier investor's stage 2), so a single stage number for
+            // all inputs would rebuild the wrong taproot script and fail to spend.
+            var stageInputTasks = request.ToSpend.Select(async x =>
+            {
+                var hex = await GetInvestmentByInvestorKey(request.ProjectId.Value, x);
+                return (hex, stageNumber: x.InvestmentStageIndex + 1);
+            });
+
+            var stageInputResults = await Task.WhenAll(stageInputTasks);
+
+            var stageTransactionInputs = stageInputResults
+                .Where(r => r.hex != string.Empty)
+                .Select(r => new StageTransactionInput(r.hex, r.stageNumber))
+                .ToList();
+
+            if (stageTransactionInputs.Count == 0)
+                return Result.Failure<SpendStageFundsResponse>("No investment transactions found for the selected UTXOs.");
+
+            founderContext.InvestmentTrasnactionsHex = stageTransactionInputs.Select(s => s.TransactionHex).ToList();
+
             var addressResult = await GetUnfundedReleaseAddress(request.WalletId);
             if (addressResult.IsFailure) 
                 return Result.Failure<SpendStageFundsResponse>("Could not get an unfunded release address");
             
             var addressScript = BitcoinAddress.Create(addressResult.Value, network.BitcoinNetwork).ScriptPubKey;
-            
-            int stageNumber = selectedStageId + 1;
 
             var signedTransaction = founderTransactionActions.SpendFounderStage(founderContext.ProjectInfo,
-                founderContext.InvestmentTrasnactionsHex, stageNumber, addressScript,
+                stageTransactionInputs, addressScript,
                 founderKey, request.SelectedFee); 
             
             return Result.Success(new SpendStageFundsResponse(new TransactionDraft

--- a/src/sdk/Angor.Sdk/Funding/Projects/ProjectInvestmentsService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/ProjectInvestmentsService.cs
@@ -87,6 +87,10 @@ public class ProjectInvestmentsService(IProjectService projectService, INetworkC
                 item.InvestorPublicKey = projectInvestments
                     .First(p => p.TransactionId == item.Trxid)
                     .InvestorPublicKey;
+
+                // For Invest projects the per-investment stage index always matches the
+                // project-level stage index (fixed stages, same schedule for every investor).
+                item.StageIndex = stage.StageIndex;
             }
         }
 
@@ -173,10 +177,21 @@ public class ProjectInvestmentsService(IProjectService projectService, INetworkC
             }
         }
 
-        // Order by date for consistent ordering
+        // Order by date for consistent ordering.
+        // Reassign StageIndex sequentially — buckets are keyed by release date, and different
+        // investments can contribute different per-investment stage indices to the same bucket
+        // (e.g. a later investor's stage 1 lands in an earlier investor's stage 2 date).
+        // Without reassignment two buckets can share the same StageIndex (e.g. December and
+        // January both carrying index 5), which collides when consumers group by stage number
+        // and silently merges/loses a stage in the UI.
         var orderedList = stagesByDate.Values
             .OrderBy(s => s.StageDate)
             .ToList();
+
+        for (int i = 0; i < orderedList.Count; i++)
+        {
+            orderedList[i].StageIndex = i;
+        }
 
         return Result.Success<IEnumerable<StageData>>(orderedList);
     }

--- a/src/shared/Angor.Shared.Tests/Protocol/InvestmentIntegrationsTests.cs
+++ b/src/shared/Angor.Shared.Tests/Protocol/InvestmentIntegrationsTests.cs
@@ -1115,5 +1115,103 @@ namespace Angor.Test.Protocol
             TransactionValidation.ThanTheTransactionHasNoErrors(investor1RecoverStage2.Transaction,
                 investorInvTrx.Outputs.AsCoins().Where(c => c.Amount > 0));
         }
+
+        /// <summary>
+        /// Regression test: two Fund investors with shifted schedules share a release date —
+        /// investor 1 (starts Feb 1) has their stage 2 on Mar 15, while investor 2 (starts
+        /// Feb 20, after the payout day) has their stage 1 on Mar 15. The founder must be
+        /// able to claim both UTXOs in a single transaction by providing each input its own
+        /// per-investment stage number, otherwise the wrong taproot script is rebuilt and
+        /// the spend fails validation.
+        /// </summary>
+        [Fact]
+        public void FundTransaction_MixedSchedules_FounderClaimsSharedDateBucket_Test()
+        {
+            var network = Networks.Bitcoin.Testnet();
+
+            var words = new WalletWords { Words = new Mnemonic(Wordlist.English, WordCount.Twelve).ToString() };
+
+            var founderKey = _derivationOperations.DeriveFounderPrivateKey(words, 1);
+            var founderReceiveAddress = new Key().PubKey.ScriptPubKey;
+
+            var projectInfo = new ProjectInfo
+            {
+                Version = 2,
+                ProjectType = ProjectType.Fund,
+                TargetAmount = 0,
+                PenaltyDays = 0,
+                StartDate = new DateTime(2025, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+                ExpiryDate = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+                PenaltyThreshold = Money.Coins(10).Satoshi, // both investors below threshold
+                FounderKey = _derivationOperations.DeriveFounderKey(words, 1),
+                FounderRecoveryKey = _derivationOperations.DeriveFounderRecoveryKey(words, _derivationOperations.DeriveFounderKey(words, 1)),
+                ProjectSeeders = new ProjectSeeders(),
+                DynamicStagePatterns = new List<DynamicStagePattern>
+                {
+                    new DynamicStagePattern
+                    {
+                        PatternId = 0,
+                        Name = "3-Month Fund (15th of month)",
+                        Frequency = StageFrequency.Monthly,
+                        StageCount = 3,
+                        PayoutDayType = PayoutDayType.SpecificDayOfMonth,
+                        PayoutDay = 15
+                    }
+                }
+            };
+            projectInfo.ProjectIdentifier = _derivationOperations.DeriveAngorKey(angorRootKey, projectInfo.FounderKey);
+
+            // Investor 1 starts Feb 1 → stages Feb 15, Mar 15, Apr 15
+            var investor1Key = new Key();
+            var investor1Parameters = FundingParameters.CreateForFund(
+                projectInfo,
+                Encoders.Hex.EncodeData(investor1Key.PubKey.ToBytes()),
+                Money.Coins(0.5m).Satoshi,
+                0,
+                new DateTime(2025, 2, 1, 0, 0, 0, DateTimeKind.Utc));
+
+            var investor1Trx = _investorTransactionActions.CreateInvestmentTransaction(projectInfo, investor1Parameters);
+            Assert.NotNull(investor1Trx);
+
+            // Investor 2 starts Feb 20 (after the 15th) → schedule shifts to Mar 15, Apr 15, May 15
+            var investor2Key = new Key();
+            var investor2Parameters = FundingParameters.CreateForFund(
+                projectInfo,
+                Encoders.Hex.EncodeData(investor2Key.PubKey.ToBytes()),
+                Money.Coins(0.3m).Satoshi,
+                0,
+                new DateTime(2025, 2, 20, 0, 0, 0, DateTimeKind.Utc));
+
+            var investor2Trx = _investorTransactionActions.CreateInvestmentTransaction(projectInfo, investor2Parameters);
+            Assert.NotNull(investor2Trx);
+
+            // The founder claims the shared Mar 15 date bucket:
+            // investor 1's stage 2 + investor 2's stage 1, each with its own stage number
+            var mixedBucketInputs = new[]
+            {
+                new StageTransactionInput(investor1Trx.ToHex(), 2),
+                new StageTransactionInput(investor2Trx.ToHex(), 1)
+            };
+
+            var founderClaimTrx = _founderTransactionActions.SpendFounderStage(
+                projectInfo,
+                mixedBucketInputs,
+                founderReceiveAddress,
+                founderKey,
+                _expectedFeeEstimation);
+
+            Assert.NotNull(founderClaimTrx);
+            Assert.NotNull(founderClaimTrx.Transaction);
+            Assert.Equal(2, founderClaimTrx.Transaction.Inputs.Count);
+
+            // Both stages unlock on Mar 15 — the locktime must match the shared release date
+            var expectedLockTime = Utils.DateTimeToUnixTime(new DateTime(2025, 3, 15, 0, 1, 0, DateTimeKind.Utc));
+            Assert.Equal(expectedLockTime, founderClaimTrx.Transaction.LockTime.Value);
+
+            // Full script validation — fails if the wrong taproot script was rebuilt for either input
+            TransactionValidation.ThanTheTransactionHasNoErrors(founderClaimTrx.Transaction,
+                investor1Trx.Outputs.AsCoins().Where(c => c.Amount > 0)
+                    .Concat(investor2Trx.Outputs.AsCoins().Where(c => c.Amount > 0)));
+        }
     }
 }


### PR DESCRIPTION
## Problem

For **Fund/Subscribe** projects, stages are grouped by release date across investments. A later investor's schedule is shifted relative to earlier investors — e.g. investing after the payout day pushes their stage 1 to the next month, sharing a release date with earlier investors' stage 2.

Observed on signet (project \ngor1q8ahddscgamu6jwyeuzq7vwhes9fqfn685u0rx2\): 5 investments, 30 stage UTXOs across 7 distinct release dates (Jul 2026 → Jan 2027), but the UI showed only 6 stages / 29 UTXOs. The 5th investor's last stage (Jan 19, 2027) was silently merged into December's bucket because both buckets carried \StageIndex = 5\, and the ViewModel groups by stage number.

There was also a latent claiming bug: \SpendStageFunds\ used a single stage number for all selected UTXOs, but a date bucket can mix different per-investment stage indices — claiming such a bucket would rebuild the wrong taproot script for some inputs and fail.

## Fix

- **\ProjectInvestmentsService.ScanDynamicTypeInvestments\**: reassign bucket \StageIndex\ sequentially after ordering by date, so every date bucket is a distinct stage (Jan 2027 now shows as Stage 7)
- **\ClaimableTransactionDto\ / \SpendTransactionDto\**: added \InvestmentStageIndex\ — the 0-based stage index within the investment transaction itself, needed to rebuild the correct taproot script when spending
- **\SpendStageFunds\**: builds one \StageTransactionInput(hex, stageNumber)\ per UTXO using its own per-investment stage index, instead of one stage number for all inputs
- **\ManageProjectViewModel\**: carries \InvestmentStageIndex\ through the claim flow
- CLI + old avalonia call sites updated for the new required DTO property
- \AGENTS.md\: updated project overview (design app is primary, webapp is investor-only, src/avalonia is dead code)

## Tests

- SDK tests: 323 passed
- Shared tests: 154 passed
- \SpendStageFundsTests\ updated to mock the per-input overload (intentional behavior change)