### PR TITLE
Fix claim button no-op on comma-decimal locales + malformed blossom blob URL

### DIFF
--- a/src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs
+++ b/src/design/App/UI/Sections/FindProjects/InvestPageViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using App.UI.Shared.Helpers;
 using System.Threading;
 using Angor.Sdk.Common;
 using CSharpFunctionalExtensions;
@@ -184,7 +185,9 @@ public partial class InvestPageViewModel : ReactiveObject, IDisposable
 
     // ── Computed totals ──
     public string TotalAmount => ComputeTotal();
-    public string FormattedAmount => string.IsNullOrWhiteSpace(InvestmentAmount) ? "0.00000000" : $"{ParseAmount():F8}";
+    public string FormattedAmount => string.IsNullOrWhiteSpace(InvestmentAmount)
+        ? "0.00000000"
+        : ParseAmount().ToString("F8", System.Globalization.CultureInfo.InvariantCulture);
     public string AngorFeeAmount => $"{ParseAmount() * Constants.AngorFeeRate:F8} {_currencyService.Symbol}";
 
     // Vue ref: subscription shows sats in transaction details
@@ -519,10 +522,8 @@ public partial class InvestPageViewModel : ReactiveObject, IDisposable
 
     private double ParseAmount()
     {
-        if (double.TryParse(InvestmentAmount, System.Globalization.NumberStyles.Float,
-            System.Globalization.CultureInfo.InvariantCulture, out var val))
-            return val;
-        return 0;
+        // User-typed field: tolerate both ',' and '.' decimal separators.
+        return AmountParser.TryParseUserAmount(InvestmentAmount, out double val) ? val : 0;
     }
 
     private string ComputeTotal()

--- a/src/design/App/UI/Sections/Funds/SendFundsModal.axaml.cs
+++ b/src/design/App/UI/Sections/Funds/SendFundsModal.axaml.cs
@@ -268,8 +268,7 @@ public partial class SendFundsModal : UserControl, IBackdropCloseable
         if (string.IsNullOrEmpty(_walletId)) return;
 
         var address = AddressInput.Text?.Trim() ?? "";
-        if (!double.TryParse(AmountInput.Text, System.Globalization.NumberStyles.Any,
-                System.Globalization.CultureInfo.InvariantCulture, out var amount)) return;
+        if (!AmountParser.TryParseUserAmount(AmountInput.Text, out double amount)) return;
 
         // Disable send button and show spinner during operation
         var sendBtn = this.FindControl<Button>("BtnSend");
