### PR TITLE
fix: verify approval event author against project nostr pubkey

### DIFF
--- a/src/sdk/Angor.Sdk.Tests/Funding/Services/InvestmentHandshakeServiceTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Services/InvestmentHandshakeServiceTests.cs
@@ -1,0 +1,143 @@
+using Angor.Data.Documents.Interfaces;
+using Angor.Sdk.Common;
+using Angor.Sdk.Funding.Services;
+using Angor.Sdk.Funding.Shared;
+using Angor.Shared.Services;
+using CSharpFunctionalExtensions;
+using FluentAssertions;
+using Moq;
+using Serilog;
+using Xunit;
+
+namespace Angor.Sdk.Tests.Funding.Services;
+
+public class InvestmentHandshakeServiceTests
+{
+    private const string ProjectNostrPubKey = "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111";
+    private const string InvestorNostrPubKey = "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222";
+    private const string AttackerNostrPubKey = "cccc3333cccc3333cccc3333cccc3333cccc3333cccc3333cccc3333cccc3333";
+    private const string RequestEventId = "request-event-id-1";
+
+    private readonly Mock<ISignService> _mockSignService = new();
+    private readonly Mock<INostrDecrypter> _mockNostrDecrypter = new();
+    private readonly Mock<ISerializer> _mockSerializer = new();
+    private readonly Mock<ILogger> _mockLogger = new();
+    private readonly Mock<IGenericDocumentCollection<InvestmentHandshake>> _mockCollection = new();
+
+    private readonly WalletId _walletId = new("wallet-1");
+    private readonly ProjectId _projectId = new("angor-project-1");
+
+    private InvestmentHandshakeService CreateSut()
+    {
+        _mockCollection
+            .Setup(c => c.FindAsync(It.IsAny<System.Linq.Expressions.Expression<Func<InvestmentHandshake, bool>>>()))
+            .ReturnsAsync(Result.Success(Enumerable.Empty<InvestmentHandshake>()));
+        _mockCollection
+            .Setup(c => c.UpsertAsync(It.IsAny<Func<InvestmentHandshake, string>>(), It.IsAny<InvestmentHandshake>()))
+            .ReturnsAsync(Result.Success(true));
+
+        _mockNostrDecrypter
+            .Setup(d => d.Decrypt(It.IsAny<WalletId>(), It.IsAny<ProjectId>(), It.IsAny<DirectMessage>()))
+            .ReturnsAsync(Result.Failure<string>("not decryptable in test"));
+
+        return new InvestmentHandshakeService(
+            _mockSignService.Object,
+            _mockNostrDecrypter.Object,
+            _mockSerializer.Object,
+            _mockLogger.Object,
+            _mockCollection.Object);
+    }
+
+    private void SetupNostrMessages(params (InvestmentMessageType Type, string Id, string PubKey)[] messages)
+    {
+        _mockSignService
+            .Setup(s => s.LookupAllInvestmentMessagesAsync(
+                ProjectNostrPubKey,
+                It.IsAny<string?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<Action<InvestmentMessageType, string, string, string, DateTime>>(),
+                It.IsAny<Action>()))
+            .Callback((string _, string? _, DateTime? _,
+                Action<InvestmentMessageType, string, string, string, DateTime> onMessage,
+                Action onAllMessagesReceived) =>
+            {
+                foreach (var (type, id, pubKey) in messages)
+                {
+                    onMessage(type, id, pubKey, "encrypted-content", DateTime.UtcNow);
+                }
+
+                onAllMessagesReceived();
+            })
+            .Returns(Task.CompletedTask);
+    }
+
+    [Fact]
+    public async Task SyncHandshakesFromNostr_WhenApprovalAuthoredByProjectKey_MarksRequestApproved()
+    {
+        // Arrange
+        SetupNostrMessages(
+            (InvestmentMessageType.Request, RequestEventId, InvestorNostrPubKey),
+            (InvestmentMessageType.Approval, RequestEventId, ProjectNostrPubKey));
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.SyncHandshakesFromNostrAsync(_walletId, _projectId, ProjectNostrPubKey);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var handshake = result.Value.Should().ContainSingle().Subject;
+        handshake.Status.Should().Be(InvestmentRequestStatus.Approved);
+        handshake.ApprovalEventId.Should().Be(RequestEventId);
+    }
+
+    [Fact]
+    public async Task SyncHandshakesFromNostr_WhenApprovalAuthoredByOtherKey_IgnoresSpoofedApproval()
+    {
+        // Arrange
+        SetupNostrMessages(
+            (InvestmentMessageType.Request, RequestEventId, InvestorNostrPubKey),
+            (InvestmentMessageType.Approval, RequestEventId, AttackerNostrPubKey));
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.SyncHandshakesFromNostrAsync(_walletId, _projectId, ProjectNostrPubKey);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var handshake = result.Value.Should().ContainSingle().Subject;
+        handshake.Status.Should().Be(InvestmentRequestStatus.Pending);
+        handshake.ApprovalEventId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SyncHandshakesFromNostr_WhenSpoofedApprovalTargetsExistingHandshake_DoesNotUpdateStatus()
+    {
+        // Arrange
+        SetupNostrMessages(
+            (InvestmentMessageType.Request, RequestEventId, InvestorNostrPubKey),
+            (InvestmentMessageType.Approval, RequestEventId, AttackerNostrPubKey));
+        var sut = CreateSut();
+
+        var existing = new InvestmentHandshake
+        {
+            Id = "existing-id",
+            WalletId = _walletId.Value,
+            ProjectId = _projectId.Value,
+            RequestEventId = RequestEventId,
+            InvestorNostrPubKey = InvestorNostrPubKey,
+            Status = InvestmentRequestStatus.Pending
+        };
+        _mockCollection
+            .Setup(c => c.FindAsync(It.IsAny<System.Linq.Expressions.Expression<Func<InvestmentHandshake, bool>>>()))
+            .ReturnsAsync(Result.Success<IEnumerable<InvestmentHandshake>>(new[] { existing }));
+
+        // Act
+        var result = await sut.SyncHandshakesFromNostrAsync(_walletId, _projectId, ProjectNostrPubKey);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty(); // nothing changed, nothing upserted
+        existing.Status.Should().Be(InvestmentRequestStatus.Pending);
+        existing.ApprovalEventId.Should().BeNull();
+    }
+}

--- a/src/sdk/Angor.Sdk/Funding/Services/InvestmentHandshakeService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Services/InvestmentHandshakeService.cs
@@ -329,7 +329,17 @@ public class InvestmentHandshakeService(
                             break;
                         case InvestmentMessageType.Approval:
                             // For approvals, we need to extract the event identifier from the content/tags
-                            // The pubKey here is the founder's pubKey, and we need the referenced event ID
+                            // The pubKey here is the author's pubKey, and we need the referenced event ID.
+                            // Only the project's Nostr key can author a valid approval - anyone can publish
+                            // an event addressed to the project (p-tag) with the approval subject, so events
+                            // authored by any other key are spoofed and must be ignored.
+                            if (!string.Equals(pubKey, projectNostrPubKey, StringComparison.OrdinalIgnoreCase))
+                            {
+                                logger.Warning(
+                                    "Ignoring spoofed approval event {EventId} authored by {Author}; expected project pubkey {Expected}",
+                                    id, pubKey, projectNostrPubKey);
+                                break;
+                            }
                             approvals.Add(new ApprovalInfo(pubKey, created, id));
                             break;
                     }


### PR DESCRIPTION
Fixes #944

## Problem

\InvestmentHandshakeService.SyncHandshakesFromNostrAsync\ treated **any** Nostr event as a founder approval as long as it was a kind-4 DM with \subject = Re:Investment offer\ and an \e\ tag referencing an investment request. The author (\pubkey\) was never checked against the project's Nostr pubkey, so anyone could publish a spoofed DM addressed to the project (p-tag) and cause the founder's next sync to mark a victim's request as \Approved\ — blocking legitimate approvals and corrupting handshake state.

## Fix

In \FetchAllInvestmentMessagesFromNostr\, an event is only treated as an approval when its author pubkey equals \projectNostrPubKey\. Spoofed approvals are logged with a warning and ignored. The author data was already available (\ApprovalInfo.ProfileIdentifier\); it just wasn't being checked.

## Tests

New \InvestmentHandshakeServiceTests\ covering:
- genuine approval (authored by project key) → request marked \Approved\
- spoofed approval (authored by another key) → new handshake stays \Pending\, no \ApprovalEventId\
- spoofed approval targeting an existing pending handshake → status unchanged, nothing upserted

Full SDK test suite passes (326 passed, 0 failed).