### PR TITLE
Improve indexer failure handling and reduce relay log noise

### DIFF
--- a/src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs
+++ b/src/design/App/UI/Shared/PaymentFlow/PaymentFlowViewModel.cs
@@ -383,7 +383,7 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "RefreshAllBalancesAsync failed");
-            ErrorMessage = "We couldn't prepare a receive address for this payment. Unlock the wallet and try again.";
+            ErrorMessage = DescribeAddressFailure(ex.Message);
             IsProcessing = false;
             _addressReadyTcs.TrySetCanceled();
             return;
@@ -398,7 +398,7 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "GetNextReceiveAddress threw");
-            ErrorMessage = "We couldn't prepare a receive address for this payment. Unlock the wallet and try again.";
+            ErrorMessage = DescribeAddressFailure(ex.Message);
             IsProcessing = false;
             _addressReadyTcs.TrySetCanceled();
             return;
@@ -406,7 +406,7 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
         if (addressResult.IsFailure)
         {
             _logger.LogError("GetNextReceiveAddress failed: {Error}", addressResult.Error);
-            ErrorMessage = "We couldn't prepare a receive address for this payment. Unlock the wallet and try again.";
+            ErrorMessage = DescribeAddressFailure(addressResult.Error);
             IsProcessing = false;
             _addressReadyTcs.TrySetCanceled();
             return;
@@ -427,6 +427,24 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
         {
             IsProcessing = false;
         }
+    }
+
+    /// <summary>
+    /// Builds a user-facing message for a failed receive-address preparation.
+    /// Distinguishes indexer/network failures (actionable: switch indexer in Settings)
+    /// from wallet issues (actionable: unlock the wallet).
+    /// </summary>
+    private static string DescribeAddressFailure(string? detail)
+    {
+        var isNetworkIssue = detail != null &&
+                             (detail.Contains("Indexer", StringComparison.OrdinalIgnoreCase) ||
+                              detail.Contains("timeout", StringComparison.OrdinalIgnoreCase) ||
+                              detail.Contains("canceled", StringComparison.OrdinalIgnoreCase) ||
+                              detail.Contains("HttpRequestException", StringComparison.OrdinalIgnoreCase));
+
+        return isNetworkIssue
+            ? $"We couldn't reach the Bitcoin indexer to prepare a receive address. Check your internet connection or select a different indexer in Settings, then try again. ({detail})"
+            : "We couldn't prepare a receive address for this payment. Unlock the wallet and try again.";
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -677,7 +695,9 @@ public partial class PaymentFlowViewModel : ReactiveObject, IDisposable
         var wallet = Wallets.FirstOrDefault();
         if (wallet?.Id is null || string.IsNullOrEmpty(OnChainAddress))
         {
-            ErrorMessage = "We couldn't start watching for your payment because the wallet wasn't ready. Please try again.";
+            // If address generation already reported a specific error (e.g. indexer
+            // unreachable), keep it — it tells the user how to fix the problem.
+            ErrorMessage ??= "We couldn't start watching for your payment because no receive address is available yet. Please try again.";
             return;
         }
 

--- a/src/sdk/Angor.Sdk/Common/NetworkConfiguration.cs
+++ b/src/sdk/Angor.Sdk/Common/NetworkConfiguration.cs
@@ -79,8 +79,6 @@ public class NetworkConfiguration : INetworkConfiguration
                 new() { Name = "wss://relay2.angor.io", Url = "wss://relay2.angor.io", IsPrimary = true },
                 new() { Name = "wss://relay.damus.io", Url = "wss://relay.damus.io", IsPrimary = true },
                 new() { Name = "wss://nos.lol", Url = "wss://nos.lol", IsPrimary = true },
-                new() { Name = "wss://nostr-01.yakihonne.com", Url = "wss://nostr-01.yakihonne.com", IsPrimary = true },
-                new() { Name = "wss://nostr-02.yakihonne.com", Url = "wss://nostr-02.yakihonne.com", IsPrimary = true },
             };
         }
 

--- a/src/shared/Angor.Shared/Services/MempoolSpaceIndexerApi.cs
+++ b/src/shared/Angor.Shared/Services/MempoolSpaceIndexerApi.cs
@@ -131,12 +131,19 @@ public class MempoolSpaceIndexerApi : IIndexerService
 
         var client = _clientFactory.CreateClient(key);
         client.BaseAddress = new Uri(indexer.Url);
-        client.Timeout = TimeSpan.FromSeconds(10);
+        // 30s rather than 10s: cold indexers (Fulcrum/electrs) can be slow to answer
+        // address queries, and the wallet gap-scan fans out many requests at once —
+        // a single slow response would otherwise fail receive-address generation.
+        client.Timeout = TimeSpan.FromSeconds(30);
 
         _clients.TryAdd(key, client);
 
