### PR TITLE
fix: dust change output and sat/vB fee units in project deploy

### DIFF
--- a/src/design/App/UI/Sections/MyProjects/Deploy/DeployFlowViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/Deploy/DeployFlowViewModel.cs
@@ -6,6 +6,7 @@ using Angor.Sdk.Funding.Founder;
 using Angor.Sdk.Funding.Founder.Operations;
 using Angor.Sdk.Funding.Projects;
 using Angor.Sdk.Funding.Projects.Dtos;
+using Angor.Sdk.Funding.Shared;
 using Angor.Sdk.Wallet.Application;
 using Angor.Sdk.Funding.Investor;
 using Angor.Sdk.Wallet.Domain;
@@ -243,11 +244,11 @@ public partial class DeployFlowViewModel : ReactiveObject
 
         // Step 4: Create blockchain transaction
         var txResult = await _projectAppService.CreateProject(
-            walletId, SelectedFeeRate, ProjectData, infoResult.Value.EventId, projectSeed);
+            walletId, new DomainFeerate(SelectedFeeRate), ProjectData, infoResult.Value.EventId, projectSeed);
         if (txResult.IsFailure)
         {
             _logger.LogError("Deploy: create blockchain transaction failed: {Error}", txResult.Error);
-            return Result.Failure("We could not prepare the on-chain deployment transaction. Check your wallet balance, fee rate, and spendable funds, then try again.");
+            return Result.Failure(DescribePrepareFailure(txResult.Error));
         }
 
         // Step 5: Publish to blockchain
@@ -256,10 +257,51 @@ public partial class DeployFlowViewModel : ReactiveObject
         if (publishResult.IsFailure)
         {
             _logger.LogError("Deploy: publish transaction failed: {Error}", publishResult.Error);
-            return Result.Failure("The deployment transaction was prepared, but the network rejected the broadcast. Please try again in a moment.");
+            return Result.Failure(DescribeBroadcastFailure(publishResult.Error));
         }
 
         return Result.Success();
+    }
+
+    /// <summary>Turn a raw transaction-build failure into something the user can act on.</summary>
+    private static string DescribePrepareFailure(string? error)
+    {
+        if (!string.IsNullOrEmpty(error) &&
+            error.Contains("not enough funds", StringComparison.OrdinalIgnoreCase))
+        {
+            return "There aren't enough spendable funds to cover the deployment amount plus the network fee. Add a little more to the wallet or lower the fee rate, then try again.";
+        }
+
+        return "We could not prepare the on-chain deployment transaction. Check your wallet balance, fee rate, and spendable funds, then try again.";
+    }
+
+    /// <summary>Turn a raw broadcast rejection into something the user can act on.
+    /// The node's reason arrives from the indexer as e.g.
+    /// {"error":"sendrawtransaction RPC error: {\"code\":-26,\"message\":\"dust\"}"}</summary>
+    private static string DescribeBroadcastFailure(string? error)
+    {
+        if (!string.IsNullOrEmpty(error))
+        {
+            if (error.Contains("dust", StringComparison.OrdinalIgnoreCase))
+            {
+                return "The network rejected the deployment because the leftover change would be too small to spend. Add a little more to the wallet or lower the fee rate, then try again.";
+            }
+
+            if (error.Contains("min relay fee not met", StringComparison.OrdinalIgnoreCase) ||
+                error.Contains("fee-too-low", StringComparison.OrdinalIgnoreCase) ||
+                error.Contains("insufficient fee", StringComparison.OrdinalIgnoreCase))
+            {
+                return "The network rejected the deployment because the fee was too low. Choose a higher fee rate and try again.";
+            }
+
+            if (error.Contains("missingorspent", StringComparison.OrdinalIgnoreCase) ||
+                error.Contains("txn-mempool-conflict", StringComparison.OrdinalIgnoreCase))
+            {
+                return "The coins used for this deployment have already been spent by another pending transaction. Wait for it to confirm, then try again.";
+            }
+        }
+
+        return "The deployment transaction was prepared, but the network rejected the broadcast. Please try again in a moment.";
     }
 
     /// <summary>Close the overlay without completing.