@@ -341,8 +340,7 @@ public partial class SendFundsModal : UserControl, IBackdropCloseable
         }
 
         if (string.IsNullOrWhiteSpace(AmountInput.Text) ||
-            !double.TryParse(AmountInput.Text, System.Globalization.NumberStyles.Any,
-                System.Globalization.CultureInfo.InvariantCulture, out var amount))
+            !AmountParser.TryParseUserAmount(AmountInput.Text, out double amount))
         {
             AmountError.Text = "Amount must be greater than 0";
             AmountError.IsVisible = true;

--- a/src/design/App/UI/Sections/Funds/SendFundsModalViewModel.cs
+++ b/src/design/App/UI/Sections/Funds/SendFundsModalViewModel.cs
@@ -109,7 +109,7 @@ public partial class SendFundsModalViewModel : ReactiveObject, IDisposable
         }
 
         if (string.IsNullOrWhiteSpace(AmountText) ||
-            !double.TryParse(AmountText, NumberStyles.Any, CultureInfo.InvariantCulture, out var amount))
+            !AmountParser.TryParseUserAmount(AmountText, out double amount))
         {
             AmountError = "Amount must be greater than 0";
             RaiseErrorProperties();

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
@@ -130,6 +130,31 @@ public partial class ProjectStageViewModel : ReactiveObject
 /// </summary>
 public partial class CreateProjectViewModel : ReactiveObject
 {
+    // ─────────────────────────────────────────────────────────────────
+    //  CULTURE-SAFE AMOUNT PARSING
+    //  User-typed amounts must tolerate both '.' and ',' decimal separators;
+    //  parsing must never depend on the OS culture (on comma-decimal locales
+    //  current-culture TryParse of "0.5" yields 5 or fails entirely).
+    // ─────────────────────────────────────────────────────────────────
+
+    internal static bool TryParseUserAmount(string? text, out double value)
+    {
+        value = 0;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        var normalized = text.Trim().Replace(',', '.');
+        return double.TryParse(normalized, System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture, out value);
+    }
+
+    internal static bool TryParseUserAmount(string? text, out decimal value)
+    {
+        value = 0;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        var normalized = text.Trim().Replace(',', '.');
+        return decimal.TryParse(normalized, System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture, out value);
+    }
+
     // ── Wizard navigation state ──
     [Reactive] private int currentStep = 1;
     [Reactive] private int maxStepReached = 1;
@@ -570,7 +595,7 @@ public partial class CreateProjectViewModel : ReactiveObject
                 if (ProjectType == "subscription")
                 {
                     if (string.IsNullOrWhiteSpace(SubscriptionPrice) ||
-                        !double.TryParse(SubscriptionPrice, out var subPrice) || subPrice <= 0)
+                        !TryParseUserAmount(SubscriptionPrice, out double subPrice) || subPrice <= 0)
                     {
                         FormError = "Please enter a valid subscription price";
                         TargetAmountError = "Subscription price is required";
@@ -581,7 +606,7 @@ public partial class CreateProjectViewModel : ReactiveObject
                 else if (ProjectType == "fund")
                 {
                     if (string.IsNullOrWhiteSpace(TargetAmount) ||
-                        !double.TryParse(TargetAmount, out var goalAmt) || goalAmt <= 0)
+                        !TryParseUserAmount(TargetAmount, out double goalAmt) || goalAmt <= 0)
                     {
                         FormError = "Please enter a valid goal amount";
                         TargetAmountError = "Goal amount is required";
@@ -592,7 +617,7 @@ public partial class CreateProjectViewModel : ReactiveObject
                 else // investment
                 {
                     if (string.IsNullOrWhiteSpace(TargetAmount) ||
-                        !double.TryParse(TargetAmount, out var targetAmt) || targetAmt <= 0)
+                        !TryParseUserAmount(TargetAmount, out double targetAmt) || targetAmt <= 0)
                     {
                         FormError = "Please enter a valid target amount";
                         TargetAmountError = "Target amount is required";
@@ -601,9 +626,7 @@ public partial class CreateProjectViewModel : ReactiveObject
                     }
 
                     // Production validation: target amount limits
-                    var amountResult = validator.ValidateTargetAmount((decimal)double.Parse(TargetAmount,
-                        System.Globalization.NumberStyles.Float,
-                        System.Globalization.CultureInfo.InvariantCulture));
+                    var amountResult = validator.ValidateTargetAmount((decimal)targetAmt);
                     if (!amountResult.IsValid)
                     {
                         FormError = amountResult.ErrorMessage!;
@@ -756,8 +779,7 @@ public partial class CreateProjectViewModel : ReactiveObject
     {
         // Parse target amount as BTC and convert to satoshis.
         // The UI always accepts BTC values (e.g. "1" = 1 BTC = 100_000_000 sats).
-        if (!decimal.TryParse(TargetAmount, System.Globalization.NumberStyles.Number,
-                System.Globalization.CultureInfo.InvariantCulture, out var tBtc) || tBtc <= 0)
+        if (!TryParseUserAmount(TargetAmount, out decimal tBtc) || tBtc <= 0)
             throw new InvalidOperationException(
                 $"Invalid target amount '{TargetAmount}'. Cannot deploy project without a valid target amount.");
         var targetSats = tBtc.ToUnitSatoshi();
@@ -851,8 +873,7 @@ public partial class CreateProjectViewModel : ReactiveObject
         // Invest projects have fixed stages and no approval threshold.
         long? penaltyThreshold = null;
         if (sdkProjectType == SdkProjectType.Fund &&
-            double.TryParse(ApprovalThreshold, System.Globalization.NumberStyles.Float,
-                System.Globalization.CultureInfo.InvariantCulture, out var thresholdBtc) && thresholdBtc > 0)
+            TryParseUserAmount(ApprovalThreshold, out double thresholdBtc) && thresholdBtc > 0)
         {
             penaltyThreshold = ((decimal)thresholdBtc).ToUnitSatoshi();
         }
@@ -929,7 +950,7 @@ public partial class CreateProjectViewModel : ReactiveObject
         var baseDate = InvestEndDate.HasValue
             ? InvestEndDate.Value
             : DateTime.TryParse(StartDate, out var sd) ? sd : DateTime.UtcNow;
-        var targetBtc = double.TryParse(TargetAmount, out var t) ? t : 1.0;
+        var targetBtc = TryParseUserAmount(TargetAmount, out double t) ? t : 1.0;
         var percentPerStage = 100.0 / stageCount;
 
         for (int i = 0; i < stageCount; i++)
@@ -947,7 +968,7 @@ public partial class CreateProjectViewModel : ReactiveObject
                 PercentageValue = pct,
                 ReleaseDate = FormatReleaseDateOrdinal(releaseDate),
                 ReleaseDateValue = DateOnly.FromDateTime(releaseDate),
-                AmountBtc = btcAmount.ToString("F4"),
+                AmountBtc = btcAmount.ToString("F4", System.Globalization.CultureInfo.InvariantCulture),
                 StageLabel = "Stage",
                 DisplayText = $"{pct}% ({btcAmount:F4} {_currencyService.Symbol}) released on {FormatReleaseDateOrdinal(releaseDate)}"
             });
@@ -972,10 +993,10 @@ public partial class CreateProjectViewModel : ReactiveObject
         // Vue: uses max of selected installment counts as the number of payouts
         var count = SelectedInstallmentCounts.Max();
         var baseDate = DateTime.TryParse(StartDate, out var sd) ? sd : DateTime.UtcNow;
-        var targetBtc = double.TryParse(TargetAmount, out var t) ? t : 1.0;
+        var targetBtc = TryParseUserAmount(TargetAmount, out double t) ? t : 1.0;
 
         // For subscription, use SubscriptionPrice as BTC
-        if (ProjectType == "subscription" && double.TryParse(SubscriptionPrice, out var subBtc))
+        if (ProjectType == "subscription" && TryParseUserAmount(SubscriptionPrice, out double subBtc))
             targetBtc = subBtc;
 
         var percentPerStage = 100.0 / count;
@@ -1009,7 +1030,7 @@ public partial class CreateProjectViewModel : ReactiveObject
                 PercentageValue = pct,
                 ReleaseDate = FormatReleaseDateOrdinal(releaseDate),
                 ReleaseDateValue = DateOnly.FromDateTime(releaseDate),
-                AmountBtc = (targetBtc * pct / 100).ToString("F4"),
+                AmountBtc = (targetBtc * pct / 100).ToString("F4", System.Globalization.CultureInfo.InvariantCulture),
                 StageLabel = label,
                 DisplayText = $"{pct}% paid on {FormatReleaseDateOrdinal(releaseDate)}"
             });
@@ -1334,7 +1355,7 @@ public partial class CreateProjectViewModel : ReactiveObject
 
         var baseDate = DateTime.TryParse(StartDate, out var sd) ? sd : DateTime.UtcNow;
         var percentPerStage = 100.0 / count;
-        var targetBtc = double.TryParse(TargetAmount, out var t) ? t : 1.0;
+        var targetBtc = TryParseUserAmount(TargetAmount, out double t) ? t : 1.0;
 
         for (int i = 0; i < count; i++)
         {
@@ -1354,7 +1375,7 @@ public partial class CreateProjectViewModel : ReactiveObject
                 PercentageValue = pct,
                 ReleaseDate = FormatReleaseDateOrdinal(releaseDate),
                 ReleaseDateValue = DateOnly.FromDateTime(releaseDate),
-                AmountBtc = (targetBtc * pct / 100).ToString("F4"),
+                AmountBtc = (targetBtc * pct / 100).ToString("F4", System.Globalization.CultureInfo.InvariantCulture),
                 StageLabel = label,
                 DisplayText = $"{pct}% paid on {FormatReleaseDateOrdinal(releaseDate)}"
             });
