### PR TITLE
fix: median-time-past safety buffer for timelocked spend gating (non-final claims)

### DIFF
--- a/src/design/App/UI/Sections/MyProjects/ManageProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/ManageProjectViewModel.cs
@@ -566,15 +566,31 @@ public partial class ManageProjectViewModel : ReactiveObject
             _logger.LogError("SubmitTransactionFromDraft failed while claiming stage funds for project {ProjectId}: {Error}",
                 Project.ProjectIdentifier,
                 publishResult.Error);
-            ToastRequested?.Invoke($"Failed to claim stage funds: {publishResult.Error}");
+            ToastRequested?.Invoke($"Failed to claim stage funds: {ToFriendlyClaimError(publishResult.Error)}");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "ClaimStageFundsAsync threw exception for project {ProjectId}", Project.ProjectIdentifier);
-            ToastRequested?.Invoke($"Failed to claim stage funds: {ex.Message}");
+            ToastRequested?.Invoke($"Failed to claim stage funds: {ToFriendlyClaimError(ex.Message)}");
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Maps raw node/broadcast errors to actionable messages. A "non-final" rejection means
+    /// the stage timelock has not yet been reached on-chain: Bitcoin evaluates locktimes
+    /// against the tip's median-time-past, which lags wall-clock time by roughly an hour.
+    /// </summary>
+    private static string ToFriendlyClaimError(string error)
+    {
+        if (error.Contains("non-final", StringComparison.OrdinalIgnoreCase))
+        {
+            return "The network has not confirmed the stage unlock time yet (block time lags "
+                   + "real time by up to an hour or two). Please try again in about an hour.";
+        }
+
+        return error;
     }
 
     /// <summary>

--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/GetClaimableTransactionsTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/GetClaimableTransactionsTests.cs
@@ -530,4 +530,72 @@ public class GetClaimableTransactionsTests
         result.Value.Transactions.First().ClaimStatus.Should().Be(ClaimStatus.SpentByFounder,
             "Spent status should take priority over future release date");
     }
+
+    [Fact]
+    public async Task Handle_WhenReleaseDateJustPassed_ShowsLockedDuringMedianTimePastBuffer()
+    {
+        // Arrange — regression for the "non-final" broadcast rejection: the release date has
+        // passed by wall-clock time, but the network validates nLockTime against the chain
+        // tip's median-time-past, which lags wall clock by up to ~2 hours. The stage must
+        // stay Locked during the safety buffer so the founder is not offered a claim that
+        // bitcoind would reject.
+        var walletId = new WalletId("wallet-1");
+        var projectId = new ProjectId("project-1");
+        var request = new GetClaimableTransactions.GetClaimableTransactionsRequest(walletId, projectId);
+
+        var stageData = new StageData
+        {
+            StageIndex = 0,
+            StageDate = DateTime.UtcNow.AddMinutes(-30), // passed by wall clock, within the buffer
+            IsDynamic = true,
+            Items = new List<StageDataTrx>
+            {
+                new StageDataTrx { Amount = 50_000, IsSpent = false, InvestorPublicKey = "investor-pub-1" }
+            }
+        };
+
+        _mockProjectInvestmentsService
+            .Setup(x => x.ScanFullInvestments(projectId.Value))
+            .ReturnsAsync(Result.Success<IEnumerable<StageData>>(new[] { stageData }));
+
+        // Act
+        var result = await _sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Transactions.First().ClaimStatus.Should().Be(ClaimStatus.Locked,
+            "median-time-past may not have reached the release date yet");
+    }
+
+    [Fact]
+    public async Task Handle_WhenReleaseDatePassedBeyondBuffer_ShowsUnspent()
+    {
+        // Arrange — once the safety buffer has elapsed, median-time-past has caught up and
+        // the stage is genuinely claimable.
+        var walletId = new WalletId("wallet-1");
+        var projectId = new ProjectId("project-1");
+        var request = new GetClaimableTransactions.GetClaimableTransactionsRequest(walletId, projectId);
+
+        var stageData = new StageData
+        {
+            StageIndex = 0,
+            StageDate = DateTime.UtcNow.AddHours(-3), // past the 2-hour buffer
+            IsDynamic = true,
+            Items = new List<StageDataTrx>
+            {
+                new StageDataTrx { Amount = 50_000, IsSpent = false, InvestorPublicKey = "investor-pub-1" }
+            }
+        };
+
+        _mockProjectInvestmentsService
+            .Setup(x => x.ScanFullInvestments(projectId.Value))
+            .ReturnsAsync(Result.Success<IEnumerable<StageData>>(new[] { stageData }));
+
+        // Act
+        var result = await _sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Transactions.First().ClaimStatus.Should().Be(ClaimStatus.Unspent);
+    }
 }

