### PR TITLE
Fix intermittent infinite 'Loading project...' hang (EOSE race with never-connected relays)

### DIFF
--- a/src/shared/Angor.Shared/Services/INostrCommunicationFactory.cs
+++ b/src/shared/Angor.Shared/Services/INostrCommunicationFactory.cs
@@ -9,7 +9,7 @@ public interface INostrCommunicationFactory
     void CloseClientConnection();
     int GetNumberOfRelaysConnected();
     bool EoseEventReceivedOnAllRelays(string subscription);
-    bool MonitoringEoseReceivedOnSubscription(string subscription);
+    bool MonitoringEoseReceivedOnSubscription(string subscription, bool includeDiscoveryRelays = false);
     void ClearEoseReceivedOnSubscriptionMonitoring(string subscription);
     bool OkEventReceivedOnAllRelays(string eventId);
     void MonitoringOkReceivedOnSubscription(string eventId);

--- a/src/shared/Angor.Shared/Services/IRelaySubscriptionsHandling.cs
+++ b/src/shared/Angor.Shared/Services/IRelaySubscriptionsHandling.cs
@@ -6,7 +6,7 @@ public interface IRelaySubscriptionsHandling
 {
     bool TryAddOKAction(string eventId, Action<NostrOkResponse> action);
     void HandleOkMessages(NostrOkResponse _);
-    bool TryAddEoseAction(string subscriptionName, Action action);
+    bool TryAddEoseAction(string subscriptionName, Action action, bool includeDiscoveryRelays = false);
     void HandleEoseMessages(NostrEoseResponse _);
     bool RelaySubscriptionAdded(string subscriptionKey);
     bool TryAddRelaySubscription(string subscriptionKey, IDisposable subscription, bool keepActive = false);

--- a/src/shared/Angor.Shared/Services/NostrCommunicationFactory.cs
+++ b/src/shared/Angor.Shared/Services/NostrCommunicationFactory.cs
@@ -30,7 +30,7 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
         _okCalledOnSubscriptionClients = new();
     }
 
-    private ConcurrentDictionary<string, byte> GetAllConnectedRelayNames()
+    private ConcurrentDictionary<string, byte> GetAllConnectedRelayNames(bool includeDiscoveryRelays = false)
     {
         var allRelays = new ConcurrentDictionary<string, byte>();
 
@@ -38,17 +38,23 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
         {
             foreach (var client in _nostrMultiWebsocketClient.Clients)
             {
-                allRelays.TryAdd(client.Communicator.Name, 0);
+                // Only track relays whose websocket is actually running. A relay that never
+                // completed the WS upgrade will never send EOSE, and its DisconnectionHappened
+                // already fired before any subscription was monitored — so including it here
+                // would block the "all relays sent EOSE" completion check forever.
+                if (client.Communicator.IsRunning)
+                    allRelays.TryAdd(client.Communicator.Name, 0);
             }
         }
 
-        // if (_nostrMultiWebsocketClientDiscovery != null)
-        // {
-        //     foreach (var client in _nostrMultiWebsocketClientDiscovery.Clients)
-        //     {
-        //         allRelays.Add(client.Communicator.Name);
-        //     }
-        // }
+        if (includeDiscoveryRelays && _nostrMultiWebsocketClientDiscovery != null)
+        {
+            foreach (var client in _nostrMultiWebsocketClientDiscovery.Clients)
+            {
+                if (client.Communicator.IsRunning)
+                    allRelays.TryAdd(client.Communicator.Name, 0);
+            }
+        }
 
         return allRelays;
     }
@@ -190,10 +196,10 @@ public class NostrCommunicationFactory : IDisposable , INostrCommunicationFactor
         return response;
     }
     