@@ -1715,7 +1736,7 @@ public partial class CreateProjectViewModel : ReactiveObject
             PercentageValue = 10,
             ReleaseDate = FormatReleaseDateOrdinal(today),
             ReleaseDateValue = DateOnly.FromDateTime(today),
-            AmountBtc = (targetBtc * 0.10).ToString("F4"),
+            AmountBtc = (targetBtc * 0.10).ToString("F4", System.Globalization.CultureInfo.InvariantCulture),
             StageLabel = "Stage",
             DisplayText = $"10% ({targetBtc * 0.10:F4} {_currencyService.Symbol}) released on {FormatReleaseDateOrdinal(today)}"
         });
@@ -1725,7 +1746,7 @@ public partial class CreateProjectViewModel : ReactiveObject
             PercentageValue = 30,
             ReleaseDate = FormatReleaseDateOrdinal(stage2Date),
             ReleaseDateValue = DateOnly.FromDateTime(stage2Date),
-            AmountBtc = (targetBtc * 0.30).ToString("F4"),
+            AmountBtc = (targetBtc * 0.30).ToString("F4", System.Globalization.CultureInfo.InvariantCulture),
             StageLabel = "Stage",
             DisplayText = $"30% ({targetBtc * 0.30:F4} {_currencyService.Symbol}) released on {FormatReleaseDateOrdinal(stage2Date)}"
         });
