### PR TITLE
Fix recovery scan crash and wrong change-output assumptions in spend scanning

### DIFF
--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetRecoveryStatus.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetRecoveryStatus.cs
@@ -204,13 +204,20 @@ public static class GetRecoveryStatus
         {
             //TODO handle unconfirmed outbound transactions
             
-            var output = transactionInfo.Outputs.FirstOrDefault(o => o.Index == item.StageIndex + 2);
+            // Stage outputs are the taproot outputs ordered by index (same selection used to build
+            // the stage items in FindInvestments), so the stage index maps directly by position.
+            var stageOutputs = transactionInfo.Outputs
+                .Where(o => Script.FromHex(o.ScriptPubKey).IsTaprooOutput())
+                .OrderBy(o => o.Index)
+                .ToList();
 
-            if (output == null)
+            if (item.StageIndex >= stageOutputs.Count)
             {
-                logger.LogWarning("[CheckTxSpending] Stage {StageIndex}: no output at index {Index}, skipping", item.StageIndex, item.StageIndex + 2);
+                logger.LogWarning("[CheckTxSpending] Stage {StageIndex}: no matching taproot output (found {Count}), skipping", item.StageIndex, stageOutputs.Count);
                 return Result.Success();
             }
+
+            var output = stageOutputs[item.StageIndex];
 
             logger.LogInformation("[CheckTxSpending] Stage {StageIndex}: SpentInTransaction={SpentTxId}, UnfundedReleaseTxId={UnfundedTxId}, RecoveryTxId={RecoveryTxId}", 
                 item.StageIndex, output.SpentInTransaction ?? "null", lookup.Value.UnfundedReleaseTransactionId ?? "null", lookup.Value.RecoveryTransactionId ?? "null");
@@ -254,7 +261,7 @@ public static class GetRecoveryStatus
 
                         var input = spentInTransaction?.Inputs.FirstOrDefault(input =>
                             input.InputTransactionId == transactionInfo.TransactionId &&
-                            input.InputIndex == item.StageIndex + 2);
+                            input.InputIndex == output.Index);
 
                         logger.LogInformation("[CheckTxSpending] Stage {StageIndex}: spentInTransaction found={Found}, input found={InputFound}", 
                             item.StageIndex, spentInTransaction != null, input != null);

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetRecoveryStatus.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetRecoveryStatus.cs
@@ -110,7 +110,7 @@ public static class GetRecoveryStatus
             // For all project types, stages correspond to Taproot outputs
             // Transaction structure: index 0 = Angor fee, index 1 = OP_RETURN, index 2+ = stage outputs
             var taprootOutputs = trxInfo.Outputs
-                .Where(o => o.Index >= 2 && Script.FromHex(o.ScriptPubKey).IsTaprooOutput())
+                .Where(o => Script.FromHex(o.ScriptPubKey).IsTaprooOutput())
                 .OrderBy(o => o.Index)
                 .ToList();
 

--- a/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetRecoveryStatus.cs
+++ b/src/sdk/Angor.Sdk/Funding/Investor/Operations/GetRecoveryStatus.cs
@@ -110,7 +110,7 @@ public static class GetRecoveryStatus
             // For all project types, stages correspond to Taproot outputs
             // Transaction structure: index 0 = Angor fee, index 1 = OP_RETURN, index 2+ = stage outputs
             var taprootOutputs = trxInfo.Outputs
-                .Where(o => Script.FromHex(o.ScriptPubKey).IsTaprooOutput())
+                .Where(o => o.Index >= 2 && Script.FromHex(o.ScriptPubKey).IsTaprooOutput())
                 .OrderBy(o => o.Index)
                 .ToList();
 
@@ -204,7 +204,13 @@ public static class GetRecoveryStatus
         {
             //TODO handle unconfirmed outbound transactions
             
-            var output = transactionInfo.Outputs.ElementAt(item.StageIndex + 2);
+            var output = transactionInfo.Outputs.FirstOrDefault(o => o.Index == item.StageIndex + 2);
+
+            if (output == null)
+            {
+                logger.LogWarning("[CheckTxSpending] Stage {StageIndex}: no output at index {Index}, skipping", item.StageIndex, item.StageIndex + 2);
+                return Result.Success();
+            }
 
             logger.LogInformation("[CheckTxSpending] Stage {StageIndex}: SpentInTransaction={SpentTxId}, UnfundedReleaseTxId={UnfundedTxId}, RecoveryTxId={RecoveryTxId}", 
                 item.StageIndex, output.SpentInTransaction ?? "null", lookup.Value.UnfundedReleaseTransactionId ?? "null", lookup.Value.RecoveryTransactionId ?? "null");
@@ -289,8 +295,11 @@ public static class GetRecoveryStatus
                                         break;
                                     }
 