-    public bool MonitoringEoseReceivedOnSubscription(string subscription)
+    public bool MonitoringEoseReceivedOnSubscription(string subscription, bool includeDiscoveryRelays = false)
     {
         _logger.LogDebug($"Started monitoring subscription {subscription}");
-        var relayNames = GetAllConnectedRelayNames();
+        var relayNames = GetAllConnectedRelayNames(includeDiscoveryRelays);
         if (_eoseCalledOnSubscriptionClients.TryAdd(subscription, relayNames))
             return true;
         

--- a/src/shared/Angor.Shared/Services/RelayService.cs
+++ b/src/shared/Angor.Shared/Services/RelayService.cs
@@ -380,12 +380,16 @@ namespace Angor.Shared.Services
         public void LookupRelayListForNPubs(Action<string, List<NostrEventTag>> onResponse, Action onEndOfStream, params string[] npubs)
         {
             var client = _communicationFactory.GetOrCreateClient(_networkService);
+            // NIP-65 relay lists (kind 10002) are published to the discovery ("purple pages") relays,
+            // so query them alongside the regular relays — the account's relay list is often only there.
+            var discoveryClient = _communicationFactory.GetOrCreateDiscoveryClients(_networkService);
 
             var subscriptionKey = Guid.NewGuid().ToString().Replace("-", "");
 
             if (!_subscriptionsHandling.RelaySubscriptionAdded(subscriptionKey))
             {
                 var subscription = client.Streams.EventStream
+                    .Merge(discoveryClient.Streams.EventStream)
                     .Where(_ => _.Subscription == subscriptionKey)
                     .Where(_ => _.Event is not null)
                     .Select(_ => _.Event)
@@ -404,14 +408,17 @@ namespace Angor.Shared.Services
 
             if (onEndOfStream != null)
             {
-                _subscriptionsHandling.TryAddEoseAction(subscriptionKey, onEndOfStream);
+                _subscriptionsHandling.TryAddEoseAction(subscriptionKey, onEndOfStream, includeDiscoveryRelays: true);
             }
 
-            client.Send(new NostrRequest(subscriptionKey, new NostrFilter
+            var request = new NostrRequest(subscriptionKey, new NostrFilter
             {
                 Authors = npubs,
                 Kinds = [NostrKind.RelayListMetadata],
-            }));
+            });
+
+            client.Send(request);
+            discoveryClient.Send(request);
         }
 
         public async Task<ProjectMetadata?> FetchProfileMetadataAsync(string nostrPubKeyHex)

--- a/src/shared/Angor.Shared/Services/RelaySubscriptionsHandling.cs
+++ b/src/shared/Angor.Shared/Services/RelaySubscriptionsHandling.cs
@@ -136,11 +136,11 @@ public class RelaySubscriptionsHandling : IDisposable, IRelaySubscriptionsHandli
         _communicationFactory.ClearOkReceivedOnSubscriptionMonitoring(okResponse.EventId);
     }
 
-    public bool TryAddEoseAction(string subscriptionName, Action action)
+    public bool TryAddEoseAction(string subscriptionName, Action action, bool includeDiscoveryRelays = false)
     {
         if (action == null) throw new ArgumentNullException(nameof(action));
 
-        var add = _communicationFactory.MonitoringEoseReceivedOnSubscription(subscriptionName);
+        var add = _communicationFactory.MonitoringEoseReceivedOnSubscription(subscriptionName, includeDiscoveryRelays);
 
         if (!add)
             _logger.LogDebug($"Subscription {subscriptionName} is already being monitored");
@@ -189,6 +189,12 @@ public class RelaySubscriptionsHandling : IDisposable, IRelaySubscriptionsHandli
         
         _communicationFactory
             .GetOrCreateClient(_networkService)
+            .Send(new NostrCloseRequest(subscriptionKey));
+
+        // Some lookups (e.g. NIP-65 relay lists) also send the REQ to the discovery relays;
+        // closing there too is harmless when the subscription was never opened on them.
+        _communicationFactory
+            .GetOrCreateDiscoveryClients(_networkService)
             .Send(new NostrCloseRequest(subscriptionKey));
        
         subscription.Dispose();

--- a/src/webapp/Angor.Client/Pages/InvestView.razor
+++ b/src/webapp/Angor.Client/Pages/InvestView.razor
@@ -55,7 +55,13 @@
         <img src="/assets/img/angor-logo.svg" alt="Angor" />
         <span>Angor Invest</span>
     </a>
-    <span class="hub-network-badge @(network.IsMainnet ? "" : "testnet")">@network.Name</span>
+    <span class="d-flex align-items-center gap-3">
+        <span class="hub-network-badge @(network.IsMainnet ? "" : "testnet")">@network.Name</span>
+        <a class="hub-link" href="/settings" title="Relay and indexer settings">
+            <Icon IconName="settings" Width="18" Height="18" />
+            <span class="d-none d-sm-inline ms-1">Settings</span>
+        </a>
+    </span>
 </header>
 
 @if (loadingProject)
@@ -63,6 +69,9 @@
     <div class="container mt-5 text-center">
         <div class="spinner-border text-success" role="status"></div>
         <p class="mt-3" style="color: var(--text-secondary);">Loading project...</p>
+        <p class="small text-muted">
+            Taking too long? Check your <a class="hub-link" href="/settings">relay and indexer settings</a>.
+        </p>
     </div>
     return;
 }