@@ -361,12 +403,12 @@ public partial class DeployFlowViewModel : ReactiveObject
 
             // Step 4: Create blockchain transaction
             DeployStatusText = "Building transaction...";
-            var txResult = await _projectAppService.CreateProject(walletId, SelectedFeeRate, ProjectData, infoEventId, projectSeed);
+            var txResult = await _projectAppService.CreateProject(walletId, new DomainFeerate(SelectedFeeRate), ProjectData, infoEventId, projectSeed);
             if (txResult.IsFailure)
             {
                 _logger.LogError("Deploy: create blockchain transaction failed: {Error}", txResult.Error);
                 DeployStatusText = "Couldn't prepare the transaction.";
-                DeployErrorMessage = "We could not prepare the on-chain deployment transaction. Check your wallet balance, fee rate, and spendable funds, then try again.";
+                DeployErrorMessage = DescribePrepareFailure(txResult.Error);
                 IsDeploying = false;
                 return;
             }
@@ -381,7 +423,7 @@ public partial class DeployFlowViewModel : ReactiveObject
             {
                 _logger.LogError("Deploy: publish transaction failed: {Error}", publishResult.Error);
                 DeployStatusText = "Couldn't broadcast the transaction.";
-                DeployErrorMessage = "The deployment transaction was prepared, but the network rejected the broadcast. Please try again in a moment.";
+                DeployErrorMessage = DescribeBroadcastFailure(publishResult.Error);
                 IsDeploying = false;
                 return;
             }
@@ -495,12 +537,12 @@ public partial class DeployFlowViewModel : ReactiveObject
 
             // Step 4: Create blockchain transaction
             DeployStatusText = "Building transaction...";
-            var txResult = await _projectAppService.CreateProject(walletId, SelectedFeeRate, ProjectData, infoEventId, projectSeed);
+            var txResult = await _projectAppService.CreateProject(walletId, new DomainFeerate(SelectedFeeRate), ProjectData, infoEventId, projectSeed);
             if (txResult.IsFailure)
             {
                 _logger.LogError("Deploy: create blockchain transaction failed: {Error}", txResult.Error);
                 DeployStatusText = "Couldn't prepare the transaction.";
-                DeployErrorMessage = "We could not prepare the on-chain deployment transaction. Check your wallet balance, fee rate, and spendable funds, then try again.";
+                DeployErrorMessage = DescribePrepareFailure(txResult.Error);
                 IsDeploying = false;
                 return;
             }
@@ -513,7 +555,7 @@ public partial class DeployFlowViewModel : ReactiveObject
             {
                 _logger.LogError("Deploy: publish transaction failed: {Error}", publishResult.Error);
                 DeployStatusText = "Couldn't broadcast the transaction.";
-                DeployErrorMessage = "The deployment transaction was prepared, but the network rejected the broadcast. Please try again in a moment.";
+                DeployErrorMessage = DescribeBroadcastFailure(publishResult.Error);
                 IsDeploying = false;
                 return;
             }

--- a/src/sdk/Angor.Sdk.Tests/Funding/Founder/CreateProjectTests.cs
+++ b/src/sdk/Angor.Sdk.Tests/Funding/Founder/CreateProjectTests.cs
@@ -53,7 +53,7 @@ public class CreateProjectTests
         // Arrange
         var request = new CreateProjectConstants.CreateProject.CreateProjectRequest(
             new WalletId("wallet-1"),
-            10,
+            new DomainFeerate(10),
             CreateProjectDto(),
             "event-123",
             null!);
@@ -137,11 +137,37 @@ public class CreateProjectTests
         result.Value.TransactionDraft.TransactionId.Should().NotBeNullOrEmpty();
     }
 