--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/GetClaimableTransactionsTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/GetClaimableTransactionsTests.cs
@@ -4,6 +4,7 @@ using Angor.Sdk.Funding.Founder.Operations;
 using Angor.Sdk.Funding.Projects;
 using Angor.Sdk.Funding.Projects.Domain;
 using Angor.Sdk.Funding.Shared;
+using Angor.Shared;
 using Angor.Shared.Models;
 using CSharpFunctionalExtensions;
 using FluentAssertions;
@@ -14,12 +15,15 @@ namespace Angor.Sdk.Tests.Funding.Founder;
 public class GetClaimableTransactionsTests
 {
     private readonly Mock<IProjectInvestmentsService> _mockProjectInvestmentsService;
+    private readonly Mock<INetworkConfiguration> _mockNetworkConfiguration;
     private readonly GetClaimableTransactions.GetClaimableTransactionsHandler _sut;
 
     public GetClaimableTransactionsTests()
     {
         _mockProjectInvestmentsService = new Mock<IProjectInvestmentsService>();
-        _sut = new GetClaimableTransactions.GetClaimableTransactionsHandler(_mockProjectInvestmentsService.Object);
+        _mockNetworkConfiguration = new Mock<INetworkConfiguration>();
+        _mockNetworkConfiguration.Setup(x => x.GetDebugMode()).Returns(false);
+        _sut = new GetClaimableTransactions.GetClaimableTransactionsHandler(_mockProjectInvestmentsService.Object, _mockNetworkConfiguration.Object);
     }
 
     [Fact]
@@ -597,5 +601,40 @@ public class GetClaimableTransactionsTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         result.Value.Transactions.First().ClaimStatus.Should().Be(ClaimStatus.Unspent);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDebugMode_BufferIsDisabledAndStageIsImmediatelyClaimable()
+    {
+        // Arrange — UAT/integration tests run in debug mode and create projects with
+        // same-day payouts; the safety buffer must not delay claimability there.
+        _mockNetworkConfiguration.Setup(x => x.GetDebugMode()).Returns(true);
+
+        var walletId = new WalletId("wallet-1");
+        var projectId = new ProjectId("project-1");
+        var request = new GetClaimableTransactions.GetClaimableTransactionsRequest(walletId, projectId);
+
+        var stageData = new StageData
+        {
+            StageIndex = 0,
+            StageDate = DateTime.UtcNow.AddMinutes(-1), // just passed, within the normal buffer
+            IsDynamic = true,
+            Items = new List<StageDataTrx>
+            {
+                new StageDataTrx { Amount = 50_000, IsSpent = false, InvestorPublicKey = "investor-pub-1" }
+            }
+        };
+
+        _mockProjectInvestmentsService
+            .Setup(x => x.ScanFullInvestments(projectId.Value))
+            .ReturnsAsync(Result.Success<IEnumerable<StageData>>(new[] { stageData }));
+
+        // Act
+        var result = await _sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Transactions.First().ClaimStatus.Should().Be(ClaimStatus.Unspent,
+            "debug mode disables the median-time-past buffer so tests are not delayed");
     }
 }

--- a/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/InvestmentAppServiceTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Investor/Operations/InvestmentAppServiceTests.cs
@@ -428,7 +428,8 @@ public class InvestmentAppServiceTests : IClassFixture<TestNetworkFixture>
             _mockAngorIndexerService.Object,
             _mockTransactionService.Object,
             _mockProjectInvestmentsService.Object,
-            _mockProjectService.Object);
+            _mockProjectService.Object,
+            _fixture.NetworkConfiguration);
         
         var request = new GetPenalties.GetPenaltiesRequest(walletId);
 
@@ -456,7 +457,8 @@ public class InvestmentAppServiceTests : IClassFixture<TestNetworkFixture>
             _mockAngorIndexerService.Object,
             _mockTransactionService.Object,
             _mockProjectInvestmentsService.Object,
-            _mockProjectService.Object);
+            _mockProjectService.Object,
+            _fixture.NetworkConfiguration);
         
         var request = new GetPenalties.GetPenaltiesRequest(walletId);
 
@@ -484,7 +486,8 @@ public class InvestmentAppServiceTests : IClassFixture<TestNetworkFixture>
             _mockAngorIndexerService.Object,
             _mockTransactionService.Object,
             _mockProjectInvestmentsService.Object,
-            _mockProjectService.Object);
+            _mockProjectService.Object,
+            _fixture.NetworkConfiguration);
         
         var request = new GetPenalties.GetPenaltiesRequest(walletId);
 
