### PR TITLE
fix: deploy asks for too little funding and passes sat/vB as sat/kB

### DIFF
--- a/src/design/App/UI/Sections/MyProjects/Deploy/DeployFlowViewModel.cs
+++ b/src/design/App/UI/Sections/MyProjects/Deploy/DeployFlowViewModel.cs
@@ -10,6 +10,7 @@ using Angor.Sdk.Wallet.Application;
 using Angor.Sdk.Funding.Investor;
 using Angor.Sdk.Wallet.Domain;
 using Angor.Shared.Integration.Lightning;
+using Angor.Shared.Protocol;
 using App.UI.Shared;
 using App.UI.Shared.PaymentFlow;
 using App.UI.Shared.Services;
@@ -58,6 +59,12 @@ public partial class DeployFlowViewModel : ReactiveObject
     [Reactive] private string deployStatusText = "Waiting for payment...";
     [Reactive] private long selectedFeeRate = 20;
     [Reactive] private string? deployErrorMessage;
+
+    /// <summary>
+    /// <see cref="SelectedFeeRate"/> converted to sat/kB, which is what NBitcoin's
+    /// FeeRate (and therefore IWalletOperations) consumes. The fee picker returns sat/vByte.
+    /// </summary>
+    private long SelectedFeeRateSatsPerKb => SelectedFeeRate * 1000;
 
     /// <summary>The reusable payment flow VM. Created when the deploy overlay is shown.</summary>
     public PaymentFlowViewModel? PaymentFlow { get; private set; }
@@ -165,7 +172,7 @@ public partial class DeployFlowViewModel : ReactiveObject
         // Create the reusable payment flow BEFORE setting IsVisible,
         // since the view subscription fires immediately on IsVisible=true
         // and needs PaymentFlow to be ready.