+    [Fact]
+    public async Task Handle_WhenSuccessful_PassesFeeRateToWalletOperationsInSatsPerKilobyte()
+    {
+        // Arrange — DomainFeerate carries sat/vByte; IWalletOperations consumes sat/kB.
+        // Passing the raw sat/vByte value made every deploy transaction pay ~1 sat/vB,
+        // which left a sub-dust change output and got the broadcast rejected with "dust".
+        var request = new CreateProjectConstants.CreateProject.CreateProjectRequest(
+            new WalletId("wallet-1"),
+            new DomainFeerate(20),
+            CreateProjectDto(),
+            "event-123",
+            new ProjectSeedDto("founder-key", "recovery-key", "nostr-pub-key", "project-id"));
+        SetupSuccessfulFlow();
+
+        // Act
+        var result = await _sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _mockWalletOperations.Verify(
+            x => x.AddInputsAndSignTransaction(
+                It.IsAny<string>(), It.IsAny<Transaction>(), It.IsAny<WalletWords>(),
+                It.IsAny<AccountInfo>(), 20_000),
+            Times.Once);
+    }
+
     private static CreateProjectConstants.CreateProject.CreateProjectRequest CreateValidRequest()
     {
         return new CreateProjectConstants.CreateProject.CreateProjectRequest(
             new WalletId("wallet-1"),
-            10,
+            new DomainFeerate(10),
             CreateProjectDto(),
             "event-123",
             new ProjectSeedDto("founder-key", "recovery-key", "nostr-pub-key", "project-id"));

--- a/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProject.cs
+++ b/src/sdk/Angor.Sdk/Funding/Founder/Operations/CreateProject.cs
@@ -23,7 +23,7 @@ public static class CreateProjectConstants
         /// </summary>
         public record CreateProjectRequest(
                 WalletId WalletId,
-                long SelectedFeeRate,
+                DomainFeerate SelectedFeeRate,
                 CreateProjectDto Project,
                 string ProjectInfoEventId,
                 ProjectSeedDto ProjectSeedDto) // Event ID from CreateProjectInfo
@@ -56,7 +56,8 @@ public static class CreateProjectConstants
                 var transactionInfo = await CreateProjectTransaction(
                       request.WalletId,
                       wallet.Value.ToWalletWords(),
-                      request.SelectedFeeRate,
+                      // IWalletOperations consumes fee rates in sat/kB; DomainFeerate carries sat/vByte.
+                      request.SelectedFeeRate.SatsPerKilobyte,
                       newProjectKeys.FounderKey,
                       newProjectKeys.ProjectIdentifier,
                       request.ProjectInfoEventId);
@@ -97,7 +98,7 @@ public static class CreateProjectConstants
             private async Task<Result<TransactionInfo>> CreateProjectTransaction(
                     WalletId walletId,
                     WalletWords words,
-                    long selectedFee,
+                    long feeRateSatsPerKb,
                     string founderKey,
                     string projectIdentifier,
                     string projectInfoEventId)
@@ -124,7 +125,7 @@ public static class CreateProjectConstants
                         unsignedTransaction,
                         words,
                         accountInfo,
-                        selectedFee);
+                        feeRateSatsPerKb);
 
                 return Result.Success(signedTransaction);
             }

--- a/src/sdk/Angor.Sdk/Funding/Projects/IProjectAppService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/IProjectAppService.cs
@@ -22,7 +22,7 @@ public interface IProjectAppService
     Task<Result<ScanFounderProjects.ScanFounderProjectsResponse>> ScanFounderProjects(WalletId walletId);
     Task<Result<CreateProjectProfileResponse>> CreateProjectProfile(WalletId walletId, ProjectSeedDto projectSeedDto, CreateProjectDto project);
     Task<Result<CreateProjectInfoResponse>> CreateProjectInfo(WalletId walletId, CreateProjectDto project, ProjectSeedDto projectSeedDto);
-    Task<Result<CreateProjectResponse>> CreateProject(WalletId walletId, long selectedFee, CreateProjectDto project, string projectInfoEventId, ProjectSeedDto projectSeedDto);
+    Task<Result<CreateProjectResponse>> CreateProject(WalletId walletId, DomainFeerate selectedFee, CreateProjectDto project, string projectInfoEventId, ProjectSeedDto projectSeedDto);
     Task<Result<ProjectStatisticsDto>> GetProjectStatistics(ProjectId projectId);
 
     /// <summary>