@@ -530,7 +533,8 @@ public class InvestmentAppServiceTests : IClassFixture<TestNetworkFixture>
             _mockAngorIndexerService.Object,
             _mockTransactionService.Object,
             _mockProjectInvestmentsService.Object,
-            _mockProjectService.Object);
+            _mockProjectService.Object,
+            _fixture.NetworkConfiguration);
         
         var request = new GetPenalties.GetPenaltiesRequest(walletId);
 

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetClaimableTransactions.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetClaimableTransactions.cs
@@ -71,8 +71,11 @@ public static class GetClaimableTransactions
                 };
             }
 
-            // Check if stage release date hasn't been reached yet (works for both dynamic and fixed stages)
-            if (stageData.StageDate > DateTime.UtcNow)
+            // Check if the stage timelock has been reached on-chain (works for both dynamic and
+            // fixed stages). The network validates nLockTime against the chain tip's
+            // median-time-past, which lags wall-clock time — without the safety buffer the UI
+            // offers claims that bitcoind rejects as "non-final" right after the release date.
+            if (stageData.StageDate.Add(TimelockSafety.MedianTimePastBuffer) > DateTime.UtcNow)
             {
                 return ClaimStatus.Locked;
             }

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetClaimableTransactions.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/GetClaimableTransactions.cs
@@ -3,6 +3,7 @@ using Angor.Sdk.Funding.Founder.Dtos;
 using Angor.Sdk.Funding.Projects;
 using Angor.Sdk.Funding.Projects.Domain;
 using Angor.Sdk.Funding.Shared;
+using Angor.Shared;
 using Angor.Shared.Models;
 using CSharpFunctionalExtensions;
 using MediatR;
@@ -15,7 +16,7 @@ public static class GetClaimableTransactions
 
     public record GetClaimableTransactionsResponse(IEnumerable<ClaimableTransactionDto> Transactions);
 
-    public class GetClaimableTransactionsHandler(IProjectInvestmentsService projectInvestmentsService) : IRequestHandler<GetClaimableTransactionsRequest, Result<GetClaimableTransactionsResponse>>
+    public class GetClaimableTransactionsHandler(IProjectInvestmentsService projectInvestmentsService, INetworkConfiguration networkConfiguration) : IRequestHandler<GetClaimableTransactionsRequest, Result<GetClaimableTransactionsResponse>>
     {
         public async Task<Result<GetClaimableTransactionsResponse>> Handle(GetClaimableTransactionsRequest request, CancellationToken cancellationToken)
         {
@@ -26,6 +27,8 @@ public static class GetClaimableTransactions
                 return Result.Failure<GetClaimableTransactionsResponse>(resultList.Error);
             }
 
+            var timelockBuffer = TimelockSafety.BufferFor(networkConfiguration);
+
             var list = resultList.Value.SelectMany(stageData => stageData.Items
                     .Select<StageDataTrx, ClaimableTransactionDto>(item =>
                        new ClaimableTransactionDto()
@@ -35,13 +38,13 @@ public static class GetClaimableTransactions
                            Amount = new Amount(item.Amount),
                            DynamicReleaseDate = stageData.StageDate,
                            InvestorAddress = item.InvestorPublicKey,
-                           ClaimStatus = DetermineClaimStatus(item, stageData),
+                           ClaimStatus = DetermineClaimStatus(item, stageData, timelockBuffer),
                        }));
 
             return Result.Success(new GetClaimableTransactionsResponse(list));
         }
 