@@ -1735,7 +1756,7 @@ public partial class CreateProjectViewModel : ReactiveObject
             PercentageValue = 60,
             ReleaseDate = FormatReleaseDateOrdinal(stage3Date),
             ReleaseDateValue = DateOnly.FromDateTime(stage3Date),
-            AmountBtc = (targetBtc * 0.60).ToString("F4"),
+            AmountBtc = (targetBtc * 0.60).ToString("F4", System.Globalization.CultureInfo.InvariantCulture),
             StageLabel = "Stage",
             DisplayText = $"60% ({targetBtc * 0.60:F4} {_currencyService.Symbol}) released on {FormatReleaseDateOrdinal(stage3Date)}"
         });

--- a/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/CreateProjectViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using App.UI.Shared.Helpers;
 using Angor.Sdk.Funding.Projects.Dtos;
 using Angor.Sdk.Funding.Projects.Domain;
 using Angor.Shared;
@@ -137,23 +138,11 @@ public partial class CreateProjectViewModel : ReactiveObject
     //  current-culture TryParse of "0.5" yields 5 or fails entirely).
     // ─────────────────────────────────────────────────────────────────
 
-    internal static bool TryParseUserAmount(string? text, out double value)
-    {
-        value = 0;
-        if (string.IsNullOrWhiteSpace(text)) return false;
-        var normalized = text.Trim().Replace(',', '.');
-        return double.TryParse(normalized, System.Globalization.NumberStyles.Float,
-            System.Globalization.CultureInfo.InvariantCulture, out value);
-    }
+    internal static bool TryParseUserAmount(string? text, out double value) =>
+        AmountParser.TryParseUserAmount(text, out value);
 
-    internal static bool TryParseUserAmount(string? text, out decimal value)
-    {
-        value = 0;
-        if (string.IsNullOrWhiteSpace(text)) return false;
-        var normalized = text.Trim().Replace(',', '.');
-        return decimal.TryParse(normalized, System.Globalization.NumberStyles.Float,
-            System.Globalization.CultureInfo.InvariantCulture, out value);
-    }
+    internal static bool TryParseUserAmount(string? text, out decimal value) =>
+        AmountParser.TryParseUserAmount(text, out value);
 
     // ── Wizard navigation state ──
     [Reactive] private int currentStep = 1;

--- a/src/design/App/UI/Sections/MyProjects/Modals/ManageProjectModalsView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/Modals/ManageProjectModalsView.axaml.cs
@@ -443,7 +443,7 @@ public partial class ManageProjectModalsView : UserControl
     /// </summary>
     private static double ParseBtc(string? amount)
     {
-        return double.TryParse(amount, NumberStyles.Float, CultureInfo.InvariantCulture, out var v) ? v : 0;
+        return AmountParser.ParseInvariantOrZero(amount);
     }
 
     /// <summary>

--- a/src/design/App/UI/Sections/MyProjects/Modals/ManageProjectModalsView.axaml.cs
+++ b/src/design/App/UI/Sections/MyProjects/Modals/ManageProjectModalsView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using Angor.Shared.Services;
 using App.UI.Shared;
@@ -232,11 +233,11 @@ public partial class ManageProjectModalsView : UserControl
             if (stage == null) return;
 
             var selectedTxs = stage.AvailableTransactions.Where(t => t.IsSelected).ToList();
-            var selectedAmount = selectedTxs.Sum(t => double.TryParse(t.Amount, out var v) ? v : 0);
+            var selectedAmount = selectedTxs.Sum(t => ParseBtc(t.Amount));
 
             if (selectedAmount <= 0 || selectedTxs.Count == 0) return; // nothing selected
 