+        _logger.LogInformation("Using indexer {IndexerUrl}", indexer.Url);
+
         return client;
     }
+
+    private static string IndexerHost(HttpClient client) => client.BaseAddress?.Host ?? "unknown";
 
     public async Task<string> PublishTransactionAsync(string trxHex)
     {
@@ -188,9 +195,17 @@ public class MempoolSpaceIndexerApi : IIndexerService
         var urlBalance = $"{MempoolApiRoute}/address/";
         var client = GetIndexerClient(); // Call once, reuse for all requests
 
-        var tasks = data.Select(x => client.GetAsync(urlBalance + x.Address));
-
-        var results = await Task.WhenAll(tasks);
+        HttpResponseMessage[] results;
+        try
+        {
+            var tasks = data.Select(x => client.GetAsync(urlBalance + x.Address));
+            results = await Task.WhenAll(tasks);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Address balance request to indexer {IndexerHost} failed: {Message}", IndexerHost(client), ex.Message);
+            throw new InvalidOperationException($"Indexer {IndexerHost(client)} did not respond: {ex.Message}", ex);
+        }
 
         var response = new List<AddressBalance>();
 
@@ -199,7 +214,7 @@ public class MempoolSpaceIndexerApi : IIndexerService
             _networkService.CheckAndHandleError(apiResponse);
 
             if (!apiResponse.IsSuccessStatusCode)
-                throw new InvalidOperationException(apiResponse.ReasonPhrase);
+                throw new InvalidOperationException($"Indexer {IndexerHost(client)} returned an error: {apiResponse.ReasonPhrase}");
 
             var addressResponse = await apiResponse.Content.ReadFromJsonAsync<AddressResponse>(new JsonSerializerOptions()
             { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower });
@@ -223,11 +238,21 @@ public class MempoolSpaceIndexerApi : IIndexerService
         var client = GetIndexerClient(); // Call once, reuse for all requests
         var txsUrl = $"{MempoolApiRoute}/address/{address}/txs";
 
-        var response = await client.GetAsync(txsUrl);
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.GetAsync(txsUrl);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("UTXO request to indexer {IndexerHost} failed: {Message}", IndexerHost(client), ex.Message);
+            throw new InvalidOperationException($"Indexer {IndexerHost(client)} did not respond: {ex.Message}", ex);
+        }
+
         _networkService.CheckAndHandleError(response);
 
         if (!response.IsSuccessStatusCode)
-            throw new InvalidOperationException(response.ReasonPhrase);
+            throw new InvalidOperationException($"Indexer {IndexerHost(client)} returned an error: {response.ReasonPhrase}");
 
         var trx = await response.Content.ReadFromJsonAsync<List<MempoolTransaction>>(new JsonSerializerOptions()
         { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower });

--- a/src/shared/Angor.Shared/Services/NostrCommunicationFactory.cs
+++ b/src/shared/Angor.Shared/Services/NostrCommunicationFactory.cs
@@ -77,7 +77,7 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
                 
                 var tryRemove = clientsReceivedList.TryRemove(x.CommunicatorName, out _);
                     
-                _logger.LogWarning("EOSE {x.Subscription} removed {x.CommunicatorName} - {tryRemove}",
+                _logger.LogDebug("EOSE {x.Subscription} removed {x.CommunicatorName} - {tryRemove}",
                     x.Subscription, x.CommunicatorName, tryRemove);
             }));
 
@@ -87,7 +87,7 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
                 if (_okCalledOnSubscriptionClients.TryGetValue(x.EventId ?? string.Empty, out var clientsReceivedList))
                 {
                     var tryRemove = clientsReceivedList.TryRemove(x.CommunicatorName, out _);
-                    _logger.LogWarning($"OK {x.EventId} accepted: {x.Accepted} removed ok {x.CommunicatorName} - {tryRemove}");
+                    _logger.LogDebug($"OK {x.EventId} accepted: {x.Accepted} removed ok {x.CommunicatorName} - {tryRemove}");
                 }
             }));
 
@@ -151,7 +151,7 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
                      
                 var tryRemove = clientsReceivedList.TryRemove(x.CommunicatorName, out _);
                     
-                _logger.LogWarning("EOSE {x.Subscription} removed {x.CommunicatorName} - {tryRemove}",
+                _logger.LogDebug("EOSE {x.Subscription} removed {x.CommunicatorName} - {tryRemove}",
                     x.Subscription, x.CommunicatorName, tryRemove);
             }));
             