--- a/src/sdk/Angor.Sdk/Funding/Projects/ProjectAppService.cs
+++ b/src/sdk/Angor.Sdk/Funding/Projects/ProjectAppService.cs
@@ -46,7 +46,7 @@ public class ProjectAppService(
         return mediator.Send(new CreateProjectInfoRequest(walletId, project, projectSeedDto));
     }
 
-    public Task<Result<CreateProjectResponse>> CreateProject(WalletId walletId, long selectedFee, CreateProjectDto project, string projectInfoEventId, ProjectSeedDto projectSeedDto)
+    public Task<Result<CreateProjectResponse>> CreateProject(WalletId walletId, DomainFeerate selectedFee, CreateProjectDto project, string projectInfoEventId, ProjectSeedDto projectSeedDto)
     {
         return mediator.Send(new CreateProjectRequest(walletId, selectedFee, project, projectInfoEventId, projectSeedDto));
     }

--- a/src/shared/Angor.Shared.Tests/WalletOperationsTest.cs
+++ b/src/shared/Angor.Shared.Tests/WalletOperationsTest.cs
@@ -80,6 +80,43 @@ public class WalletOperationsTest : AngorTestData
         _sut.UpdateAccountInfoWithNewAddressesAsync(accountInfo).Wait();
     }
 