-        private static ClaimStatus DetermineClaimStatus(StageDataTrx item, StageData stageData)
+        private static ClaimStatus DetermineClaimStatus(StageDataTrx item, StageData stageData, TimeSpan timelockBuffer)
         {
             // Check spent status first — a spent stage should always show as spent,
             // even if its release date is in the future
@@ -75,7 +78,7 @@ public static class GetClaimableTransactions
             // fixed stages). The network validates nLockTime against the chain tip's
             // median-time-past, which lags wall-clock time — without the safety buffer the UI
             // offers claims that bitcoind rejects as "non-final" right after the release date.
-            if (stageData.StageDate.Add(TimelockSafety.MedianTimePastBuffer) > DateTime.UtcNow)
+            if (stageData.StageDate.Add(timelockBuffer) > DateTime.UtcNow)
             {
                 return ClaimStatus.Locked;
             }

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetPenalties.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetPenalties.cs
@@ -5,6 +5,7 @@ using Angor.Sdk.Funding.Projects;
 using Angor.Sdk.Funding.Projects.Domain;
 using Angor.Sdk.Funding.Services;
 using Angor.Sdk.Funding.Shared;
+using Angor.Shared;
 using Angor.Shared.Services;
 using NBitcoin;
 using CSharpFunctionalExtensions;
@@ -23,7 +24,8 @@ public class GetPenalties
         IAngorIndexerService angorIndexerService,
         ITransactionService transactionService,
         IProjectInvestmentsService investmentsService,
-        IProjectService projectService) : IRequestHandler<GetPenaltiesRequest, Result<GetPenaltiesResponse>>
+        IProjectService projectService,
+        INetworkConfiguration networkConfiguration) : IRequestHandler<GetPenaltiesRequest, Result<GetPenaltiesResponse>>
     {
 
         public async Task<Result<GetPenaltiesResponse>> Handle(GetPenaltiesRequest request,
@@ -169,7 +171,7 @@ public class GetPenalties
                     // Penalty release is timelocked; the network validates it against the chain
                     // tip's median-time-past, which lags wall-clock time. Apply a safety buffer
                     // so the release is never offered before the network will accept it.
-                    penaltyProject.IsExpired = (expieryDate.Add(TimelockSafety.MedianTimePastBuffer) - DateTimeOffset.UtcNow) <= TimeSpan.Zero;
+                    penaltyProject.IsExpired = (expieryDate.Add(TimelockSafety.BufferFor(networkConfiguration)) - DateTimeOffset.UtcNow) <= TimeSpan.Zero;
                 }
             }
             catch (Exception e)

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetPenalties.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetPenalties.cs
@@ -166,7 +166,10 @@ public class GetPenalties
                     var expieryDate = Utils.UnixTimeToDateTime(recoveryTransaction.Timestamp)
                         .AddDays(penaltyProject.Project.PenaltyDuration.Days);
                     penaltyProject.DaysLeftForPenalty = (expieryDate.Date - DateTimeOffset.UtcNow.Date).Days;
-                    penaltyProject.IsExpired = (expieryDate - DateTimeOffset.UtcNow).Days <= 0;
+                    // Penalty release is timelocked; the network validates it against the chain
+                    // tip's median-time-past, which lags wall-clock time. Apply a safety buffer
+                    // so the release is never offered before the network will accept it.
+                    penaltyProject.IsExpired = (expieryDate.Add(TimelockSafety.MedianTimePastBuffer) - DateTimeOffset.UtcNow) <= TimeSpan.Zero;
                 }
             }
             catch (Exception e)

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetRecoveryStatus.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetRecoveryStatus.cs
@@ -176,7 +176,7 @@ public static class GetRecoveryStatus
             // network against the chain tip's median-time-past, which lags wall-clock time.
             // Apply a safety buffer so the user is never offered a spend that bitcoind would
             // reject as "non-final".
-            var safeNow = DateTime.UtcNow - TimelockSafety.MedianTimePastBuffer;
+            var safeNow = DateTime.UtcNow - TimelockSafety.BufferFor(networkConfiguration);
 
             var isEndOfProject = projectInfo.ExpiryDate < safeNow;
 

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetRecoveryStatus.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetRecoveryStatus.cs
@@ -172,12 +172,18 @@ public static class GetRecoveryStatus
             var isAboveThreshold = projectInfo.ProjectType == ProjectType.Fund
                 && investorTransactionActions.IsInvestmentAbovePenaltyThreshold(projectInfo, totalInvestmentAmount);
             
-            var isEndOfProject = projectInfo.ExpiryDate < DateTime.UtcNow;
+            // Timelocked spends (end-of-project CLTV, penalty release) are validated by the
+            // network against the chain tip's median-time-past, which lags wall-clock time.
+            // Apply a safety buffer so the user is never offered a spend that bitcoind would
+            // reject as "non-final".
+            var safeNow = DateTime.UtcNow - TimelockSafety.MedianTimePastBuffer;
+
+            var isEndOfProject = projectInfo.ExpiryDate < safeNow;
 
             var response = new InvestorProjectRecoveryDto
             {
                 HasUnspentItems = stageItems.Any(a => a.IsSpent == false),
-                HasSpendableItemsInPenalty = (stageItems.Any(a => a.ScriptType == ProjectScriptTypeEnum.InvestorWithPenalty) && DateTime.UtcNow > penaltyExpieryDate),
+                HasSpendableItemsInPenalty = (stageItems.Any(a => a.ScriptType == ProjectScriptTypeEnum.InvestorWithPenalty) && safeNow > penaltyExpieryDate),
                 EndOfProject = isEndOfProject,
                 IsAboveThreshold = isAboveThreshold,
                 TotalSpendable = stageItems.Where(a => !a.IsSpent).Sum(a => a.Amount),

--- a/src/sdk/Angor.Sdk/Funding/Shared/TimelockSafety.cs
+++ b/src/sdk/Angor.Sdk/Funding/Shared/TimelockSafety.cs
@@ -1,3 +1,5 @@
+using Angor.Shared;
+
 namespace Angor.Sdk.Funding.Shared;
 
 /// <summary>
@@ -16,4 +18,14 @@ public static class TimelockSafety
     /// so that MTP has caught up by the time the user is offered the spend.
     /// </summary>
     public static readonly TimeSpan MedianTimePastBuffer = TimeSpan.FromHours(2);
+
+    /// <summary>
+    /// The buffer to apply for the current configuration. Debug mode (used by UAT and
+    /// integration tests, which create projects with same-day payouts and zero penalty
+    /// days) disables the buffer so timelocked actions become available immediately.
+    /// </summary>
+    public static TimeSpan BufferFor(INetworkConfiguration networkConfiguration)
+    {
+        return networkConfiguration.GetDebugMode() ? TimeSpan.Zero : MedianTimePastBuffer;
+    }
 }