@@ -161,7 +161,7 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
                 if (_okCalledOnSubscriptionClients.TryGetValue(x.EventId ?? string.Empty, out var clientsReceivedList))
                 {
                     var tryRemove = clientsReceivedList.TryRemove(x.CommunicatorName, out _);
-                    _logger.LogWarning($"OK {x.EventId} accepted: {x.Accepted} removed ok {x.CommunicatorName} - {tryRemove}");
+                    _logger.LogDebug($"OK {x.EventId} accepted: {x.Accepted} removed ok {x.CommunicatorName} - {tryRemove}");
                 } 
             }));
             
@@ -259,9 +259,9 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
         _serviceSubscriptions.Add(nostrCommunicator.DisconnectionHappened.Subscribe(e =>
         {
             if (e.Exception != null)
-                _logger.LogError(e.Exception,
-                    "Relay {relayName} disconnected, type: {Type}, reason: {CloseStatusDescription}", 
-                    relayName, e.Type, e.CloseStatusDescription);
+                _logger.LogWarning(
+                    "Relay {relayName} disconnected, type: {Type}, reason: {Reason}",
+                    relayName, e.Type, e.CloseStatusDescription ?? e.Exception.Message);
             else
                 _logger.LogDebug(
                     "Relay {relayName} disconnected, type: {Type}, reason: {CloseStatusDescription}", 
@@ -273,7 +273,7 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
             {
                 if (kvp.Value.TryRemove(relayName, out _))
                 {
-                    _logger.LogWarning(
+                    _logger.LogDebug(
                         "Removed disconnected relay {RelayName} from EOSE tracking for subscription {Subscription}",
                         relayName, kvp.Key);
                 }
@@ -283,7 +283,7 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
             {
                 if (kvp.Value.TryRemove(relayName, out _))
                 {
-                    _logger.LogWarning(
+                    _logger.LogDebug(
                         "Removed disconnected relay {RelayName} from OK tracking for event {EventId}",
                         relayName, kvp.Key);
                 }

--- a/src/webapp/Angor.Client/NetworkConfiguration.cs
+++ b/src/webapp/Angor.Client/NetworkConfiguration.cs
@@ -118,8 +118,6 @@ public class NetworkConfiguration : INetworkConfiguration
                 new SettingsUrl { Name = "", Url = "wss://relay2.angor.io", IsPrimary = true },
                 new SettingsUrl { Name = "", Url = "wss://relay.damus.io", IsPrimary = true },
                 new SettingsUrl { Name = "", Url = "wss://nos.lol", IsPrimary = true },
-                new SettingsUrl { Name = "", Url = "wss://nostr-01.yakihonne.com", IsPrimary = true },
-                new SettingsUrl { Name = "", Url = "wss://nostr-02.yakihonne.com", IsPrimary = true },
             };
         }
 


### PR DESCRIPTION
Follow-up to a user bug report on v0.2.34 (Fedora rpm): founder couldn't pay for project deployment — the deploy screen showed *'We couldn't start watching for your payment because the wallet wasn't ready'* and the Receive modal hung on *Loading...*. Root cause: the primary indexer was timing out (10s HttpClient timeout), so `GetNextReceiveAddress` never produced an address, and the log never said which indexer failed. The log was also flooded with relay disconnect stack traces every minute.

## Changes

### Indexer failure handling
- **Log which indexer is in use** and include the indexer host in address-balance/UTXO failure messages (`Indexer <host> did not respond: ...`) so future reports name the endpoint (`MempoolSpaceIndexerApi`).
- **Timeout 10s → 30s** for the wallet indexer client — cold Fulcrum/electrs can be slow to answer address queries and the gap-scan fans out many requests at once; one slow response failed the whole receive-address generation.
- **Clearer user-facing errors** in `PaymentFlowViewModel`: indexer/network failures now tell the user to check their connection or switch indexers in Settings (with the failure detail), instead of the misleading 'unlock the wallet' / 'wallet wasn't ready' text. The generic 'no receive address available' message no longer overwrites the real cause.

### Relay log noise
- **Removed yakihonne relays** (`nostr-01`/`nostr-02.yakihonne.com`) from the default mainnet relay lists in both the SDK and the webapp — they were returning 502s continuously. Note: existing installs keep them in saved settings; only fresh profiles get the new defaults.
- **Demoted relay disconnect logging**: a single-line warning (type + reason) instead of an error with a full stack trace fired on every reconnect attempt (once a minute per dead relay); EOSE/OK tracking messages demoted from warning to debug.

## Validation
- `Angor.Shared`, `Angor.Sdk`, `App` (design) and `Angor.Client` (webapp) all build with 0 errors.

## Not in this PR (known follow-ups)
- The deploy screen requests a hardcoded 10,000 sats while the actual creation transaction pays `AngorCreateFeeSats` (10,001) + miner fee — paying exactly the requested amount leaves the wallet short.
- Optional migration to prune yakihonne relays from existing users' saved settings.
- Optional indexer-selection popup when the indexer is unreachable (kept to a better inline error for now).