### PR TITLE
perf: parallelize investment scanning with bounded concurrency

### DIFF
--- a/src/sdk/Angor.Sdk.Tests/Funding/Projects/ProjectInvestmentsServiceTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Projects/ProjectInvestmentsServiceTests.cs
@@ -7,6 +7,7 @@ using Angor.Shared;
 using Angor.Shared.Models;
 using Angor.Shared.Protocol;
 using Angor.Shared.Services;
+using Angor.Shared.Utilities;
 using NBitcoin;
 using CSharpFunctionalExtensions;
 using FluentAssertions;
@@ -437,6 +438,102 @@ public class ProjectInvestmentsServiceTests : IClassFixture<TestNetworkFixture>
 
         var itemB = marchBucket.Items.Single(i => i.InvestorPublicKey == investorKeyB);
         itemB.StageIndex.Should().Be(0, "Mar 15 is investor B's first stage (0-based index 0)");
+    }
+
+    /// <summary>
+    /// Guards the bounded-concurrency behaviour of the investment scan. Projects can have
+    /// hundreds of investors (× stages for Fund projects), so the scan must parallelize
+    /// indexer round-trips WITHOUT firing them all at once — unbounded Task.WhenAll would
+    /// mean thousands of simultaneous HTTP requests (socket exhaustion / rate limiting).
+    /// Each bounded slot may issue two concurrent requests (tx hex + tx info), so the
+    /// ceiling is 2 × MaxConcurrentIndexerRequests.
+    /// </summary>
+    [Fact]
+    public async Task ScanFullInvestments_ManyFundInvestors_LimitsConcurrentIndexerRequests()
+    {
+        // Arrange
+        const int investorCount = 30;
+        const int maxAllowedInFlight = 24; // 2 × MaxConcurrentIndexerRequests (12)
+
+        var (project, projectInfo) = CreateFundProject();
+
+        var investments = Enumerable.Range(0, investorCount)
+            .Select(_ => CreateFundInvestment(projectInfo, new DateTime(2030, 2, 1, 0, 0, 0, DateTimeKind.Utc)))
+            .ToArray();
+
+        _mockProjectService
+            .Setup(x => x.GetAsync(It.Is<ProjectId>(p => p.Value == project.Id.Value)))
+            .ReturnsAsync(Result.Success(project));
+
+        _mockAngorIndexerService
+            .Setup(x => x.GetInvestmentsAsync(project.Id.Value))
+            .ReturnsAsync(investments.Select(i => new ProjectInvestment
+            {
+                TransactionId = i.trx.GetHash().ToString(),
+                InvestorPublicKey = i.investorKey
+            }).ToList());
+
+        var inFlight = 0;
+        var maxObservedInFlight = 0;
+
+        async Task<T> TrackInFlight<T>(T value)
+        {
+            var current = Interlocked.Increment(ref inFlight);
+            int knownMax;
+            while (current > (knownMax = Volatile.Read(ref maxObservedInFlight)))
+            {
+                Interlocked.CompareExchange(ref maxObservedInFlight, current, knownMax);
+            }
+
+            await Task.Delay(20); // hold the slot long enough for overlap to be observable
+            Interlocked.Decrement(ref inFlight);
+            return value;
+        }
+
+        const string spentTxId = "spending-tx-id";
+
+        foreach (var (trx, _) in investments)
+        {
+            var txId = trx.GetHash().ToString();
+            var txHex = trx.ToHex();
+
+            _mockTransactionService
+                .Setup(x => x.GetTransactionHexByIdAsync(txId))
+                .Returns(() => TrackInFlight(txHex));
+
+            // All taproot stage outputs spent so CheckSpentFund makes an indexer call per stage
+            var queryBuilder = TestDataBuilder.CreateQueryTransaction().WithTransactionId(txId);
+            for (int i = 0; i < trx.Outputs.Count; i++)
+            {
+                if (trx.Outputs[i].ScriptPubKey.IsTaprooOutput())
+                    queryBuilder.AddOutput(i, trx.Outputs[i].Value.Satoshi, spentTxId);
+                else
+                    queryBuilder.AddOutput(i, trx.Outputs[i].Value.Satoshi);
+            }
+
+            var queryTransaction = queryBuilder.Build();
+
+            _mockTransactionService
+                .Setup(x => x.GetTransactionInfoByIdAsync(txId))
+                .Returns(() => TrackInFlight<QueryTransaction?>(queryTransaction));
+        }
+
+        var spendingTx = TestDataBuilder.CreateQueryTransaction().WithTransactionId(spentTxId).Build();
+        _mockTransactionService
+            .Setup(x => x.GetTransactionInfoByIdAsync(spentTxId))
+            .Returns(() => TrackInFlight<QueryTransaction?>(spendingTx));
+
+        // Act
+        var result = await _sut.ScanFullInvestments(project.Id.Value);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        result.Value.Sum(s => s.Items.Count).Should().Be(investorCount * 3, "every investor has 3 stages");
+
+        maxObservedInFlight.Should().BeGreaterThan(1,
+            "the scan should overlap indexer round-trips instead of awaiting them sequentially");
+        maxObservedInFlight.Should().BeLessThanOrEqualTo(maxAllowedInFlight,
+            "the scan must bound concurrent indexer requests so large projects don't exhaust sockets or trip rate limits");
     }
 
     private (Project project, ProjectInfo projectInfo) CreateFundProject()