-                                    // P2WSH outputs = penalty timelock recovery
-                                    if (spentInTransaction.Outputs.SkipLast(1)
+                                    // P2WSH outputs = penalty timelock recovery. Filter by script type
+                                    // instead of SkipLast(1), which wrongly assumes a change output exists.
+                                    if (spentInTransaction.Outputs
+                                            .Where(o => !string.IsNullOrEmpty(o.ScriptPubKey)
+                                                        && Script.FromHex(o.ScriptPubKey).IsScriptType(ScriptType.P2WSH))
                                             .Any(o => !string.IsNullOrEmpty(o.SpentInTransaction)))
                                     {
                                         item.Status = "Recovered after penalty";

--- a/src/sdk/Angor.Sdk/Funding/Projects/ProjectInvestmentsService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/ProjectInvestmentsService.cs
@@ -304,24 +304,19 @@ public class ProjectInvestmentsService(IProjectService projectService, INetworkC
             ProjectIdentifier = project.ProjectIdentifier
         };
 
-        // Stage outputs are always the taproot outputs at index >= 2 of the actual transaction.
-        // Transaction structure: index 0 = Angor fee, index 1 = OP_RETURN, index 2+ = stage outputs.
+        // Stage outputs are the taproot outputs of the actual transaction, ordered by index.
         // Never use project.Stages.Count here: Fund/Subscribe investments have dynamic stage counts,
-        // and never assume the last output is change (there may be no change output at all).
-        var stageCount = investmentTransaction.Outputs.AsIndexedOutputs()
-            .Count(o => o.N >= 2 && o.TxOut.ScriptPubKey.IsTaprooOutput());
+        // and never assume positions (fee outputs may change) or that the last output is change.
+        var stageOutputs = trxInfo.Outputs
+            .Where(o => !string.IsNullOrEmpty(o.ScriptPubKey) && Script.FromHex(o.ScriptPubKey).IsTaprooOutput())
+            .OrderBy(o => o.Index)
+            .ToList();
 
-        logger.LogInformation("[ScanInvestmentSpends] stageCount={StageCount}, projectStagesCount={ProjectStagesCount}", stageCount, project.Stages?.Count ?? 0);
+        logger.LogInformation("[ScanInvestmentSpends] stageCount={StageCount}, projectStagesCount={ProjectStagesCount}", stageOutputs.Count, project.Stages?.Count ?? 0);
 
-        for (int stageIndex = 0; stageIndex < stageCount; stageIndex++)
+        for (int stageIndex = 0; stageIndex < stageOutputs.Count; stageIndex++)
         {
-            var output = trxInfo.Outputs.FirstOrDefault(f => f.Index == stageIndex + 2);
-
-            if (output == null)
-            {
-                logger.LogWarning("[ScanInvestmentSpends] Stage {StageIndex}: no output at index {Index}, skipping", stageIndex, stageIndex + 2);
-                continue;
-            }
+            var output = stageOutputs[stageIndex];
 
             logger.LogInformation("[ScanInvestmentSpends] Stage {StageIndex}: SpentInTransaction={SpentTxId}", stageIndex, output.SpentInTransaction ?? "null");
 
@@ -387,9 +382,7 @@ public class ProjectInvestmentsService(IProjectService projectService, INetworkC
                             // Sum the actual stage (taproot) outputs. Do not use SkipLast(1) to
                             // exclude change - there may be no change output, in which case the
                             // last output is a real stage output.
-                            var totalsats = investmentTransaction.Outputs.AsIndexedOutputs()
-                                .Where(o => o.N >= 2 && o.TxOut.ScriptPubKey.IsTaprooOutput())
-                                .Sum(o => o.TxOut.Value.Satoshi);
+                            var totalsats = stageOutputs.Sum(s => s.Balance);
                             response.AmountInRecovery = totalsats;
                             
                             logger.LogInformation("[ScanInvestmentSpends] Stage {StageIndex}: Penalty recovery, Set RecoveryTransactionId={TxId}", stageIndex, output.SpentInTransaction);

--- a/src/sdk/Angor.Sdk/Funding/Projects/ProjectInvestmentsService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/ProjectInvestmentsService.cs
@@ -304,18 +304,24 @@ public class ProjectInvestmentsService(IProjectService projectService, INetworkC
             ProjectIdentifier = project.ProjectIdentifier
         };
 
-        // For Invest projects, use Stages.Count. For Fund/Subscribe (dynamic), determine from taproot outputs.
-        // Transaction structure: index 0 = Angor fee, index 1 = OP_RETURN, index 2+ = stage outputs
-        var stageCount = project.Stages?.Count > 0
-            ? project.Stages.Count
-            : investmentTransaction.Outputs.AsIndexedOutputs()
-                .Count(o => o.TxOut.ScriptPubKey.IsTaprooOutput());
+        // Stage outputs are always the taproot outputs at index >= 2 of the actual transaction.
+        // Transaction structure: index 0 = Angor fee, index 1 = OP_RETURN, index 2+ = stage outputs.
+        // Never use project.Stages.Count here: Fund/Subscribe investments have dynamic stage counts,
+        // and never assume the last output is change (there may be no change output at all).
+        var stageCount = investmentTransaction.Outputs.AsIndexedOutputs()
+            .Count(o => o.N >= 2 && o.TxOut.ScriptPubKey.IsTaprooOutput());
 
         logger.LogInformation("[ScanInvestmentSpends] stageCount={StageCount}, projectStagesCount={ProjectStagesCount}", stageCount, project.Stages?.Count ?? 0);
 
         for (int stageIndex = 0; stageIndex < stageCount; stageIndex++)
         {
-            var output = trxInfo.Outputs.First(f => f.Index == stageIndex + 2);
+            var output = trxInfo.Outputs.FirstOrDefault(f => f.Index == stageIndex + 2);
+
+            if (output == null)
+            {
+                logger.LogWarning("[ScanInvestmentSpends] Stage {StageIndex}: no output at index {Index}, skipping", stageIndex, stageIndex + 2);
+                continue;
+            }
 
             logger.LogInformation("[ScanInvestmentSpends] Stage {StageIndex}: SpentInTransaction={SpentTxId}", stageIndex, output.SpentInTransaction ?? "null");
 
@@ -377,7 +383,13 @@ public class ProjectInvestmentsService(IProjectService projectService, INetworkC
                             }
 
                             response.RecoveryTransactionId = output.SpentInTransaction;
-                            var totalsats = trxInfo.Outputs.SkipLast(1).Sum(s => s.Balance);
+
+                            // Sum the actual stage (taproot) outputs. Do not use SkipLast(1) to
+                            // exclude change - there may be no change output, in which case the
+                            // last output is a real stage output.
+                            var totalsats = investmentTransaction.Outputs.AsIndexedOutputs()
+                                .Where(o => o.N >= 2 && o.TxOut.ScriptPubKey.IsTaprooOutput())
+                                .Sum(o => o.TxOut.Value.Satoshi);
                             response.AmountInRecovery = totalsats;
                             
                             logger.LogInformation("[ScanInvestmentSpends] Stage {StageIndex}: Penalty recovery, Set RecoveryTransactionId={TxId}", stageIndex, output.SpentInTransaction);
@@ -388,11 +400,16 @@ public class ProjectInvestmentsService(IProjectService projectService, INetworkC
                             if (spentRecoveryInfo == null)
                                 return response;
 
-                            if (spentRecoveryInfo.Outputs.SkipLast(1)
-                                .Any(_ => !string.IsNullOrEmpty(_.SpentInTransaction)))
+                            // Penalty outputs are P2WSH timelock scripts. Filter by script type
+                            // instead of SkipLast(1), which wrongly assumes a change output exists.
+                            var spentPenaltyOutput = spentRecoveryInfo.Outputs
+                                .Where(o => !string.IsNullOrEmpty(o.ScriptPubKey)
+                                            && Script.FromHex(o.ScriptPubKey).IsScriptType(ScriptType.P2WSH))
+                                .FirstOrDefault(o => !string.IsNullOrEmpty(o.SpentInTransaction));
+
+                            if (spentPenaltyOutput != null)
                             {
-                                response.RecoveryReleaseTransactionId = spentRecoveryInfo.Outputs
-                                    .First(_ => !string.IsNullOrEmpty(_.SpentInTransaction)).SpentInTransaction;
+                                response.RecoveryReleaseTransactionId = spentPenaltyOutput.SpentInTransaction;
                             }
 
                             return response;


### PR DESCRIPTION
﻿## Problem

`GetRecoveryStatus` crashes with `InvalidOperationException: Sequence contains no matching element` in `ProjectInvestmentsService.ScanInvestmentSpends`:

```
[ERR] Unhandled exception executing GetRecoveryStatusRequest
System.InvalidOperationException: Sequence contains no matching element
   at ProjectInvestmentsService.ScanInvestmentSpends(...)
```

### Root causes

1. **Stage count taken from `project.Stages.Count`** whenever stages are declared. Fund/Subscribe investments have *dynamic* stage counts per investment, so the declared stage template can be longer than the actual transaction's stage outputs. The loop then does `trxInfo.Outputs.First(f => f.Index == stageIndex + 2)` for an output that doesn't exist and throws. Worse: if the tx happened to have a change output at that index, it would *silently misinterpret change as a stage* instead of crashing.
2. **`SkipLast(1)` used to exclude change** in three places. When a transaction has no change output, `SkipLast(1)` skips a real Angor output (a stage output or a penalty output), producing wrong recovery amounts / missed release detection.

## Fixes

- `ScanInvestmentSpends`: derive stage count from the actual taproot outputs at index >= 2 of the investment transaction (0 = Angor fee, 1 = OP_RETURN); guarded `FirstOrDefault` instead of crashing `First`
- `AmountInRecovery`: sum the taproot stage outputs instead of `Outputs.SkipLast(1)`
- Recovery-release detection (`ProjectInvestmentsService` + `GetRecoveryStatus.CheckTransactionSpendingAsync`): filter penalty outputs by **P2WSH script type** instead of `SkipLast(1)`
- `GetRecoveryStatus.FindInvestments`: only count taproot outputs at index >= 2
- `CheckTransactionSpendingAsync`: replace crashing `Outputs.ElementAt(stageIndex + 2)` with guarded lookup

## Testing

- `dotnet build src/sdk/Angor.Sdk` — clean, 0 errors
- `dotnet test src/sdk/Angor.Sdk.Tests` — 333 passed, 0 failed
