### PR TITLE
Don't let an unacknowledged NIP-65 list block project deployment

### DIFF
--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/CreateProjectProfileTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/CreateProjectProfileTests.cs
@@ -189,6 +189,58 @@ public class CreateProjectProfileTests
     }
 
     [Fact]
+    public async Task Handle_WhenNip65AckNeverArrives_ReturnsSuccessWithProfileEventId()
+    {
+        // Arrange
+        // Reproduces an unreachable discovery relay: PublishNip65List is invoked but no OK
+        // callback ever fires. The profile itself was already stored, so deployment must proceed.
+        var request = CreateValidRequest();
+        SetupSeedwords();
+        SetupDerivation();
+
+        var sut = new CreateProjectProfile.CreateProjectProfileHandler(
+            _mockSeedwordsProvider.Object,
+            _mockDerivationOperations.Object,
+            _mockAngorIndexerService.Object,
+            _mockRelayService.Object,
+            _mockDerivedProjectKeysCollection.Object,
+            _mockLogger.Object,
+            TimeSpan.FromMilliseconds(200));
+
+        _mockRelayService
+            .Setup(x => x.CreateNostrProfileAsync(
+                It.IsAny<Nostr.Client.Messages.Metadata.NostrMetadata>(),
+                It.IsAny<string>(),
+                It.IsAny<Action<NostrOkResponse>>()))
+            .Returns<Nostr.Client.Messages.Metadata.NostrMetadata, string, Action<NostrOkResponse>>(
+                (metadata, key, callback) =>
+                {
+                    callback(new NostrOkResponse
+                    {
+                        Accepted = true,
+                        EventId = "profile-event-id"
+                    });
+                    return Task.FromResult("profile-event-id");
+                });
+
+        _mockRelayService
+            .Setup(x => x.PublishNip65List(
+                It.IsAny<string>(),
+                It.IsAny<Action<NostrOkResponse>>()))
+            .Returns<string, Action<NostrOkResponse>>((key, callback) => "nip65-event-id");
+
+        // Act
+        var result = await sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.EventId.Should().Be("profile-event-id");
+        _mockRelayService.Verify(
+            x => x.PublishNip65List(It.IsAny<string>(), It.IsAny<Action<NostrOkResponse>>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task Handle_WhenSuccessful_DeriveNostrKeyFromFounderKey()
     {
         // Arrange

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectProfile.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProjectProfile.cs
@@ -33,9 +33,20 @@ public static class CreateProjectProfile
                 IAngorIndexerService angorIndexerService,
                 IRelayService relayService,
                 IGenericDocumentCollection<DerivedProjectKeys> derivedProjectKeysCollection,
-                ILogger<CreateProjectProfileHandler> logger) 
+                ILogger<CreateProjectProfileHandler> logger,
+                TimeSpan? nip65AckTimeout = null) 
         : IRequestHandler<CreateProjectProfileRequest, Result<CreateProjectProfileResponse>>
     {
+        /// <summary>
+        /// How long to wait for the NIP-65 relay list to be acknowledged before continuing.
+        /// NIP-65 is published to the discovery relays, which are a different (and smaller) set
+        /// than the relays that store the profile itself. If every discovery relay is unreachable
+        /// no OK ever arrives, so this wait is bounded to keep an outage there from blocking deployment.
+        /// </summary>
+        private static readonly TimeSpan DefaultNip65AckTimeout = TimeSpan.FromSeconds(10);
+
+        private TimeSpan Nip65AckTimeout { get; } = nip65AckTimeout ?? DefaultNip65AckTimeout;
+
         public async Task<Result<CreateProjectProfileResponse>> Handle(CreateProjectProfileRequest request, CancellationToken cancellationToken)
         {
             var wallet = await seedwordsProvider.GetSensitiveData(request.WalletId.Value);
@@ -82,38 +93,61 @@ public static class CreateProjectProfile
             };
 
             var nip65Published = 0;
+            CancellationTokenSource? nip65AckCts = null;
 
-            var resultId = await relayService.CreateNostrProfileAsync(
-                nostrMetadata,
-                nostrKey,
-                okResponse =>
-                  {
-                      if (!okResponse.Accepted)
+            try
+            {
+                var resultId = await relayService.CreateNostrProfileAsync(
+                    nostrMetadata,
+                    nostrKey,
+                    okResponse =>
                       {
-                          logger.LogDebug("Failed to store the project profile on relay for Project {ProjectName}: Communicator {CommunicatorName} - {Message}", project.ProjectName, okResponse.CommunicatorName, okResponse.Message);
-                          tcs.TrySetResult(Result.Failure<string>($"Failed to store the project profile on the relay: {okResponse.CommunicatorName} - {okResponse.Message}"));
-                          return;
-                      }
+                          if (!okResponse.Accepted)
+                          {
+                              logger.LogDebug("Failed to store the project profile on relay for Project {ProjectName}: Communicator {CommunicatorName} - {Message}", project.ProjectName, okResponse.CommunicatorName, okResponse.Message);
+                              tcs.TrySetResult(Result.Failure<string>($"Failed to store the project profile on the relay: {okResponse.CommunicatorName} - {okResponse.Message}"));
+                              return;
+                          }
 
-                      // The OK callback fires once per relay. Only publish NIP-65 once.
-                      if (Interlocked.CompareExchange(ref nip65Published, 1, 0) != 0)
-                          return;
+                          // The OK callback fires once per relay. Only publish NIP-65 once.
+                          if (Interlocked.CompareExchange(ref nip65Published, 1, 0) != 0)
+                              return;
 
-                      relayService.PublishNip65List(nostrKey, nip65OkResponse =>
-                      {
-                         if (tcs.Task.IsCompleted)
-                             return;
+                          // The profile is already stored at this point. NIP-65 is auxiliary discovery
+                          // metadata, so a discovery relay that never answers must not stall the deploy.
+                          nip65AckCts = new CancellationTokenSource(Nip65AckTimeout);
+                          nip65AckCts.Token.Register(() =>
+                          {
+                              if (tcs.Task.IsCompleted)
+                                  return;
 
-                         if (!nip65OkResponse.Accepted)
-                             logger.LogDebug("Failed to publish NIP-65 list for Project {ProjectName}", project.ProjectName);
+                              logger.LogWarning(
+                                  "NIP-65 list was not acknowledged within {Timeout}s for Project {ProjectName}; continuing because the project profile was stored successfully.",
+                                  Nip65AckTimeout.TotalSeconds, project.ProjectName);
 
-                         tcs.TrySetResult(!nip65OkResponse.Accepted ?
-                                    Result.Failure<string>("Failed to publish NIP-65 list")
-                                  : Result.Success(okResponse.EventId!));
-                      });
-              });
+                              tcs.TrySetResult(Result.Success(okResponse.EventId!));
+                          });
 
-            return await tcs.Task;
+                          relayService.PublishNip65List(nostrKey, nip65OkResponse =>
+                          {
+                             if (tcs.Task.IsCompleted)
+                                 return;
+
+                             if (!nip65OkResponse.Accepted)
+                                 logger.LogDebug("Failed to publish NIP-65 list for Project {ProjectName}", project.ProjectName);
+
+                             tcs.TrySetResult(!nip65OkResponse.Accepted ?
+                                        Result.Failure<string>("Failed to publish NIP-65 list")
+                                      : Result.Success(okResponse.EventId!));
+                          });
+                  });
+
+                return await tcs.Task;
+            }
+            finally
+            {
+                nip65AckCts?.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`CreateProjectProfile` resolved its `TaskCompletionSource` **only** from inside the NIP-65 `OK` callback:

```csharp
relayService.PublishNip65List(nostrKey, nip65OkResponse =>
{
    ...
    tcs.TrySetResult(...);   // the only path that completes the operation
});
```

NIP-65 is published to the **discovery relays** (`RelayService.PublishNip65List` → `GetOrCreateDiscoveryClients`), which are a separate and smaller set than the relays that store the profile itself:

```csharp
public List<SettingsUrl> GetDiscoveryRelays() => new()
{
    new SettingsUrl { Url = "wss://purplerelay.com" },
    new SettingsUrl { Url = "wss://discovery.eu.nostria.app" },
};
```

If none of those relays answer, no `OK` ever arrives, nothing completes the TCS, and the operation stalls until the 30s timeout and fails the whole deploy — even though the project profile was already stored successfully on the main relays.

Observed during a UAT run, with `discovery.eu.nostria.app` returning HTTP 502:

```
[WRN] Relay wss://discovery.eu.nostria.app disconnected ... status code '502' when status code '101' was expected.
[ERR] Deploy: create project profile failed: Nostr profile creation timed out after 30s
```

Deploy then aborts at step 2 of `RunDeployStepsAsync`, surfacing *"We could not publish the project profile to the Nostr relays"* to the user.

## Fix

Bound the wait for the NIP-65 acknowledgement. If it doesn't arrive in time, log a warning and return the profile event id, since NIP-65 is auxiliary discovery metadata rather than a prerequisite for a deployed project.

An explicit NIP-65 **rejection** is still treated as a failure, so existing behaviour is unchanged — only the "no response at all" case is newly handled.

The timeout is an optional constructor parameter (default 10s) so it can be driven from tests; DI supplies the default.

## Scope / honest framing

This is **robustness hardening for a relay outage**, not a fix for a bug in our own publish logic. Worth being explicit about what was and wasn't verified:

- The defect is verifiable by inspection and reproduced by the new unit test: on the old code the "no ack" case can only ever end in the 30s timeout.
- I could **not** demonstrate this change flipping the UAT suite from red to green. During re-runs the NIP-65 ack started arriving again (`purplerelay.com` had recovered; `nostria` is still 502), so the new grace path never actually executed — `NIP-65 list was not acknowledged` appears 0 times in those logs. The most likely explanation for the original failure is that *both* discovery relays were unavailable at that moment, but I can't prove that retroactively.

So: this removes a real single-point-of-failure, but it should not be read as the cause of any particular UAT run failing.

## Testing

- `Angor.Sdk.Tests`: **335 passed, 0 failed** (14 pre-existing skips)
- `Angor.Shared.Tests`: **155 passed, 0 failed**
- All 5 pre-existing `CreateProjectProfileTests` still pass, including `Handle_WhenNip65ListFails_ReturnsFailure`
- New test `Handle_WhenNip65AckNeverArrives_ReturnsSuccessWithProfileEventId` completes in ~200ms instead of hanging
- UAT `CreateProjectTest.FullCreateAndEditProjectFlow` passes

Two other UAT tests still fail, for reasons unrelated to this change and not addressed here: `MultiFund` on signet confirmation lag (`Investment did not become active in time`) and `MultiInvest` on `Button 'RefreshButton' not found/visible within timeout`. The latter may be a genuine UI bug worth a separate look.