+    [Fact]
+    public void AddInputsAndSignTransaction_WhenChangeWouldBeDust_AddsItToTheFeeInsteadOfCreatingAnOutput()
+    {
+        // Regression: a project-deployment transaction funded with barely more than the
+        // Angor create fee left a ~200 sat change output, which relay nodes reject with
+        // "sendrawtransaction RPC error: {code:-26, message:dust}".
+        var words = new WalletWords { Words = "sorry poet adapt sister barely loud praise spray option oxygen hero surround" };
+
+        AccountInfo accountInfo = _sut.BuildAccountInfoForWalletWords(words);
+
+        const long utxoValue = 10348;
+        const long angorCreateFee = 10001;
+        AddCoins(accountInfo, 1, utxoValue);
+
+        var network = _networkConfiguration.Object.GetNetwork();
+        var projectTransaction = network.CreateTransaction();
+        projectTransaction.Outputs.Add(new TxOut(Money.Satoshis(angorCreateFee),
+            BitcoinAddress.Create(accountInfo.GetNextReceiveAddress()!, network.BitcoinNetwork).ScriptPubKey));
+        projectTransaction.Outputs.Add(new TxOut(Money.Zero, TxNullDataTemplate.Instance.GenerateScriptPubKey(new byte[32])));
+
+        // 1000 sat/kB == 1 sat/vByte, the protocol minimum
+        var result = _sut.AddInputsAndSignTransaction(
+            accountInfo.GetNextChangeReceiveAddress()!, projectTransaction, words, accountInfo, 1000);
+
+        var spendableOutputs = result.Transaction.Outputs
+            .Where(o => !o.ScriptPubKey.IsUnspendable)
+            .ToList();
+
+        Assert.All(spendableOutputs,
+            o => Assert.True(o.Value.Satoshi > ProtocolConstants.DustThresholdSats,
+                $"Output of {o.Value.Satoshi} sats is at or below the dust threshold of {ProtocolConstants.DustThresholdSats}"));
+
+        // The dust change went to the miner, so the whole UTXO is consumed by fee + outputs.
+        Assert.Equal(utxoValue - angorCreateFee, result.TransactionFee);
+        Assert.Single(spendableOutputs);
+    }
+
     private string GenerateScriptHex(string address, AngorNetwork network)
     {
         try

--- a/src/shared/Angor.Shared/WalletOperations.cs
+++ b/src/shared/Angor.Shared/WalletOperations.cs
@@ -94,46 +94,110 @@ public class WalletOperations : IWalletOperations
         }
         else
         {
-            var builder = network.BitcoinNetwork.CreateTransactionBuilder()
-                .AddCoins(signingCoins.Select(sc => sc.Coin))
-                .AddKeys(signingCoins.Select(sc => sc.Key).ToArray())
-                .SetChange(BitcoinAddress.Create(changeAddress, network.BitcoinNetwork))
-                .SendEstimatedFees(new FeeRate(Money.Satoshis(feeRate)));
+            var outputsTotal = transaction.Outputs.Sum(o => o.Value.Satoshi);
 
-            builder.ShuffleOutputs = false;
-            builder.DustPrevention = false;
-
-            foreach (var output in transaction.Outputs)
+            TransactionBuilder NewBuilder(List<SigningCoin> coins)
             {
-                builder.Send(output.ScriptPubKey, output.Value);
+                var b = network.BitcoinNetwork.CreateTransactionBuilder()
+                    .AddCoins(coins.Select(sc => sc.Coin))
+                    .AddKeys(coins.Select(sc => sc.Key).ToArray())
+                    .SetChange(BitcoinAddress.Create(changeAddress, network.BitcoinNetwork));
+
+                b.ShuffleOutputs = false;
+                // Dust prevention is off because the OP_RETURN output carries Money.Zero and
+                // NBitcoin would drop it. Sub-dust change is handled explicitly below instead.
+                b.DustPrevention = false;
+
+                foreach (var output in transaction.Outputs)
+                {
+                    b.Send(output.ScriptPubKey, output.Value);
+                }
+
+                return b;
             }
 
+            long SumInputs(Transaction tx, List<SigningCoin> coins) =>
+                tx.Inputs.Sum(input =>
+                    coins.First(sc => sc.Coin.Outpoint.ToString() == input.PrevOut.ToString()).Coin.Amount.Satoshi);
 
-            var signTransaction = builder.BuildTransaction(true);
+            // FindOutputsForTransaction above only selects enough to cover the outputs, leaving
+            // nothing for the miner fee and often producing a sub-dust change output that relay
+            // nodes reject with "dust". Size the fee, then re-select coins to cover
+            // outputs + fee (+ dust headroom). Extra inputs grow the tx, so iterate.
+            const int maxAttempts = 5;
 
-            // find the coins used
-            long totaInInputs = 0;
-            long totaInOutputs = signTransaction.Outputs.Select(s => s.Value.Satoshi).Sum();
-
-            foreach (var input in signTransaction.Inputs)
+            for (var attempt = 0; ; attempt++)
             {
-                var foundInput = signingCoins.First(sc => sc.Coin.Outpoint.ToString() == input.PrevOut.ToString());
+                // Pass 1: estimate the fee from a fully built (and therefore correctly sized) tx.
+                var sizingBuilder = NewBuilder(signingCoins);
+                sizingBuilder.SendEstimatedFees(new FeeRate(Money.Satoshis(feeRate)));
+                var sizingTransaction = sizingBuilder.BuildTransaction(true);
 
-                totaInInputs += foundInput.Coin.Amount.Satoshi;
+                var txSize = sizingTransaction.GetVirtualSize();
+                var minimumFee = new FeeRate(Money.Satoshis(ProtocolConstants.MinFeeRateSatsPerKb)).GetFee(txSize).Satoshi;
+                var estimatedFee = SumInputs(sizingTransaction, signingCoins)
+                                   - sizingTransaction.Outputs.Sum(o => o.Value.Satoshi);
+
+                // Guard against the builder under-paying relative to the protocol minimum.
+                var totalFee = Math.Max(estimatedFee, minimumFee);
+                var totalAvailable = signingCoins.Sum(sc => sc.Coin.Amount.Satoshi);
+                var changeAmount = totalAvailable - outputsTotal - totalFee;
+
+                if (changeAmount < 0)
+                {
+                    if (attempt >= maxAttempts)
+                        throw new ApplicationException(
+                            $"Not enough funds, expected {(outputsTotal + totalFee).ToUnitBtc()} BTC, found {totalAvailable.ToUnitBtc()} BTC");
+
+                    // Re-select including the fee and dust headroom, then re-measure.
+                    var utxosWithFee = FindOutputsForTransaction(
+                        outputsTotal + totalFee + ProtocolConstants.DustThresholdSats, accountInfo);
+                    signingCoins = GetUnspentOutputsForTransaction(walletWords, utxosWithFee);
+                    continue;
+                }
+
+                if (changeAmount > 0 && changeAmount <= ProtocolConstants.DustThresholdSats)
+                {
+                    // Change is dust — give it to the miner instead of creating an output that
+                    // gets rejected with "dust". The tx shrinks, so the effective fee rate only rises.
+                    totalFee += changeAmount;
+                }
+
+                // Pass 2: rebuild with the exact fee. A fresh builder is required because
+                // SendFees/SendEstimatedFees accumulate on the same instance.
+                // The builder may pick a different coin subset than projected, so verify the
+                // built transaction and fold any remaining dust change into the fee.
+                var changeScript = BitcoinAddress.Create(changeAddress, network.BitcoinNetwork).ScriptPubKey;
+                Transaction signTransaction;
+                long actualFee;
+
+                for (var fixup = 0; ; fixup++)
+                {
+                    var finalBuilder = NewBuilder(signingCoins);
+                    finalBuilder.SendFees(Money.Satoshis(totalFee));
+                    signTransaction = finalBuilder.BuildTransaction(true);
+
+                    actualFee = SumInputs(signTransaction, signingCoins)
+                                - signTransaction.Outputs.Sum(o => o.Value.Satoshi);
+
+                    var actualChange = signTransaction.Outputs
+                        .Where(o => o.ScriptPubKey == changeScript)
+                        .Sum(o => o.Value.Satoshi);
+
+                    if (actualChange == 0 || actualChange > ProtocolConstants.DustThresholdSats)
+                        break;
+
+                    if (fixup >= maxAttempts)
+                        throw new ApplicationException(
+                            $"Unable to build a transaction without a dust change output ({actualChange} sats)");
+
+                    _logger.LogDebug(
+                        "Change output of {Change} sats is below the dust threshold, adding it to the fee", actualChange);
+                    totalFee += actualChange;
+                }
+
+                return new TransactionInfo { Transaction = signTransaction, TransactionFee = actualFee };
             }
-
-            var minerFee = totaInInputs - totaInOutputs;
-
-            var txSize = signTransaction.GetVirtualSize();
-            long minimumFee = new FeeRate(Money.Satoshis(1000)).GetFee(txSize).Satoshi; //1000 sats per kilobyte
-
-            if (minerFee >= minimumFee) //Fixed a bug in the builder that creates a fee that is too low
-                return new TransactionInfo { Transaction = signTransaction, TransactionFee = minerFee };
-            
-            builder.SendFees(Money.Satoshis(minimumFee));
-            signTransaction = builder.BuildTransaction(true);
-
-            return new TransactionInfo { Transaction = signTransaction, TransactionFee = minimumFee  };
         }
     }
 