--- a/src/sdk/Angor.Sdk/Funding/Shared/TimelockSafety.cs
+++ b/src/sdk/Angor.Sdk/Funding/Shared/TimelockSafety.cs
@@ -1,0 +1,19 @@
+namespace Angor.Sdk.Funding.Shared;
+
+/// <summary>
+/// Safety margin applied when gating CLTV/CSV timelocked spends on wall-clock time.
+///
+/// Bitcoin nodes evaluate time-based locktimes against the chain tip's median-time-past
+/// (MTP, the median of the last 11 block timestamps), which typically lags wall-clock
+/// time by 30-90 minutes (worst case about 2 hours). Comparing release dates against
+/// DateTime.UtcNow alone makes outputs look spendable before the network will actually
+/// accept the transaction — sendrawtransaction rejects it with "non-final" (-26).
+/// </summary>
+public static class TimelockSafety
+{
+    /// <summary>
+    /// How long after a timelock's release date we keep treating the output as locked,
+    /// so that MTP has caught up by the time the user is offered the spend.
+    /// </summary>
+    public static readonly TimeSpan MedianTimePastBuffer = TimeSpan.FromHours(2);
+}


### PR DESCRIPTION
## Problem

A mainnet founder (project `angor1q9k9976ytwkkmswlq24e89l2fxuxl57gfp8yxgr`) tried to claim stage funds right after the stage's release date and got:

```
Failed to claim stage funds: Bad Request
{"error":"sendrawtransaction RPC error: {\"code\":-26,\"message\":\"non-final\"}"}
```

Bitcoin validates time-based `nLockTime`/CLTV/CSV against the chain tip's **median-time-past** (MTP, median of the last 11 block timestamps), which lags wall-clock time by 30-90 minutes (worst case ~2h). The app gates claimability with `DateTime.UtcNow`, so right after a release date the UI offers a claim that the network still rejects as non-final.

Note: the primary cause of the linked incident (mixed per-investment stage indices) is fixed separately in #943. This PR closes the remaining MTP window, which affects **all** timelocked flows.

## Fix (static safety buffer)

- **`TimelockSafety`** (new, `src/sdk/Angor.Sdk/Funding/Shared/TimelockSafety.cs`): a 2-hour `MedianTimePastBuffer` applied when gating timelocked spends on wall-clock time.
- Applied to:
  - founder stage claims — `GetClaimableTransactions` (stage stays `Locked` until release date + buffer)
  - investor end-of-project + penalty-release gating — `GetRecoveryStatus`
  - penalty expiry — `GetPenalties.IsExpired` (also fixes the previous `.Days <= 0` truncation that marked penalties expired up to a day early)
- **Debug mode disables the buffer** (`TimelockSafety.BufferFor`): UAT/integration tests run in debug mode with same-day payouts and `PenaltyDays = 0`; without this exemption they would block for 2h (verified against `MultiFundClaimAndRecoverTest`, `BigFundTest`, `FundAndRecoverTest` expectations).
- **Friendly error**: the founder claim flow now maps raw `non-final` broadcast errors to an actionable "try again in about an hour" message instead of raw RPC JSON.

## Tests

- `Handle_WhenReleaseDateJustPassed_ShowsLockedDuringMedianTimePastBuffer`
- `Handle_WhenReleaseDatePassedBeyondBuffer_ShowsUnspent`
- `Handle_WhenDebugMode_BufferIsDisabledAndStageIsImmediatelyClaimable`
- All 343 SDK tests and 154 shared tests pass; App + CLI build clean.