-            Vm.ClaimedAmount = selectedAmount.ToString("F8");
+            Vm.ClaimedAmount = selectedAmount.ToString("F8", CultureInfo.InvariantCulture);
 
             // Skip password modal — go directly to fee selection and claim.
             // NOTE: Keep claim modal visible during fee selection (#17) so user sees context.
@@ -328,9 +329,9 @@ public partial class ManageProjectModalsView : UserControl
             // Skip password modal — go directly to release.
             var totalRelease = Vm.Stages
                 .SelectMany(s => s.AvailableTransactions)
-                .Sum(t => double.TryParse(t.Amount, out var v) ? v : 0);
+                .Sum(t => ParseBtc(t.Amount));
 
-            Vm.ReleasedAmount = totalRelease.ToString("F8");
+            Vm.ReleasedAmount = totalRelease.ToString("F8", CultureInfo.InvariantCulture);
 
             Vm.IsReleasingFunds = true;
             var success = await Vm.ReleaseFundsToInvestorsAsync();
@@ -356,9 +357,9 @@ public partial class ManageProjectModalsView : UserControl
 
             var totalRelease = Vm.Stages
                 .SelectMany(s => s.AvailableTransactions)
-                .Sum(t => double.TryParse(t.Amount, out var v) ? v : 0);
+                .Sum(t => ParseBtc(t.Amount));
 
-            Vm.ReleasedAmount = totalRelease.ToString("F8");
+            Vm.ReleasedAmount = totalRelease.ToString("F8", CultureInfo.InvariantCulture);
 
             Vm.IsReleasingFunds = true;
             var confirmText = this.FindControl<TextBlock>("ConfirmReleaseText");
@@ -433,6 +434,17 @@ public partial class ManageProjectModalsView : UserControl
     // ─────────────────────────────────────────────────────────────────
     //  UTILITIES
     // ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Parses a BTC amount string that was formatted with InvariantCulture (dot decimal).
+    /// Must NOT use the current culture: on comma-decimal locales (e.g. de-DE, fr-FR)
+    /// culture-sensitive parsing of "0.05000000" fails or misparses, which made the
+    /// Claim button silently do nothing.
+    /// </summary>
+    private static double ParseBtc(string? amount)
+    {
+        return double.TryParse(amount, NumberStyles.Float, CultureInfo.InvariantCulture, out var v) ? v : 0;
+    }
 
     /// <summary>
     /// Wires a Click handler on a named Button.

--- a/src/design/App/UI/Shared/Helpers/AmountParser.cs
+++ b/src/design/App/UI/Shared/Helpers/AmountParser.cs
@@ -1,0 +1,46 @@
+using System.Globalization;
+
+namespace App.UI.Shared.Helpers;
+
+/// <summary>
+/// Culture-safe parsing of amount strings.
+///
+/// Rules (see PR #956):
+/// - Strings the app formats itself (InvariantCulture, dot decimal) must be parsed
+///   back with InvariantCulture — never the OS culture. On comma-decimal locales
+///   (de-DE, fr-FR, ...) current-culture parsing of "0.05000000" fails or misparses,
+///   which caused the founder Claim button to silently do nothing.
+/// - User-typed input must tolerate both ',' and '.' as the decimal separator.
+/// </summary>
+public static class AmountParser
+{
+    /// <summary>
+    /// Parses a user-typed amount, accepting both ',' and '.' as decimal separator.
+    /// Never throws; returns false for null/blank/invalid input.
+    /// </summary>
+    public static bool TryParseUserAmount(string? text, out double value)
+    {
+        value = 0;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        var normalized = text.Trim().Replace(',', '.');
+        return double.TryParse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+    }
+
+    /// <inheritdoc cref="TryParseUserAmount(string?, out double)"/>
+    public static bool TryParseUserAmount(string? text, out decimal value)
+    {
+        value = 0;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        var normalized = text.Trim().Replace(',', '.');
+        return decimal.TryParse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+    }
+
+    /// <summary>
+    /// Parses an app-formatted (InvariantCulture) amount string; returns 0 when invalid.
+    /// Use for round-trip strings the app formatted itself, NOT for user input.
+    /// </summary>
+    public static double ParseInvariantOrZero(string? amount)
+    {
+        return double.TryParse(amount, NumberStyles.Float, CultureInfo.InvariantCulture, out var v) ? v : 0;
+    }
+}