### PR DESCRIPTION
﻿## What happened

A user reported project deployment failing with the generic banner **"The deployment transaction was prepared, but the network rejected the broadcast."** on mainnet.

Pulled their log export off Blossom (`src/tools/decrypt-log/fetch-latest.mjs`). The actual error was never shown in the UI:

```
[ERR] MempoolSpaceIndexerApi: Broadcast attempt 1/3 failed: Bad Request
  {"error":"sendrawtransaction RPC error: {\"code\":-26,\"message\":\"dust\"}"}
```

Sequence from the log:

| Time | Event |
|---|---|
| 16:45:31 | `Not enough funds, expected 0.00010001 BTC, found 0.0001 BTC` — funded exactly 10,000 sats, `AngorCreateFeeSats` is 10,001 |
| 16:50:58 | monitoring `bc1q89k3z...` for 10,000 sats |
| 16:52:01 | `Required amount met. Required: 10000, Available: 10348` — user topped up |
| 16:52:02 | broadcast rejected: **dust** (x3 retries, then again at 18:04) |

10,348 in − 10,001 (Angor fee output) − ~150 (miner fee) ≈ **~200 sat change output**, below the dust limit.

## Root cause

Three fixes already in the repo had never been applied to the deploy path.

**1. Dust change.** `12b18815` fixed `AddInputsFromAddressAndSignTransaction` to fold sub-dust change into the fee. Deploy goes through the *other* method, `AddInputsAndSignTransaction`, which hands off to the NBitcoin builder with `DustPrevention = false` and emits the dust output verbatim.