-        var deployFeeSats = 10_000L; // 0.0001 BTC deploy fee
+        var deployFeeSats = NetworkConfiguration.AngorCreateFeeSats;
         PaymentFlow = new PaymentFlowViewModel(
             _walletAppService,
             _investmentAppService,
@@ -181,6 +188,13 @@ public partial class DeployFlowViewModel : ReactiveObject
                 AmountSats = deployFeeSats,
                 StageCount = 0,
                 FeeRateSatsPerVbyte = (int)SelectedFeeRate,
+                // The deploy transaction pays the Angor create fee output AND its own miner
+                // fee, and must leave enough over that the change output clears the dust
+                // threshold — otherwise the node rejects the broadcast with "dust".
+                // Same tx shape as the investment base tx with no stage outputs.
+                OnChainRequiredSatsOverride = deployFeeSats
+                    + InvestmentFeeEstimator.EstimateInvestmentTxFee(0, SelectedFeeRate)
+                    + ProtocolConstants.DustThresholdSats,
                 Title = "Fund Deployment",
                 SuccessTitle = $"{projectName} Deployed!",
                 SuccessDescription = "Your project has been successfully deployed to the blockchain.",
@@ -243,7 +257,7 @@ public partial class DeployFlowViewModel : ReactiveObject
 
         // Step 4: Create blockchain transaction
         var txResult = await _projectAppService.CreateProject(
-            walletId, SelectedFeeRate, ProjectData, infoResult.Value.EventId, projectSeed);
+            walletId, SelectedFeeRateSatsPerKb, ProjectData, infoResult.Value.EventId, projectSeed);
         if (txResult.IsFailure)
         {
             _logger.LogError("Deploy: create blockchain transaction failed: {Error}", txResult.Error);
@@ -361,7 +375,7 @@ public partial class DeployFlowViewModel : ReactiveObject
 
             // Step 4: Create blockchain transaction
             DeployStatusText = "Building transaction...";
-            var txResult = await _projectAppService.CreateProject(walletId, SelectedFeeRate, ProjectData, infoEventId, projectSeed);
+            var txResult = await _projectAppService.CreateProject(walletId, SelectedFeeRateSatsPerKb, ProjectData, infoEventId, projectSeed);
             if (txResult.IsFailure)
             {
                 _logger.LogError("Deploy: create blockchain transaction failed: {Error}", txResult.Error);
@@ -495,7 +509,7 @@ public partial class DeployFlowViewModel : ReactiveObject
 
             // Step 4: Create blockchain transaction
             DeployStatusText = "Building transaction...";
-            var txResult = await _projectAppService.CreateProject(walletId, SelectedFeeRate, ProjectData, infoEventId, projectSeed);
+            var txResult = await _projectAppService.CreateProject(walletId, SelectedFeeRateSatsPerKb, ProjectData, infoEventId, projectSeed);
             if (txResult.IsFailure)
             {
                 _logger.LogError("Deploy: create blockchain transaction failed: {Error}", txResult.Error);


### PR DESCRIPTION
Supersedes #958, which fixed three things and restructured `WalletOperations`. This is the minimal version: two changes, one file, +18/-4.

## The bug

A user hit the generic **"The deployment transaction was prepared, but the network rejected the broadcast"** banner on mainnet. Their log export (pulled via `src/tools/decrypt-log/fetch-latest.mjs`) had the real error:

```
[ERR] MempoolSpaceIndexerApi: Broadcast attempt 1/3 failed: Bad Request
  {"error":"sendrawtransaction RPC error: {\"code\":-26,\"message\":\"dust\"}"}
```

| Time | Log line |
|---|---|
| 16:45:31 | `Not enough funds, expected 0.00010001 BTC, found 0.0001 BTC` |
| 16:50:58 | `Starting address monitoring ... required amount: 10000 sats` |
| 16:52:01 | `Required amount met. Required: 10000, Available: 10348` |
| 16:52:02 | broadcast rejected: **dust** (x3, and again at 18:04) |

The flow asked for **10,000** sats. `NetworkConfiguration.AngorCreateFeeSats` is **10,001**. After topping up to 10,348 the user had **347 sats** of headroom for the miner fee *and* the change output combined.

There is no way to split 347 sats successfully. `change = 347 - fee`, and `DustThresholdSats = 330`, so clearing dust needs a fee under ~17 sats — well below relay minimum on a ~250 vB transaction. Fee too low gives `dust`; fee realistic gives `not enough funds`. The user was told to fund an amount that cannot produce a valid transaction.

Worth stating plainly: **fetching live fee rates from the indexer would not have helped.** A higher estimate pushes this straight into `not enough funds`. The problem is the funding amount, not the fee source.

## Changes

**1. Request enough to actually build the transaction**

```diff
-var deployFeeSats = 10_000L; // 0.0001 BTC deploy fee
+var deployFeeSats = NetworkConfiguration.AngorCreateFeeSats;
```

```csharp
OnChainRequiredSatsOverride = deployFeeSats
    + InvestmentFeeEstimator.EstimateInvestmentTxFee(0, SelectedFeeRate)
    + ProtocolConstants.DustThresholdSats,
```

Using the constant kills the off-by-one permanently — it is the same value `CreateProject.cs:118` builds the output from.

No new estimator was written. `InvestmentFeeEstimator.BaseTxVbytes = 252` already describes this exact tx shape (10.5 overhead + 68 P2WPKH input + 43 P2WSH + 99 OP_RETURN + 31 change), so `EstimateInvestmentTxFee(stageCount: 0, ...)` is the correct number. This is the mechanism `02cff54b` added for invest, whose commit message said *"The deploy flow is unaffected"* — that assumption is what this PR corrects.

Dust headroom is included because sub-dust change is not folded into the fee anywhere on this path.

At the default 20 sat/vB the flow now requests **15,371** sats (`10001 + 5040 + 330`) rather than 10,000. `AmountDisplay`, `CanWalletPay` and `MonitorAddressForFunds` already read `OnChainRequiredSats`, so they all pick this up with no further change.

**2. sat/vB to sat/kB at the deploy call sites**

```csharp
private long SelectedFeeRateSatsPerKb => SelectedFeeRate * 1000;
```

The fee picker returns sat/vByte; NBitcoin's `FeeRate(Money)` is sat/kB. "20 sat/vB" was being applied as 20 sat/kB and then clamped to the 1000 sat/kB floor at `WalletOperations.cs:128`, so the Priority/Standard/Economy selection was inert and every deploy went out at ~1 sat/vB.

Applied at the three `CreateProject(...)` call sites rather than inside `CreateProjectHandler`, because `ProjectDeploymentOrchestrator.cs:77` (avalonia), `FounderCommands.cs:464` (CLI, `--fee` = "Selected fee in sats") and `FounderTools.cs:186` (MCP, `feeSats`) all pass this parameter with ambiguous units and would change behaviour silently. Same shape as `d39eb878`, which converted in `ManageProjectViewModel` rather than deeper in the stack.

These two interact: the unit bug kept the fee near 150 sats, which is the only reason 10,000 was ever close to sufficient. Fixing the units without fixing the amount would make tight wallets fail more often, so they land together.

## Verification

| Suite | Result |
|---|---|
| `Angor.Sdk.Tests` | 335 passed, 14 skipped |
| `Angor.Shared.Tests` | 156 passed |
| `App.Test.Integration` (LayoutRegression) | 187 passed |
| `App.Desktop` build | 0 errors |

No tests added — `DeployFlowViewModel` has no unit-test harness and standing one up would be more code than the fix.

## Deliberately not included

- **Sub-dust change is still emitted** rather than folded into the miner fee in `WalletOperations.AddInputsAndSignTransaction`. `AddInputsFromAddressAndSignTransaction` has done this since `12b18815`; the builder branch does not. Fix 1 avoids the squeeze rather than surviving it, so a wallet already holding an awkward balance can still hit `dust`. The dust headroom above is the mitigation.
- **The broadcast error is still the generic banner.** `DeployFlowViewModel.cs:259/384/516` collapse every failure into one sentence; the node's reason only reaches the log. `MempoolSpaceIndexerApi.cs:170` also builds it as `ReasonPhrase + content` with no status code or separator (`Bad Request{"error":...}`).
- **`DeployFee` at `DeployFlowViewModel.cs:82`** is still the hardcoded string `"0.0001"`, bound to the "Fee to Deploy" labels. It labels the Angor protocol fee rather than the amount to send, so it is not wrong the way `AmountSats` was, but it is 1 sat off and will not track the constant.
- **The config is built once in `Show()`** at the default 20 sat/vB, so choosing Priority afterwards leaves `OnChainRequiredSatsOverride` stale. Pre-existing — `FeeRateSatsPerVbyte` has the same issue.
- **The fee picker never calls `GetFeeEstimates()`.** The plumbing exists end to end (`MempoolSpaceIndexerApi.GetFeeEstimationAsync` to `WalletOperations` to `IWalletAppService`) and the webapp uses it in ~10 places, but `FeeSelectionPopup.axaml.cs:140-147` has hardcoded 50/20/5 since `3a9851f0`. Not a regression, and not the cause here, but now that fix 2 makes the selection real, those presets are applied literally.