--- a/src/sdk/Angor.Sdk/Funding/Projects/ProjectInvestmentsService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/ProjectInvestmentsService.cs
@@ -16,6 +16,37 @@ public class ProjectInvestmentsService(IProjectService projectService, INetworkC
     IAngorIndexerService angorIndexerService, IInvestorTransactionActions investorTransactionActions,
     ITransactionService transactionService, ILogger<ProjectInvestmentsService> logger) : IProjectInvestmentsService
 {
+    // Cap on concurrent indexer round-trips. Projects can have hundreds of investors
+    // (and dynamic projects multiply that by stage count), so unbounded Task.WhenAll
+    // could fire thousands of simultaneous HTTP requests — enough to exhaust sockets
+    // or trip indexer rate limits. A small degree of parallelism captures nearly all
+    // of the latency win from overlapping round-trips without that risk.
+    private const int MaxConcurrentIndexerRequests = 12;
+
+    /// <summary>
+    /// Runs the given task factories with bounded concurrency, preserving input order in the result.
+    /// </summary>
+    private static async Task<TResult[]> RunBoundedAsync<TResult>(
+        IEnumerable<Func<Task<TResult>>> taskFactories, int maxConcurrency)
+    {
+        using var semaphore = new SemaphoreSlim(maxConcurrency);
+
+        var tasks = taskFactories.Select(async factory =>
+        {
+            await semaphore.WaitAsync();
+            try
+            {
+                return await factory();
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }).ToList(); // materialize so all tasks start (queued on the semaphore) before awaiting
+
+        return await Task.WhenAll(tasks);
+    }
+
     public async Task<Result<IEnumerable<StageData>>> ScanFullInvestments(string projectId)
     {
         var project = await projectService.GetAsync(new ProjectId(projectId));
@@ -66,13 +97,14 @@ public class ProjectInvestmentsService(IProjectService projectService, INetworkC
 
         foreach (var stage in stageDataList)
         {
-            var tasks = investmentsResult.Value.Select(tuple =>
+            var taskFactories = investmentsResult.Value.Select(tuple =>
                 (output: tuple.trxInfo?.Outputs.First(outp => outp.Index == stage.StageIndex + 2)
                 ?? null,
                  transaction: tuple.trx, index: stage.StageIndex))
-                .Select(x => CheckSpentFund(x.output, x.transaction, projectInfo, x.index));
+                .Select(x => (Func<Task<Result<StageDataTrx>>>)(() =>
+                    CheckSpentFund(x.output, x.transaction, projectInfo, x.index)));
 
-            var results = await Task.WhenAll(tasks);
+            var results = await RunBoundedAsync(taskFactories, MaxConcurrentIndexerRequests);
 
             var combinedResult = results.Combine();
 
@@ -106,6 +138,14 @@ public class ProjectInvestmentsService(IProjectService projectService, INetworkC
 
         // Dictionary to group stages by their release date
         var stagesByDate = new Dictionary<DateTime, StageData>();
+
+        // Collect all stage work items first so the spent-fund checks (each an
+        // indexer round-trip) can run with bounded parallelism instead of
+        // O(funders × stages) sequential awaits — this dominated the
+        // "Syncing funding data…" time.
+        var workItems = new List<(QueryTransactionOutput qouts, Transaction trx, int stageIndex,
+            DateTime releaseDate, ProjectInvestment investment, byte patternId,
+            DateTime? investmentStartDate, decimal percentagePerStage)>();
 
         foreach (var (trx, trxInfo) in investmentsResult.Value)
         {
@@ -145,35 +185,48 @@ public class ProjectInvestmentsService(IProjectService projectService, INetworkC
                         pattern,
                         stageIndex);
 
-                var stageDataResult = await CheckSpentFund(qouts, trx, project.ToProjectInfo(), stageIndex);
+                workItems.Add((qouts, trx, stageIndex, releaseDate, investment,
+                    fundingParams.PatternId, fundingParams.InvestmentStartDate, percentagePerStage));
+            }
+        }
 
-                if (stageDataResult.IsFailure)
-                    continue;
+        var projectInfo = project.ToProjectInfo();
+        var checkResults = await RunBoundedAsync(
+            workItems.Select(w => (Func<Task<Result<StageDataTrx>>>)(() =>
+                CheckSpentFund(w.qouts, w.trx, projectInfo, w.stageIndex))),
+            MaxConcurrentIndexerRequests);
 
-                var stageDataTrx = stageDataResult.Value;
-                stageDataTrx.InvestorPublicKey = investment.InvestorPublicKey;
-                stageDataTrx.DynamicReleaseDate = releaseDate;
-                stageDataTrx.PatternId = fundingParams.PatternId;
-                stageDataTrx.InvestmentStartDate = fundingParams.InvestmentStartDate;
-                stageDataTrx.StageIndex = stageIndex;
-                stageDataTrx.AmountPercentage = percentagePerStage;
+        for (int i = 0; i < workItems.Count; i++)
+        {
+            var w = workItems[i];
+            var stageDataResult = checkResults[i];
 
-                // Group by release date - if a StageData for this date already exists, add the trx to its items
-                var releaseDateKey = releaseDate.Date; // Use date only to group by day
-                if (stagesByDate.TryGetValue(releaseDateKey, out var existingStageData))
+            if (stageDataResult.IsFailure)
+                continue;
+
+            var stageDataTrx = stageDataResult.Value;
+            stageDataTrx.InvestorPublicKey = w.investment.InvestorPublicKey;
+            stageDataTrx.DynamicReleaseDate = w.releaseDate;
+            stageDataTrx.PatternId = w.patternId;
+            stageDataTrx.InvestmentStartDate = w.investmentStartDate;
+            stageDataTrx.StageIndex = w.stageIndex;
+            stageDataTrx.AmountPercentage = w.percentagePerStage;
+
+            // Group by release date - if a StageData for this date already exists, add the trx to its items
+            var releaseDateKey = w.releaseDate.Date; // Use date only to group by day
+            if (stagesByDate.TryGetValue(releaseDateKey, out var existingStageData))
+            {
+                existingStageData.Items.Add(stageDataTrx);
+            }
+            else
+            {
+                stagesByDate[releaseDateKey] = new StageData
                 {
-                    existingStageData.Items.Add(stageDataTrx);
-                }
-                else
-                {
-                    stagesByDate[releaseDateKey] = new StageData
-                    {
-                        StageIndex = stageIndex,
-                        StageDate = releaseDate,
-                        IsDynamic = true,
-                        Items = [stageDataTrx]
-                    };
-                }
+                    StageIndex = w.stageIndex,
+                    StageDate = w.releaseDate,
+                    IsDynamic = true,
+                    Items = [stageDataTrx]
+                };
             }
         }
 
@@ -200,15 +253,18 @@ public class ProjectInvestmentsService(IProjectService projectService, INetworkC
     {
         var network = networkConfiguration.GetNetwork();
 
-        var tasks = projectInvestments.Select(async investment =>
+        var taskFactories = projectInvestments.Select(investment =>
+            (Func<Task<(Transaction trx, QueryTransaction? trxInfo)>>)(async () =>
         {
-            var hex = await transactionService.GetTransactionHexByIdAsync(investment.TransactionId);
-            var trxInfo = await transactionService.GetTransactionInfoByIdAsync(investment.TransactionId);
-            var trx = network.CreateTransaction(hex); //TODO handle null or invalid hex
-            return (trx, trxInfo);
-        });
+            // Fetch hex and info concurrently — two independent indexer round-trips.
+            var hexTask = transactionService.GetTransactionHexByIdAsync(investment.TransactionId);
+            var trxInfoTask = transactionService.GetTransactionInfoByIdAsync(investment.TransactionId);
+            await Task.WhenAll(hexTask, trxInfoTask);
+            var trx = network.CreateTransaction(hexTask.Result); //TODO handle null or invalid hex
+            return (trx, trxInfo: trxInfoTask.Result);
+        }));
 
-        var results = await Task.WhenAll(tasks);
+        var results = await RunBoundedAsync(taskFactories, MaxConcurrentIndexerRequests);
         return Result.Success<IList<(Transaction trx, QueryTransaction? trxInfo)>>(results.ToList());
     }
 


### PR DESCRIPTION
﻿Split out of #949 (per review discussion on the `ProjectInvestmentsService` change) so the scan-perf work gets focused review.

## Problem
`ScanDynamicTypeInvestments` awaited each spent-fund check sequentially — O(funders × stages) indexer round-trips dominated the "Syncing funding data…" time. But naively parallelizing with unbounded `Task.WhenAll` (as originally proposed in #949) is risky: projects can have **hundreds of investors**, and Fund projects multiply that by stage count — thousands of simultaneous HTTP requests would risk socket exhaustion and indexer rate limiting.

## Changes
- `ScanDynamicTypeInvestments`: collect all stage work items first, then run spent-fund checks in parallel with **bounded concurrency** (`RunBoundedAsync`, SemaphoreSlim capped at 12 concurrent indexer round-trips). Ordering is preserved (work-item index), so date-bucket grouping is byte-for-byte identical to the sequential version.
- `GetProjectInvestmentsTransactionsAsync`: fetch tx hex + tx info concurrently per investment; the per-investment fan-out (previously **already unbounded** `Task.WhenAll` over all investors) now also goes through the bound.
- `ScanInvestTypeInvestments`: the pre-existing unbounded per-stage `Task.WhenAll` is bounded too.

Bounded parallelism captures nearly all the latency win (it comes from overlapping round-trips, not N-way parallelism) with none of the failure risk at scale.

## Testing
- New unit test `ScanFullInvestments_ManyFundInvestors_LimitsConcurrentIndexerRequests`: 30 Fund investors × 3 stages with instrumented mocks tracking max in-flight indexer calls — asserts overlap happens (>1) and never exceeds 2 × cap (hex+info pairs share a slot).
- Existing grouping regression tests (`FundInvestorsWithShiftedSchedules`, `FundMixedBucket`) unchanged and green — confirms functional equivalence of the restructured loop.
- Full SDK suite: 334 passed, 14 skipped.

## Suggested UAT validation
`MultiFundClaimAndRecoverTest` (dynamic scan end-to-end incl. spent-type discrimination) and `MultiInvestClaimAndRecoverTest` (Invest path + FundersView).
