### PR TITLE
build: make App.Test.Uat build App.Desktop so UAT never runs a stale exe

### DIFF
--- a/src/design/App.Test.Uat/App.Test.Uat.csproj
+++ b/src/design/App.Test.Uat/App.Test.Uat.csproj
@@ -25,6 +25,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\App\App.csproj" />
+    <!-- UAT tests launch the App.Desktop executable (Angor2) as a child process.
+         Build it as part of this project so tests never run against a stale binary,
+         but don't reference its assembly. -->
+    <ProjectReference Include="..\App.Desktop\App.Desktop.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Problem

`App.Test.Uat` only references `App.csproj`, but its `TestProcessHost` launches the **App.Desktop** executable (`Angor2.exe`) as a child process. Building/running the UAT suite therefore never rebuilds the desktop exe, so tests can silently run against a stale binary.

This bit today after pulling #937: the two new UAT tests (auto-approve toggle, Settings seed backup) failed deterministically because the launched `Angor2.exe` predated the PR's UI/automation changes. After an explicit `dotnet build App.Desktop` the full suite passed 8/8 with no code changes.

## Fix

Add a `ProjectReference` to `App.Desktop.csproj` with `ReferenceOutputAssembly=false` — builds the exe as a dependency without referencing its assembly.

## Validation

- `dotnet build App.Test.Uat` now refreshes `App.Desktop/bin/.../Angor2.exe`
- `SettingsTest` rerun passes against the freshly built exe