@@ -74,8 +83,9 @@
             <Icon IconName="info" Width="24" Height="24" class="me-2" />
             <span>@(loadError ?? "The project was not found.")</span>
         </div>
-        <div class="text-center mt-3">
+        <div class="text-center mt-3 d-flex justify-content-center gap-3 flex-wrap">
             <a class="hub-link" href="https://angor.io" target="_blank" rel="noopener">Browse projects on angor.io</a>
+            <a class="hub-link" href="/settings">Check relay &amp; indexer settings</a>
         </div>
     </div>
     return;
@@ -918,6 +928,7 @@
 
     private Project? project;
     private bool loadingProject = true;
+    private static readonly TimeSpan ProjectLoadTimeout = TimeSpan.FromSeconds(30);
     private string? loadError;
     private bool buildSpinner;
     private bool investSpinner;
@@ -1150,6 +1161,8 @@
     /// </summary>
     private async Task LoadRemoteProjectAsync()
     {
+        StartProjectLoadWatchdog();
+
         try
         {
             var projectIndexerData = await _IndexerService.GetProjectByIdAsync(ProjectId);
@@ -1226,6 +1239,36 @@
             loadingProject = false;
             StateHasChanged();
         }
+    }
+
+    /// <summary>
+    /// Overall timeout for the remote project load. The Nostr EOSE completion callback can be
+    /// lost when relays disconnect mid-flight (or never connect at all), which would leave the
+    /// page on the loading spinner forever — fall back to an error message instead.
+    /// </summary>
+    private void StartProjectLoadWatchdog()
+    {
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(ProjectLoadTimeout);
+
+            if (!loadingProject)
+                return;
+
+            _Logger.LogWarning("Project load timed out after {Timeout}s — relays did not complete", ProjectLoadTimeout.TotalSeconds);
+
+            await InvokeAsync(() =>
+            {
+                if (!loadingProject)
+                    return;
+
+                if (project?.ProjectInfo == null)
+                    loadError = "Could not load the project from the relays. Please check your connection and refresh the page.";
+
+                loadingProject = false;
+                StateHasChanged();
+            });
+        });
     }
 
     /// <summary>
@@ -1378,7 +1421,7 @@
                         _Logger.LogInformation("Merged {Count} relays from project profile", relays.Count);
                     }
                 },
-                null,
+                () => _Logger.LogDebug("NIP-65 relay list lookup completed (EOSE from all relays incl. discovery)"),
                 nostrPubKey);
         }
         catch (Exception ex)


### PR DESCRIPTION
## Problem
Deep-linking to /investview/{projectId} intermittently hangs forever on the loading spinner. The indexer lookup succeeds, but the Nostr metadata fetch never completes when some relays (e.g. relay.damus.io, nostr-02.yakihonne.com) fail the WebSocket upgrade.

Root cause: the EOSE tracking snapshot in NostrCommunicationFactory.GetAllConnectedRelayNames() included **all registered clients, even relays that never connected**. Such relays never send EOSE, and their DisconnectionHappened event fired during startup — before any subscription was monitored — so nothing ever removed them from the tracking set and the 'all relays sent EOSE' completion callback never fired. Timing-dependent, hence intermittent.

## Fixes
- **EOSE tracking**: only snapshot relays whose websocket is actually running (\Communicator.IsRunning\); dead relays can no longer block completion (the existing disconnect-removal re-check remains as a second safety net)
- **Load timeout**: 30s watchdog on the InvestView remote project load — the UI now falls back to an error message instead of spinning forever
- **NIP-65 via purple relays**: \LookupRelayListForNPubs\ now also queries the discovery ('purple pages') relays where relay lists are actually published, with proper EOSE tracking (\includeDiscoveryRelays\) and CLOSE sent on discovery relays too
- **Premature close fix**: \MergeProjectRelays\ now passes a real end-of-stream callback; previously with \
ull\ the relay-list subscription was closed on the first EOSE from *any* relay, often before results arrived
- **Settings escape hatch**: the standalone InvestView header (and the loading/error states) now link to /settings so users can fix relay/indexer configuration when loading fails

## Validation
- Angor.Shared.Tests: 155/155 passed
- Angor.Sdk.Tests: 333 passed
- UAT (CreateProjectTest, MultiFund, MultiInvest): 3/3 passed (14m29s, real signet transactions)
- WebApp.sln builds with 0 errors