--- a/src/design/App/UI/Shared/Services/BlossomUploadService.cs
+++ b/src/design/App/UI/Shared/Services/BlossomUploadService.cs
@@ -93,8 +93,9 @@ public class BlossomUploadService
                 return Result.Failure<string>("Server returned an invalid response");
             }
 
-            logger.LogInformation("Blossom upload successful: {Url}", descriptor.Url);
-            return Result.Success(descriptor.Url);
+            var blobUrl = NormalizeBlobUrl(descriptor.Url, baseUrl, fileBytes);
+            logger.LogInformation("Blossom upload successful: {Url}", blobUrl);
+            return Result.Success(blobUrl);
         }
         catch (TaskCanceledException)
         {
@@ -153,6 +154,38 @@ public class BlossomUploadService
 
         var base64Event = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(eventJson));
         return $"Nostr {base64Event}";
+    }
+
+    /// <summary>
+    /// Normalizes the download URL returned by the server. Some servers return malformed
+    /// URLs (e.g. a duplicated scheme like "https://https://host/sha" observed from
+    /// blossom.angor.io), which breaks the support log-download tooling. Since the blob
+    /// is content-addressed, fall back to the canonical BUD-01 form
+    /// <c>{serverBaseUrl}/{sha256}</c> whenever the returned URL is not a valid absolute URL.
+    /// </summary>
+    private string NormalizeBlobUrl(string returnedUrl, string baseUrl, byte[] fileBytes)
+    {
+        // Strip duplicated scheme prefixes ("https://https://host/..." -> "https://host/...")
+        var url = returnedUrl;
+        while (url.StartsWith("https://https://", StringComparison.OrdinalIgnoreCase) ||
+               url.StartsWith("https://http://", StringComparison.OrdinalIgnoreCase) ||
+               url.StartsWith("http://https://", StringComparison.OrdinalIgnoreCase) ||
+               url.StartsWith("http://http://", StringComparison.OrdinalIgnoreCase))
+        {
+            url = url.Substring(url.IndexOf("://", StringComparison.Ordinal) + 3);
+        }
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+            (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+        {
+            return url;
+        }
+
+        var fileSha256 = Convert.ToHexString(SHA256.HashData(fileBytes)).ToLowerInvariant();
+        var canonical = $"{baseUrl}/{fileSha256}";
+        logger.LogWarning("Blossom server returned malformed blob URL '{Returned}'; using canonical '{Canonical}'",
+            returnedUrl, canonical);
+        return canonical;
     }
 
     private sealed class BlobDescriptorResponse


### PR DESCRIPTION
## Summary

A user reported that the founder **Claim** button did nothing on Windows. Log analysis (via the encrypted blossom log export) confirmed the click never reached `ClaimStageFundsAsync` — no fee dialog, no error, no toast.

### Root cause: culture-sensitive number parsing
UTXO amounts are formatted with `CultureInfo.InvariantCulture` (`"0.05000000"`) but were parsed back with the OS culture. On comma-decimal locales (de-DE, fr-FR, ...) `double.TryParse("0.05000000")` fails or misparses, so the selected total summed to 0 and the handler hit the silent `return` — "clicked Claim, nothing happened". Only non-English-locale Windows users were affected.

### Fixes
- **ManageProjectModalsView**: claim + both release paths now parse amounts with an invariant `ParseBtc` helper and format `ClaimedAmount`/`ReleasedAmount` invariantly.
- **CreateProjectViewModel** (found in a repo-wide audit): `TargetAmount`, `SubscriptionPrice`, `ApprovalThreshold` had the same round-trip mismatch (presets like `"0.5"` parse as **5** on de-DE; a user typing `0,5` passed validation but threw at deploy). Added `TryParseUserAmount` — trims, accepts both `,` and `.`, parses invariantly — and made all stage `F4` formatting invariant.
- **BlossomUploadService**: the server returned a malformed descriptor URL (`https://https://blossom.angor.io/<sha>`), which broke the support log-download tooling. The client now normalizes the returned URL and falls back to the canonical BUD-01 `{server}/{sha256}` form.

Convention going forward: internally round-tripped amount strings are invariant on both sides (BTC amounts use dot decimal in all locales); user-typed input is parsed tolerantly.

Audit note: `src/sdk` and `src/shared` are clean; remaining user-input fields (Invest amount, Send funds) parse invariantly and accept `.` only — candidates for the tolerant helper in a follow-up.

## Testing
- `dotnet build src/design/App/App.csproj` — 0 errors
- LayoutRegression suite: 146/146 passed