**2. Fee units.** `d39eb878` fixed the claim flow: the UI picker returns sat/vByte, NBitcoin's `FeeRate(Money)` is sat/kB. Deploy still passed the raw value, so "20 sat/vB" became 20 sat/kB and got clamped to the 1000 sat/kB floor — every deploy went out at ~1 sat/vB and the fee selector was a no-op.

**3. Coin selection.** `d67d72df` fixed `SendAmount` to select UTXOs covering amount + fee. Deploy still selected against the output total alone — that is the 16:45 `Not enough funds`.

## Changes

- **`WalletOperations.AddInputsAndSignTransaction`** (builder branch) — folds change `<= ProtocolConstants.DustThresholdSats` into the fee; re-selects UTXOs for `outputs + fee + dust` when the initial selection falls short; rebuilds with a *fresh* `TransactionBuilder` (`SendFees` and `SendEstimatedFees` accumulate on one instance — latent bug in the old code); verifies the built tx for dust change rather than trusting the projection, since the builder can pick a different coin subset. `DustPrevention` stays off, now with a comment explaining why (the zero-value OP_RETURN would be dropped).
- **`CreateProjectRequest.SelectedFeeRate`** — `long` to `DomainFeerate`, matching `BuildRecoveryTransaction` / `BuildPenaltyReleaseTransaction` / etc. Handler passes `.SatsPerKilobyte`. Propagated through `IProjectAppService`, `ProjectAppService`, and the three `DeployFlowViewModel` call sites. Carrying the unit in the type is what stops this recurring.
- **`DeployFlowViewModel`** — `DescribePrepareFailure` / `DescribeBroadcastFailure` map dust, low-fee, and already-spent-input rejections to actionable text across all 6 sites, falling back to the old message. Same approach as `SendFundsModal` in `d67d72df`.

## Tests

- `AddInputsAndSignTransaction_WhenChangeWouldBeDust_AddsItToTheFeeInsteadOfCreatingAnOutput` — reproduces the reporter's exact amounts. **Verified it fails against the pre-fix code** (stashed `WalletOperations.cs`, ran it, got `[FAIL]`, restored).
- `Handle_WhenSuccessful_PassesFeeRateToWalletOperationsInSatsPerKilobyte` — pins the 20 to 20,000 conversion.

| Suite | Result |
|---|---|
| `Angor.Shared.Tests` | 157 passed |
| `Angor.Sdk.Tests` | 336 passed, 14 skipped |
| `App.Test.Integration` (LayoutRegression) | 187 passed |
| `App.Desktop` + `WebApp.sln` builds | 0 errors |

`src/App.sln` as a whole needs the `ios` workload, unavailable on this machine. Pre-existing and unrelated.

## Not addressed here

- **The deploy flow requests exactly 10,000 sats** while the tx needs `AngorCreateFeeSats` + miner fee + dust-safe change. That is what caused the first failure at 16:45. Should be `10001 + estimatedFee + DustThresholdSats`.
- **`FeeSelectionPopup` presets are hardcoded** (50/20/5 sat/vB) and do not call `IWalletAppService.GetFeeEstimates()`, which already wraps mempool's `fastestFee`/`halfHourFee`/`economyFee`. The webapp uses live estimates in ~10 places; the new app only calls `GetFeeEstimates()` from `WalletAppService` and never from the deploy picker. Now that the unit bug is fixed the presets are applied literally, so 50 sat/vB is a real overpay on a ~150 vB tx.
- **`MempoolSpaceIndexerApi.cs:170`** builds its error as `ReasonPhrase + content` with no status code and no separator, producing strings like `Bad Request{"error":...}`.
